### PR TITLE
🎨 Palette: Improve radar speed button accessibility

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -585,6 +585,9 @@ class WeatherRadar {
         // Bolt Optimization: Bind loop function once to avoid allocation churn in rAF
         this.boundLoop = this.loop.bind(this);
 
+        // Palette Accessibility: Set initial state
+        this.updateSpeedLabel();
+
         this.bindEvents();
     }
 
@@ -632,7 +635,13 @@ class WeatherRadar {
 
     updateSpeedLabel() {
         if (this.ui.speedLabel) {
-            this.ui.speedLabel.textContent = CONFIG.radarSpeeds[this.speedIndex].label;
+            const label = CONFIG.radarSpeeds[this.speedIndex].label;
+            this.ui.speedLabel.textContent = label;
+
+            // Palette Accessibility: Update ARIA label with current state
+            if (this.ui.speedBtn) {
+                this.ui.speedBtn.setAttribute('aria-label', `Playback speed: ${label}`);
+            }
         }
     }
 


### PR DESCRIPTION
💡 What: Updated the radar playback speed button to use a dynamic `aria-label` that includes the current speed (e.g., "Playback speed: 1x").
🎯 Why: Previously, the button had a static label "Change playback speed", which did not inform screen reader users of the currently selected speed.
📸 Before/After: Visuals are unchanged, but the accessibility tree now reports the specific speed value.
♿ Accessibility: Screen reader users can now hear "Playback speed: 1x", "Playback speed: 2x", etc.

---
*PR created automatically by Jules for task [8373255511972426229](https://jules.google.com/task/8373255511972426229) started by @2fst4u*