### PR TITLE
🛡️ Sentinel: [Enhancement] Harden Worker security headers (HSTS preload, CSP)

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -140,9 +140,9 @@ const DEFAULT_SECURITY_HEADERS = {
   'X-Content-Type-Options': 'nosniff',
   'X-Frame-Options': 'DENY',
   'Permissions-Policy': 'accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()',
-  'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+  'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
   'Referrer-Policy': 'strict-origin-when-cross-origin',
-  'Content-Security-Policy': "upgrade-insecure-requests; default-src 'none'; frame-ancestors 'none';",
+  'Content-Security-Policy': "upgrade-insecure-requests; default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none';",
   'Cross-Origin-Opener-Policy': 'same-origin',
   'Cross-Origin-Resource-Policy': 'same-origin',
 };


### PR DESCRIPTION
🛡️ Sentinel: [Enhancement] Harden Worker security headers (HSTS preload, CSP)

## 💡 Vulnerability / Enhancement
The Worker's security headers were missing the `preload` directive for HSTS (unlike `public/_headers`) and lacked strict `base-uri` and `form-action` directives in CSP. While `default-src 'none'` covers many directives, it does not cover `base-uri` or `form-action`, leaving a theoretical gap for base tag hijacking or malicious form targets if the API response were ever interpreted as HTML.

## 🎯 Impact
- **HSTS Preload:** Without `preload`, the site cannot be submitted to the HSTS preload list, which protects users from the very first visit.
- **CSP Hardening:** Explicitly blocking `base-uri` and `form-action` prevents attackers from hijacking relative links or form submissions, even if they could somehow inject content.

## 🔧 Fix
Updated `DEFAULT_SECURITY_HEADERS` in `src/worker.js`:
1.  Added `; preload` to `Strict-Transport-Security`.
2.  Added `base-uri 'none'; form-action 'none';` to `Content-Security-Policy`.

## ✅ Verification
- Verified `src/worker.js` content matches the intended directives.
- Verified consistency with `public/_headers` (for HSTS).


---
*PR created automatically by Jules for task [15707035393823010922](https://jules.google.com/task/15707035393823010922) started by @2fst4u*