### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix memory exhaustion DoS in worker logging

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -653,7 +653,8 @@ async function handleWeatherRequest(request, env, ctx) {
     });
 
     if (!upstreamResponse.ok) {
-      const errorText = await upstreamResponse.text();
+      // SEC: Limit error body size to prevent memory exhaustion DoS
+      const errorText = await readLimitedBody(upstreamResponse, 1024);
       console.error(`Upstream Weather API Error: Status ${upstreamResponse.status} - ${errorText}`);
 
       // Cache error response to prevent hammering upstream when rate limited
@@ -860,3 +861,49 @@ async function handleRadarRequest(request, env, ctx) {
   }
 }
 
+/**
+ * Helper to safely read a limited amount of the response body
+ * Prevents memory exhaustion attacks from large upstream responses
+ */
+async function readLimitedBody(response, limit = 1024) {
+  if (!response.body) return '';
+  const reader = response.body.getReader();
+  let received = 0;
+  let chunks = [];
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const chunkLength = value.length;
+
+      if (received + chunkLength > limit) {
+          // Push enough to exceed limit by 1 to indicate truncation
+          const needed = limit - received + 1;
+          chunks.push(value.slice(0, needed));
+          received += chunkLength;
+          break;
+      }
+
+      chunks.push(value);
+      received += chunkLength;
+    }
+  } catch (err) {
+    // Ignore error, return what we have
+  } finally {
+    reader.cancel();
+  }
+
+  const decoder = new TextDecoder();
+  let result = '';
+  for (const chunk of chunks) {
+    result += decoder.decode(chunk, { stream: true });
+  }
+  result += decoder.decode();
+
+  if (result.length > limit) {
+    return result.substring(0, limit) + '... (truncated)';
+  }
+  return result;
+}


### PR DESCRIPTION
Implemented a security enhancement in the Cloudflare Worker to prevent memory exhaustion Denial of Service (DoS) attacks.

**Issue:**
Previously, `handleWeatherRequest` used `await upstreamResponse.text()` to log the full body of upstream API error responses. If a compromised or malfunctioning upstream server returned a massive payload (e.g., 100MB), this would buffer the entire content into memory, exceeding the worker's memory limit (128MB) and causing it to crash.

**Fix:**
I introduced a `readLimitedBody` helper function that streams the response body and reads only up to a specified limit (1024 bytes). It then cancels the stream reader to release resources. This ensures that even with large error responses, the worker remains stable and only logs a truncated version of the error message.

**Verification:**
- Validated the `readLimitedBody` function using a temporary test script (`test_read_limit.js`) with mock streams, verifying correct truncation and stream cancellation.
- Confirmed the integration in `src/worker.js` via file read.


---
*PR created automatically by Jules for task [424903132174894295](https://jules.google.com/task/424903132174894295) started by @2fst4u*