### PR TITLE
🛡️ Sentinel: Harden Tile Proxy Validation

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -580,6 +580,15 @@ async function handleTileRequest(request, env, ctx) {
     });
   }
 
+  // SEC: Strict Extension Validation
+  // Ensure we only proxy PNG images as expected by the frontend
+  if (!tilePath.endsWith('.png')) {
+    return new Response(JSON.stringify({ error: 'Invalid tile format' }), {
+      status: 400,
+      headers: getErrorHeaders(request)
+    });
+  }
+
   const upstreamUrl = `https://tilecache.rainviewer.com${tilePath}`;
 
   // Canonical cache key
@@ -625,6 +634,17 @@ async function handleTileRequest(request, env, ctx) {
       // Pass error status to client so frontend logic can retry or show error
       return new Response(upstreamResponse.body, {
         status: upstreamResponse.status,
+        headers: getErrorHeaders(request)
+      });
+    }
+
+    // SEC: Strict Content-Type Validation
+    // Prevent XSS via MIME sniffing if upstream returns non-image content (e.g. HTML)
+    const contentType = upstreamResponse.headers.get('Content-Type');
+    if (!contentType || !contentType.startsWith('image/')) {
+      console.error(`Upstream Tile Invalid Content-Type: ${contentType}`);
+      return new Response(JSON.stringify({ error: 'Invalid upstream content type' }), {
+        status: 502,
         headers: getErrorHeaders(request)
       });
     }


### PR DESCRIPTION
🛡️ Sentinel: [Security Enhancement] Harden Tile Proxy

**Vulnerability:**
The `handleTileRequest` proxy in `src/worker.js` blindly forwarded the `Content-Type` header from `tilecache.rainviewer.com`. If the upstream service were compromised or tricked into serving HTML/JS, a user visiting the proxy URL could be exposed to XSS via MIME sniffing, as the worker is on the same domain as the app.

**Fix:**
1.  **Extension Check:** Enforced that the requested path must end in `.png`.
2.  **Content-Type Check:** Enforced that the upstream response `Content-Type` header starts with `image/`. If not, a 502 Bad Gateway is returned.

**Verification:**
Verified using a standalone Node.js script (`verify_fix.js`) simulating the worker logic with various mock responses (valid images, HTML, executables, etc.). All test cases passed.

---
*PR created automatically by Jules for task [18270792840403648417](https://jules.google.com/task/18270792840403648417) started by @2fst4u*