### PR TITLE
🎨 Palette: Fix accessibility for Unit Toggle label

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -99,8 +99,8 @@
                         </select>
                     </div>
                     <div class="control-group control-group--units">
-                        <label>Units</label>
-                        <div class="unit-toggle" id="unitToggle" role="group" aria-label="Measurement units">
+                        <span id="unitsLabel" class="control-label">Units</span>
+                        <div class="unit-toggle" id="unitToggle" role="group" aria-labelledby="unitsLabel">
                             <button class="unit-option" data-unit="metric" type="button" aria-pressed="false">km</button>
                             <button class="unit-option active" data-unit="imperial" type="button" aria-pressed="true">mi</button>
                         </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -235,7 +235,8 @@ body {
     gap: var(--spacing-xs);
 }
 
-.control-group label {
+.control-group label,
+.control-group .control-label {
     font-size: 0.75rem;
     font-weight: 500;
     color: var(--color-text-secondary);


### PR DESCRIPTION
This PR addresses a semantic HTML issue where a `<label>` element was used to label a `div` container (the unit toggle), which is not valid HTML.

Changes:
- Replaced `<label>Units</label>` with `<span id="unitsLabel" class="control-label">Units</span>`.
- Added `aria-labelledby="unitsLabel"` to the toggle group container.
- Updated `public/styles.css` to apply existing label styles to the new `.control-label` class.

This ensures screen readers correctly associate the "Units" text with the toggle group, improving the accessibility of the settings panel.

---
*PR created automatically by Jules for task [13305785365666758909](https://jules.google.com/task/13305785365666758909) started by @2fst4u*