### PR TITLE
🎨 Palette: Improve theme toggle accessibility with dynamic labels

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -171,6 +171,23 @@ class ThemeManager {
 
     applyTheme() {
         document.documentElement.setAttribute('data-theme', this.theme);
+
+        // Palette UX: Update toggle button labels for better accessibility
+        // Dynamic labels clarify the action (e.g., "Switch to light mode") rather than just describing the current state
+        const nextTheme = this.theme === 'dark' ? 'light' : 'dark';
+        const label = `Switch to ${nextTheme} mode`;
+
+        const updateBtn = (id) => {
+            const btn = document.getElementById(id);
+            if (btn) {
+                btn.setAttribute('aria-label', label);
+                btn.setAttribute('title', label);
+            }
+        };
+
+        updateBtn('themeToggle');
+        updateBtn('mobileThemeToggle');
+
         if (this.onThemeChange) this.onThemeChange(this.theme);
     }
 


### PR DESCRIPTION
Implemented dynamic ARIA labels for the theme toggle buttons to improve accessibility for screen reader users and clarity for all users via tooltips. The labels now describe the action (e.g., 'Switch to dark mode') rather than the current state. Confirmed via Playwright verification script.

---
*PR created automatically by Jules for task [2184910817104655537](https://jules.google.com/task/2184910817104655537) started by @2fst4u*