### PR TITLE
🎨 Palette: Refactor Privacy Link to Semantic Button

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1760,8 +1760,7 @@ class PrivacyModal {
 
     bindEvents() {
         if (this.privacyLink) {
-            this.privacyLink.addEventListener('click', (e) => {
-                e.preventDefault();
+            this.privacyLink.addEventListener('click', () => {
                 this.open();
             });
         }

--- a/public/index.html
+++ b/public/index.html
@@ -161,7 +161,7 @@
             </div>
 
             <div class="sidebar-footer">
-                <a href="#" id="privacyLink">Privacy</a>
+                <button type="button" id="privacyLink" class="link-button">Privacy</button>
                 <span>•</span>
                 <a href="https://github.com/circuit-weather/circuit-weather" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -504,6 +504,20 @@ body {
     color: var(--color-primary);
 }
 
+.link-button {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    text-decoration: none;
+}
+
+.link-button:hover {
+    color: var(--color-primary);
+}
+
 .sidebar-footer span {
     color: var(--color-border);
 }


### PR DESCRIPTION
🎨 Palette UX Improvement: Refactored the "Privacy" link to a semantic button.

💡 **What:** Changed the "Privacy" footer link from an anchor tag (`<a href="#">`) to a `<button type="button">`.
🎯 **Why:** To improve accessibility and semantic correctness. Interactive elements that trigger in-page actions (like opening a modal) should be buttons, not links. This avoids the anti-pattern of `href="#"`.
📸 **Visuals:** The button is styled to look identical to the original link using a new `.link-button` utility class.
♿ **Accessibility:** Screen readers will now correctly announce the element as a button, and it behaves correctly with keyboard interactions without requiring hacky `href` attributes.


---
*PR created automatically by Jules for task [7298462943218086336](https://jules.google.com/task/7298462943218086336) started by @2fst4u*