### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix app crash when localStorage is disabled

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -121,6 +121,28 @@ function escapeHtml(str) {
     return String(str).replace(ESCAPE_REGEX, char => ESCAPE_MAP[char]);
 }
 
+// ===================================
+// Safe Storage Helper
+// ===================================
+
+const SafeStorage = {
+    getItem(key) {
+        try {
+            return localStorage.getItem(key);
+        } catch (e) {
+            // SEC: Fail securely if storage is disabled/blocked (e.g. privacy settings)
+            return null;
+        }
+    },
+    setItem(key, value) {
+        try {
+            localStorage.setItem(key, value);
+        } catch (e) {
+            // SEC: Fail securely if storage is disabled/blocked
+        }
+    }
+};
+
 
 // ===================================
 // Theme Manager
@@ -135,7 +157,7 @@ class ThemeManager {
     }
 
     getInitialTheme() {
-        const stored = localStorage.getItem('theme');
+        const stored = SafeStorage.getItem('theme');
         if (stored) return stored;
         return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
     }
@@ -148,7 +170,7 @@ class ThemeManager {
     toggle() {
         this.theme = this.theme === 'dark' ? 'light' : 'dark';
         this.applyTheme();
-        localStorage.setItem('theme', this.theme);
+        SafeStorage.setItem('theme', this.theme);
     }
 
     bindEvents() {
@@ -1108,7 +1130,7 @@ class RangeCircles {
     }
 
     getInitialUnit() {
-        const stored = localStorage.getItem('unit');
+        const stored = SafeStorage.getItem('unit');
         if (stored) return stored;
         // Detect from locale (imperial countries: US, Liberia, Myanmar)
         const lang = navigator.language || 'en-US';
@@ -1133,7 +1155,7 @@ class RangeCircles {
 
     setUnit(unit) {
         this.unit = unit;
-        localStorage.setItem('unit', unit);
+        SafeStorage.setItem('unit', unit);
         this.updateToggleUI();
         if (this.center) this.draw(this.center);
     }


### PR DESCRIPTION
Implemented a `SafeStorage` helper in `public/app.js` to wrap `localStorage` access. This prevents the application from crashing with a `SecurityError` if the user has disabled cookies or local storage, or if the app is running in a restricted context (e.g., sandboxed iframe). Modified `ThemeManager` and `RangeCircles` to use this helper, ensuring the app falls back to default settings gracefully instead of failing to initialize. Verified with a custom test script that mocked a broken storage environment.

---
*PR created automatically by Jules for task [18396193087600588876](https://jules.google.com/task/18396193087600588876) started by @2fst4u*