### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Cache Poisoning risk in API proxy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -97,3 +97,8 @@
 **Vulnerability:** The `handleTileRequest` in `src/worker.js` blindly appended the request path suffix to the upstream URL without validation. This allowed directory traversal (`..`) and potentially accessing arbitrary paths on the upstream server.
 **Learning:** Proxy endpoints often assume the input path is safe or that the upstream will handle it. However, unvalidated path construction is a common vector for SSRF or traversing into unintended API endpoints.
 **Prevention:** Strictly validate proxy path segments against an allowlist of characters and explicitly reject directory traversal sequences (`..`) before constructing upstream URLs.
+
+## 2026-03-12 - Upstream Cache Poisoning via Content-Type Mismatch
+**Vulnerability:** The API proxy in `src/worker.js` trusted upstream responses (e.g., from Jolpica) to always be valid JSON. If the upstream returned a 200 OK response with an HTML error page (e.g., from a WAF or maintenance page), the worker would cache this as `application/json` for 1 hour. This effectively poisoned the cache, causing the frontend application to break for all users served from that cache edge until TTL expired.
+**Learning:** Proxying "success" status codes (200 OK) blindly is dangerous if the upstream content type is not validated. Modern applications rely on strict content types, and caching layers can propagate transient upstream errors as persistent failures if not intercepted.
+**Prevention:** In API proxies, always validate that the `Content-Type` of the upstream response matches the expected type (e.g., `application/json`) before caching or serving it to the client. If the type is invalid (e.g. `text/html`), treat the response as an error (502 Bad Gateway) and do not cache it.

--- a/src/worker.js
+++ b/src/worker.js
@@ -402,6 +402,16 @@ async function handleApiRequest(request, env, ctx) {
       }, ctx);
     }
 
+    // SEC: Strict Content-Type Validation
+    // Prevent cache poisoning if upstream returns HTML error page with 200 OK
+    const contentType = upstreamResponse.headers.get('Content-Type');
+    if (!contentType || !contentType.includes('application/json')) {
+      console.error(`Upstream Invalid Content-Type: ${contentType}`);
+      return cacheAndReturnError(request, cache, cacheKey, 502, {
+        error: 'Invalid upstream content type',
+      }, ctx);
+    }
+
     // Bolt Optimization: Stream response instead of buffering text
     const [cacheBody, clientBody] = upstreamResponse.body.tee();
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Upstream Cache Poisoning
The API proxy in `src/worker.js` blindly forwarded 200 OK responses from the upstream Jolpica API and cached them as `application/json` for 1 hour. If the upstream returned an HTML error page (e.g., maintenance or WAF block) with a 200 OK status, this invalid content would be cached and served to all users, causing the frontend application to crash (SyntaxError on JSON parse) until the cache expired.

🎯 Impact: Denial of Service (DoS) for 1 hour if upstream has a transient failure that returns HTML.

🔧 Fix:
- Added strict `Content-Type` validation in `handleApiRequest`.
- Checks if `upstreamResponse.headers.get('Content-Type')` includes `application/json`.
- If invalid (e.g., `text/html`), returns 502 Bad Gateway and prevents caching of the success response.

✅ Verification:
- Created `tests/verify_fix.js` mocking the Worker environment.
- Verified that an HTML response from upstream now results in a 502 error instead of a 200 OK JSON response.
- Verified that valid JSON responses are still processed correctly.

---
*PR created automatically by Jules for task [6007811098548032327](https://jules.google.com/task/6007811098548032327) started by @2fst4u*