### PR TITLE
Add accessible labels to countdown timer

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1892,8 +1892,14 @@ class CountdownTimer {
         const diff = this.targetTime - now;
 
         if (diff <= 0) {
-            if (this.ui.timer) this.ui.timer.textContent = 'NOW';
-            if (this.ui.mobileTimer) this.ui.mobileTimer.textContent = 'NOW';
+            if (this.ui.timer) {
+                this.ui.timer.textContent = 'NOW';
+                this.ui.timer.removeAttribute('aria-label');
+            }
+            if (this.ui.mobileTimer) {
+                this.ui.mobileTimer.textContent = 'NOW';
+                this.ui.mobileTimer.removeAttribute('aria-label');
+            }
             this.stop();
             return;
         }
@@ -1910,10 +1916,37 @@ class CountdownTimer {
             timeText = `${hours.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
         }
 
-        if (this.ui.timer) this.ui.timer.textContent = timeText;
-        if (this.ui.mobileTimer) this.ui.mobileTimer.textContent = timeText;
+        const accessibleText = this.getAccessibleDuration(diff);
+
+        if (this.ui.timer) {
+            this.ui.timer.textContent = timeText;
+            this.ui.timer.setAttribute('aria-label', accessibleText);
+        }
+        if (this.ui.mobileTimer) {
+            this.ui.mobileTimer.textContent = timeText;
+            this.ui.mobileTimer.setAttribute('aria-label', accessibleText);
+        }
         if (this.ui.session) this.ui.session.textContent = this.sessionName;
         if (this.ui.mobileSession) this.ui.mobileSession.textContent = this.sessionName;
+    }
+
+    getAccessibleDuration(diff) {
+        const hours = Math.floor(diff / 3600000);
+        const mins = Math.floor((diff % 3600000) / 60000);
+        const secs = Math.floor((diff % 60000) / 1000);
+
+        if (hours > 24) {
+            const days = Math.floor(hours / 24);
+            const remHours = hours % 24;
+            return `${days} day${days !== 1 ? 's' : ''}, ${remHours} hour${remHours !== 1 ? 's' : ''}`;
+        }
+
+        const parts = [];
+        if (hours > 0) parts.push(`${hours} hour${hours !== 1 ? 's' : ''}`);
+        if (mins > 0) parts.push(`${mins} minute${mins !== 1 ? 's' : ''}`);
+        parts.push(`${secs} second${secs !== 1 ? 's' : ''}`);
+
+        return parts.join(', ');
     }
 
     show(visible) {

--- a/public/index.html
+++ b/public/index.html
@@ -126,7 +126,7 @@
                 <!-- Session Countdown -->
                 <div class="countdown-card" id="countdownCard" style="display: none;">
                     <div class="countdown-label">Session starts in</div>
-                    <div class="countdown-timer" id="countdownTimer">--:--:--</div>
+                <div class="countdown-timer" id="countdownTimer" role="timer">--:--:--</div>
                     <div class="countdown-session" id="countdownSession"></div>
                 </div>
 
@@ -254,7 +254,7 @@
             <!-- Mobile Countdown Overlay (visible only on mobile) -->
             <div class="mobile-countdown" id="mobileCountdown" style="display: none;">
                 <div class="mobile-countdown-label">Starts in</div>
-                <div class="mobile-countdown-timer" id="mobileCountdownTimer">--:--:--</div>
+                <div class="mobile-countdown-timer" id="mobileCountdownTimer" role="timer">--:--:--</div>
                 <div class="mobile-countdown-session" id="mobileCountdownSession"></div>
             </div>
 


### PR DESCRIPTION
Implemented accessible labels for the countdown timer to improve screen reader experience. The visual timer displays `HH:MM:SS`, which is often read poorly by screen readers. Added `role="timer"` and dynamic `aria-label` updates with natural language duration (e.g., "2 hours, 30 minutes, 15 seconds"). Confirmed functionality with a reproduction test script mocking the browser environment.

---
*PR created automatically by Jules for task [10777757164671667157](https://jules.google.com/task/10777757164671667157) started by @2fst4u*