### PR TITLE
⚡ Bolt: Optimize TrackLayer caching

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -515,31 +515,39 @@ class TrackLayer {
         }
 
         try {
-            let data;
-
-            // Check cache first
+            // Check cache first (Bolt Optimization: Cache L.geoJSON layer instead of raw data)
             if (this.cache.has(circuitId)) {
-                data = this.cache.get(circuitId);
-            } else {
-                let url;
-                if (CONFIG.trackApi.startsWith('/')) {
-                    // Worker proxy (no extension)
-                    url = `${CONFIG.trackApi}/${geoJsonId}`;
-                } else {
-                    // Direct GitHub (needs extension)
-                    url = `${CONFIG.trackApi}/${geoJsonId}.geojson`;
-                }
-
-                const response = await fetch(url);
-
-                if (!response.ok) throw new Error(`Track fetch failed: ${response.status}`);
+                this.layer = this.cache.get(circuitId);
 
                 // Check if this is still the requested circuit
                 if (this.currentCircuitId !== circuitId) return;
 
-                data = await response.json();
-                this.cache.set(circuitId, data);
+                if (!this.map.hasLayer(this.layer)) {
+                    this.layer.addTo(this.map);
+                }
+
+                this.updateStyle();
+                this.layer.bringToBack();
+                return;
             }
+
+            let url;
+            if (CONFIG.trackApi.startsWith('/')) {
+                // Worker proxy (no extension)
+                url = `${CONFIG.trackApi}/${geoJsonId}`;
+            } else {
+                // Direct GitHub (needs extension)
+                url = `${CONFIG.trackApi}/${geoJsonId}.geojson`;
+            }
+
+            const response = await fetch(url);
+
+            if (!response.ok) throw new Error(`Track fetch failed: ${response.status}`);
+
+            // Check if this is still the requested circuit
+            if (this.currentCircuitId !== circuitId) return;
+
+            const data = await response.json();
 
             // Double check before rendering
             if (this.currentCircuitId !== circuitId) return;
@@ -555,7 +563,12 @@ class TrackLayer {
                     lineJoin: 'round',
                     className: 'track-path'
                 }
-            }).addTo(this.map);
+            });
+
+            // Cache the created layer
+            this.cache.set(circuitId, this.layer);
+
+            this.layer.addTo(this.map);
 
             // Apply correct weight for current zoom
             this.updateStyle();


### PR DESCRIPTION
⚡ Bolt: Optimize TrackLayer caching

💡 What: Changed `TrackLayer` to cache the instantiated `L.geoJSON` layer object instead of the raw GeoJSON data.
🎯 Why: Previously, every time a user returned to a circuit, the application would re-parse the GeoJSON and create new Leaflet layer instances (and associated DOM elements), causing unnecessary CPU overhead and GC pressure.
📊 Impact: Eliminates `L.geoJSON` instantiation overhead on subsequent visits to the same circuit. Verified via test script (1 call vs 2 calls).
🔬 Measurement: Run `test_optimization.js` (reproduction script provided during development) to observe that `L.geoJSON` constructor is called only once per circuit.

---
*PR created automatically by Jules for task [3655244600052749412](https://jules.google.com/task/3655244600052749412) started by @2fst4u*