### PR TITLE
🎨 Palette: Improve dependent dropdown empty state guidance

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-21 - Dependent Dropdown Empty States
+**Learning:** For dependent dropdowns (like Session depending on Round), simply disabling the second dropdown is insufficient guidance. Changing the default option text from a generic "Select..." to an explicit instruction like "Select a round first" significantly reduces cognitive load and explains the disabled state.
+**Action:** Always provide explicit guidance text in the default option of disabled dependent inputs.

--- a/public/app.js
+++ b/public/app.js
@@ -2106,7 +2106,22 @@ class CircuitWeatherApp {
     bindEvents() {
         if (this.ui.roundSelect) {
             this.ui.roundSelect.addEventListener('change', (e) => {
-                if (e.target.value) this.selectRound(e.target.value);
+                if (e.target.value) {
+                    this.selectRound(e.target.value);
+                } else {
+                    // Palette UX: Reset session select when round is cleared
+                    if (this.ui.sessionSelect) {
+                        this.ui.sessionSelect.disabled = true;
+                        this.ui.sessionSelect.innerHTML = '<option value="">Select a round first</option>';
+                    }
+                    this.selectedSession = null;
+                    this.selectedRace = null;
+                    if (this.ui.forecastSection) this.ui.forecastSection.style.display = 'none';
+                    if (this.ui.raceInfoBanner) this.ui.raceInfoBanner.style.display = 'none';
+                    this.countdown.show(false);
+                    this.trackLayer.clear();
+                    this.rangeCircles.clear();
+                }
             });
         }
 

--- a/public/index.html
+++ b/public/index.html
@@ -95,7 +95,7 @@
                     <div class="control-group">
                         <label for="sessionSelect">Session</label>
                         <select id="sessionSelect" class="select" disabled>
-                            <option value="">Select a session...</option>
+                            <option value="">Select a round first</option>
                         </select>
                     </div>
                     <div class="control-group control-group--units">


### PR DESCRIPTION
💡 **What**: Improved the empty state guidance for the dependent "Session" dropdown.
🎯 **Why**: Users seeing a disabled "Select session..." dropdown might not immediately understand why it is unavailable. "Select a round first" provides clear instruction. Additionally, clearing the round selection previously left the UI in an inconsistent state; now it cleanly resets.
📸 **Before/After**:
- Before: Disabled dropdown showed "Select session..."
- After: Disabled dropdown shows "Select a round first"
♿ **Accessibility**: Provides clearer context for screen reader users encountering the disabled control.

---
*PR created automatically by Jules for task [16482859646322290427](https://jules.google.com/task/16482859646322290427) started by @2fst4u*