### PR TITLE
feat: Add visible radar tile error indicator

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -605,6 +605,11 @@ class WeatherRadar {
         this.pollingInterval = null;
         this.pendingFrames = null;
 
+        // Tile error tracking
+        this.tileErrorCount = 0;
+        this.tileErrorThreshold = 3; // Show warning after this many errors
+        this.lastTileErrorTime = 0;
+
         // Bolt Optimization: Cache DOM elements
         this.ui = {
             playBtn: document.getElementById('radarPlayBtn'),
@@ -615,7 +620,9 @@ class WeatherRadar {
             relative: document.getElementById('radarRelative'),
             timeStart: document.getElementById('radarTimeStart'),
             timeEnd: document.getElementById('radarTimeEnd'),
-            controls: document.getElementById('radarControls')
+            controls: document.getElementById('radarControls'),
+            status: document.getElementById('radarStatus'),
+            statusText: document.getElementById('radarStatusText')
         };
 
         // Bolt Optimization: Reuse DateTimeFormat
@@ -730,6 +737,8 @@ class WeatherRadar {
 
             // Wait for tiles to load before starting animation
             await this.waitForTilesToLoad();
+            // Reset tile error state on successful load
+            this.hideTileError();
             this.play();
         } catch (error) {
             console.error('Radar load failed:', error);
@@ -828,11 +837,53 @@ class WeatherRadar {
             updateWhenZooming: false,
             keepBuffer: 2,
         });
+
+        // Handle tile loading errors
+        layer.on('tileerror', (e) => {
+            this.handleTileError(e);
+        });
+
         layer.addTo(this.map);
         // Store frame info on the layer for easier matching later
         layer.frameTime = frame.time;
         layer.framePath = frame.path;
         return layer;
+    }
+
+    handleTileError(e) {
+        const now = Date.now();
+
+        // Debounce: only count errors once per second
+        if (now - this.lastTileErrorTime < 1000) {
+            return;
+        }
+        this.lastTileErrorTime = now;
+        this.tileErrorCount++;
+
+        // Log tile error details to console
+        const tileUrl = e.tile?.src || 'unknown';
+        console.warn(`[Radar] Tile load failed (${this.tileErrorCount}):`, tileUrl);
+
+        // Show status indicator after threshold
+        if (this.tileErrorCount >= this.tileErrorThreshold) {
+            this.showTileError();
+        }
+    }
+
+    showTileError() {
+        if (this.ui.status) {
+            this.ui.status.style.display = 'flex';
+            if (this.ui.statusText) {
+                this.ui.statusText.textContent = `Tile errors (${this.tileErrorCount})`;
+            }
+        }
+    }
+
+    hideTileError() {
+        this.tileErrorCount = 0;
+        if (this.ui.status) {
+            this.ui.status.style.display = 'none';
+        }
     }
 
     // Bolt Optimization: Reuse Leaflet layers to reduce DOM churn
@@ -1117,6 +1168,7 @@ class WeatherRadar {
     destroy() {
         this.stopPolling();
         this.pause();
+        this.hideTileError();
         this.layers.forEach(layer => {
             if (layer) this.map.removeLayer(layer);
         });

--- a/public/index.html
+++ b/public/index.html
@@ -233,6 +233,10 @@
                     title="Playback speed">
                     <span id="radarSpeedLabel">1x</span>
                 </button>
+                <div class="radar-status" id="radarStatus" role="status" aria-live="polite" style="display: none;">
+                    <span class="radar-status-icon" aria-hidden="true">⚠️</span>
+                    <span class="radar-status-text" id="radarStatusText">Tiles loading...</span>
+                </div>
             </div>
 
             <!-- Mobile Countdown Overlay (visible only on mobile) -->

--- a/public/styles.css
+++ b/public/styles.css
@@ -785,6 +785,34 @@ body {
     border-color: var(--color-primary);
 }
 
+/* Radar Status Indicator */
+.radar-status {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    background: rgba(239, 68, 68, 0.15);
+    border: 1px solid rgba(239, 68, 68, 0.4);
+    border-radius: var(--radius-md);
+    font-size: 0.65rem;
+    color: #ef4444;
+    white-space: nowrap;
+    animation: radar-status-pulse 2s ease-in-out infinite;
+}
+
+.radar-status-icon {
+    font-size: 0.8rem;
+}
+
+.radar-status-text {
+    font-weight: 500;
+}
+
+@keyframes radar-status-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.7; }
+}
+
 /* ===================================
    Loading Overlay
    =================================== */


### PR DESCRIPTION
## Summary
Makes radar tile failures visible to users instead of failing silently.

## Changes
- Add tileerror event handler to log and track tile loading failures
- Add debounced error counting (1-second debounce) to prevent spam
- Add UI status indicator showing tile error count after threshold (3 errors)
- Add CSS styling for error indicator with pulse animation
- Reset error state on successful load and cleanup

## Testing
- Navigate to a circuit
- If tiles fail to load, a warning indicator will appear in the radar controls
- Check browser console for tile error logs: [Radar] Tile load failed (N): url