### PR TITLE
🛡️ Sentinel: [HIGH] Add input validation to tile proxy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -92,3 +92,8 @@
 **Vulnerability:** The simple Fixed Window rate limiter allowed traffic bursts up to 2x the limit at window boundaries (e.g., 100 reqs at T=59s and 100 reqs at T=60.1s).
 **Learning:** Fixed Window algorithms are simple but susceptible to boundary attacks. For security-critical rate limiting, they provide insufficient protection against calculated floods.
 **Prevention:** Use a Token Bucket or Sliding Window Log algorithm which enforces a consistent rate over time and smooths out bursts.
+
+## 2026-03-10 - Unrestricted Tile Proxy Path
+**Vulnerability:** The `handleTileRequest` in `src/worker.js` blindly appended the request path suffix to the upstream URL without validation. This allowed directory traversal (`..`) and potentially accessing arbitrary paths on the upstream server.
+**Learning:** Proxy endpoints often assume the input path is safe or that the upstream will handle it. However, unvalidated path construction is a common vector for SSRF or traversing into unintended API endpoints.
+**Prevention:** Strictly validate proxy path segments against an allowlist of characters and explicitly reject directory traversal sequences (`..`) before constructing upstream URLs.

--- a/src/worker.js
+++ b/src/worker.js
@@ -789,6 +789,15 @@ async function handleTileRequest(request, env, ctx) {
   const url = new URL(request.url);
   // Extract path suffix: /api/tiles/v2/radar/... -> /v2/radar/...
   const tilePath = url.pathname.replace('/api/tiles', '');
+
+  // SEC: Validate tilePath (length and content) to prevent traversal/SSRF
+  if (tilePath.length > 255 || !VALID_API_PATH_REGEX.test(tilePath) || tilePath.includes('..') || tilePath.includes('//')) {
+    return new Response(JSON.stringify({ error: 'Invalid tile path' }), {
+      status: 400,
+      headers: getErrorHeaders(request)
+    });
+  }
+
   const upstreamUrl = `https://tilecache.rainviewer.com${tilePath}`;
 
   // Canonical cache key


### PR DESCRIPTION
Added strict input validation to `handleTileRequest` in `src/worker.js`.
- Checks for `tilePath` length (> 255 chars).
- Validates characters against `VALID_API_PATH_REGEX` (alphanumeric, `/`, `.`, `_`, `-`).
- Explicitly rejects `..` and `//` to prevent directory traversal and SSRF risks.
- Returns 400 Bad Request if validation fails.

---
*PR created automatically by Jules for task [17478777306095072831](https://jules.google.com/task/17478777306095072831) started by @2fst4u*