### PR TITLE
🎨 Palette: Improve map accessibility by removing interactive overlays from tab order

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -30,3 +30,7 @@
 ## 2026-02-21 - Actionable Empty States
 **Learning:** Generic empty states like "Forecast available closer to session" provide insufficient guidance when the user selects a distant future event, potentially causing confusion about whether the feature is broken.
 **Action:** When data is unavailable due to time constraints, provide specific, actionable information (e.g., "Forecast available from [Date]") to manage user expectations effectively.
+
+## 2024-05-24 - Map Accessibility: Clutter in Tab Order
+**Learning:** Leaflet markers and overlays are interactive by default (`interactive: true`), making them focusable tab stops even when purely decorative or informational (like distance labels). This clutters the keyboard navigation sequence for map users.
+**Action:** Always set `{ interactive: false, keyboard: false }` for map overlays that are visual-only to ensure they don't block map panning or create unnecessary tab stops.

--- a/public/app.js
+++ b/public/app.js
@@ -554,6 +554,7 @@ class TrackLayer {
 
             this.layer = L.geoJSON(data, {
                 style: {
+                    interactive: false,
                     color: '#e10600',
                     weight: 4, // Initial, will be updated immediately
                     opacity: 0.8,
@@ -1225,6 +1226,7 @@ class RangeCircles {
                 if (!this.map.hasLayer(circle)) circle.addTo(this.map);
             } else {
                 const circle = L.circle(center, {
+                    interactive: false,
                     radius: radius,
                     color: rangeColor,
                     fillColor: 'transparent',
@@ -1260,7 +1262,7 @@ class RangeCircles {
                     iconSize: [30, 12],
                     iconAnchor: [0, 6],
                 });
-                const labelMarker = L.marker(labelLatLng, { icon: label });
+                const labelMarker = L.marker(labelLatLng, { icon: label, interactive: false, keyboard: false });
                 labelMarker.addTo(this.map);
                 this.labels.push(labelMarker);
             }
@@ -1283,6 +1285,8 @@ class RangeCircles {
             if (!this.map.hasLayer(this.centerMarker)) this.centerMarker.addTo(this.map);
         } else {
             this.centerMarker = L.circleMarker(center, {
+                interactive: false,
+                keyboard: false,
                 radius: 6,
                 color: rangeColor,
                 fillColor: '#ffffff',


### PR DESCRIPTION
Palette UX improvement: Decluttered map tab order by making visual overlays non-interactive.

---
*PR created automatically by Jules for task [6983153740425420261](https://jules.google.com/task/6983153740425420261) started by @2fst4u*