### PR TITLE
Clean up deprecated RangeCircles config

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -31,8 +31,6 @@ const CONFIG = {
         { label: '2x', speed: 500 }
     ],
     defaultSpeedIndex: 1, // Start at 1x
-    // Range circles by zoom level (metric/imperial)
-    // Deprecated: Logic now dynamic in RangeCircles class
 };
 // SEC: Prevent runtime tampering with configuration
 Object.freeze(CONFIG);


### PR DESCRIPTION
Removed deprecated configuration comments for RangeCircles in `public/app.js` as the logic has been moved to the `RangeCircles` class and is now dynamic. Confirmed that the `RangeCircles` class does not rely on these configuration keys. Verified that the application loads correctly and `public/app.js` is syntactically valid.

---
*PR created automatically by Jules for task [4384311810903150173](https://jules.google.com/task/4384311810903150173) started by @2fst4u*