### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden tile proxy (Content-Type + Headers)

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -650,8 +650,9 @@ async function handleTileRequest(request, env, ctx) {
 
     // SEC: Strict Content-Type Validation
     // Prevent XSS via MIME sniffing if upstream returns non-image content (e.g. HTML)
+    // Only allow PNG as we enforced .png extension in URL. Blocks image/svg+xml.
     const contentType = upstreamResponse.headers.get('Content-Type');
-    if (!contentType || !contentType.startsWith('image/')) {
+    if (!contentType || !contentType.startsWith('image/png')) {
       console.error(`Upstream Tile Invalid Content-Type: ${contentType}`);
       return new Response(JSON.stringify({ error: 'Invalid upstream content type' }), {
         status: 502,
@@ -666,6 +667,12 @@ async function handleTileRequest(request, env, ctx) {
     cacheHeaders.set('Cache-Control', 'public, max-age=7200'); // 2 Hours TTL
     cacheHeaders.set('X-Cache', 'MISS');
     cacheHeaders.set('Access-Control-Allow-Origin', '*');
+
+    // SEC: Add security headers (missing in previous version)
+    // Ensures X-Content-Type-Options: nosniff is set on cached tiles
+    Object.entries(DEFAULT_SECURITY_HEADERS).forEach(([key, value]) => {
+      cacheHeaders.set(key, value);
+    });
 
     // Clean up headers
     cacheHeaders.delete('Set-Cookie');


### PR DESCRIPTION
This PR hardens the `handleTileRequest` function in `src/worker.js`.
It introduces two key security enhancements:
1.  **Strict Content-Type Validation:** Explicitly checks that the upstream response is `image/png`. This prevents "MIME confusion" attacks where an upstream server might return HTML or SVG content (containing scripts) disguised as an image. This aligns with the existing logic that enforces the `.png` extension in the URL.
2.  **Security Headers:** Merges `DEFAULT_SECURITY_HEADERS` (including `X-Content-Type-Options: nosniff` and `Content-Security-Policy`) into the cached response headers. Previously, these headers were only applied to error responses, leaving successful tile responses potentially vulnerable if the browser attempted to sniff the content type.

These changes were verified using a temporary test script (`tests/verify_fix.mjs`) that simulated the Cloudflare Worker environment and asserted the presence of the security headers and proper handling of content types.
🚨 Severity: MEDIUM
💡 Vulnerability: Missing security headers on cached assets / Loose Content-Type check
🎯 Impact: Potential XSS via MIME sniffing if upstream is compromised
🔧 Fix: Enforce strict `image/png` and inject security headers
✅ Verification: verified with `tests/verify_fix.mjs` (created and deleted during process)

---
*PR created automatically by Jules for task [15694989686799119863](https://jules.google.com/task/15694989686799119863) started by @2fst4u*