### PR TITLE
⚡ Bolt: Debounce ResizeObserver in MapManager

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,7 @@
 ## 2024-05-25 - RateLimiter Generational Cleanup
 **Learning:** Throttled O(N) cleanup in RateLimiters is still insufficient under sustained attack as it blocks the event loop periodically.
 **Action:** Implement Generational Garbage Collection (Double Buffering) to achieve O(1) cleanup by simply rotating Maps, eliminating iteration entirely.
+
+## 2026-05-25 - ResizeObserver Debouncing
+**Learning:** `ResizeObserver` fires as rapidly as 60fps during window resizing. Performing expensive layout operations like `map.invalidateSize()` directly in the callback causes significant main thread blocking and layout thrashing.
+**Action:** Always debounce `ResizeObserver` callbacks when they trigger expensive UI updates or reflows.

--- a/public/app.js
+++ b/public/app.js
@@ -2113,11 +2113,13 @@ class MapManager {
         // This is more efficient than window.resize listeners and manual timeouts
         const mapContainer = document.getElementById('map');
         if (mapContainer && window.ResizeObserver) {
-            this.resizeObserver = new ResizeObserver(() => {
+            // Bolt Optimization: Debounce resize events to prevent layout thrashing
+            // invalidateSize() is expensive, so we only run it once the resize settles (100ms)
+            this.resizeObserver = new ResizeObserver(debounce(() => {
                 if (this.map) {
                     this.map.invalidateSize();
                 }
-            });
+            }, 100));
             this.resizeObserver.observe(mapContainer);
         }
 


### PR DESCRIPTION
Debounced the MapManager ResizeObserver to prevent excessive layout thrashing during window resize events.

---
*PR created automatically by Jules for task [10943448736579055045](https://jules.google.com/task/10943448736579055045) started by @2fst4u*