### PR TITLE
🎨 Palette: Improve loading state accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,1 +1,7 @@
-## 2024-05-24 - Initialization Error State\n**Learning:** The application had no visual feedback for initialization failures (API downtime), leaving users with a broken UI.\n**Action:** Implemented a reusable `.error-state` pattern that replaces sidebar content with a friendly error message and retry action. This pattern can be reused for other critical failures.
+## 2024-05-24 - Initialization Error State
+**Learning:** The application had no visual feedback for initialization failures (API downtime), leaving users with a broken UI.
+**Action:** Implemented a reusable `.error-state` pattern that replaces sidebar content with a friendly error message and retry action. This pattern can be reused for other critical failures.
+
+## 2025-01-28 - Loading State Accessibility
+**Learning:** Screen readers may announce empty containers or nothing at all when content is being fetched, leading to confusion.
+**Action:** Use `aria-busy="true"` on the container and `aria-hidden="true"` on the skeleton loader to communicate state without noise.

--- a/public/app.js
+++ b/public/app.js
@@ -2789,9 +2789,11 @@ class CircuitWeatherApp {
 
         if (unavailable) unavailable.style.display = 'none';
         if (content) {
+            // Palette A11y: Mark region as busy during loading
+            content.setAttribute('aria-busy', 'true');
             content.style.display = 'block';
             content.innerHTML = `
-                <div class="weather-dashboard">
+                <div class="weather-dashboard" aria-hidden="true">
                     <div class="weather-current">
                         <div class="weather-metric">
                             <span class="weather-label skeleton"><span class="skeleton-text" style="width: 30px"></span></span>
@@ -2867,7 +2869,10 @@ class CircuitWeatherApp {
             return;
         }
 
+        // Palette A11y: Clear busy state
         const content = this.ui.forecastContent;
+        if (content) content.removeAttribute('aria-busy');
+
         const unavailable = this.ui.forecastUnavailable;
 
         if (!weather.available) {


### PR DESCRIPTION
💡 What: Added `aria-busy="true"` to the forecast container and `aria-hidden="true"` to the skeleton loader during data fetching.
🎯 Why: Screen readers were silent or confusing during the loading state. This ensures they ignore the skeleton structure and understand the region is updating.
♿ Accessibility:
- Forecast container now reports "busy" status.
- Visual-only skeleton elements are hidden from AT.

---
*PR created automatically by Jules for task [12512488465426228877](https://jules.google.com/task/12512488465426228877) started by @2fst4u*