### PR TITLE
🛡️ Sentinel: [HIGH] Improve Rate Limiter eviction strategy

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -46,9 +46,11 @@ class RateLimiter {
       // SEC: Prevent memory exhaustion DoS
       if (this.counts.size >= this.maxIps) {
         this.cleanup(now);
-        // If still full after cleanup, clear everything to save the worker
+        // If still full after cleanup, evict oldest entry (LRU) to make room
+        // This prevents a full reset which would benefit attackers
         if (this.counts.size >= this.maxIps) {
-          this.counts.clear();
+          const oldestIp = this.counts.keys().next().value;
+          this.counts.delete(oldestIp);
         }
       }
 


### PR DESCRIPTION
This PR addresses a security vulnerability in the in-memory Rate Limiter used by the Cloudflare Worker.

**Vulnerability:**
Previously, when the rate limiter's internal map reached its maximum capacity (`maxIps`), the code executed `this.counts.clear()`, wiping all rate limit records. This behavior could be exploited by an attacker (or triggered by high legitimate traffic) to reset their own rate limit counters by flooding the system with requests from distinct IPs, effectively bypassing the protection.

**Fix:**
I have modified the `RateLimiter.check()` method to use a Least Recently Used (LRU) eviction strategy. When the map is full, the oldest entry (the first key in the Map) is removed to make space for the new one. This ensures that:
1.  The memory usage remains bounded.
2.  The rate limit counters for other active IPs are preserved.
3.  The system does not "fail open" under load.

**Verification:**
A verification script (`verify_dos_protection.js`) was created to reproduce the "fail-open" behavior (verifying it cleared all entries) and then to confirm the fix (verifying it evicts only the oldest entry). The script passed successfully after the fix.


---
*PR created automatically by Jules for task [1010884878429080872](https://jules.google.com/task/1010884878429080872) started by @2fst4u*