### PR TITLE
🎨 Palette: Add external link indicators

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-26 - External Links Accessibility
+**Learning:** External links often lack visual or audible indicators, causing confusion when new tabs open unexpectedly.
+**Action:** Always include an external link icon and screen-reader-only text "(opens in a new tab)" for `target="_blank"` links.

--- a/public/index.html
+++ b/public/index.html
@@ -183,7 +183,15 @@
                 <button type="button" id="privacyLink" class="link-button">Privacy</button>
                 <span>•</span>
                 <a href="https://github.com/circuit-weather/circuit-weather" target="_blank"
-                    rel="noopener noreferrer">GitHub</a>
+                    rel="noopener noreferrer" class="external-link">
+                    GitHub
+                    <svg class="icon-external" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                        <polyline points="15 3 21 3 21 9"></polyline>
+                        <line x1="10" y1="14" x2="21" y2="3"></line>
+                    </svg>
+                    <span class="sr-only">(opens in a new tab)</span>
+                </a>
             </div>
         </aside>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1746,6 +1746,33 @@ body {
     outline-offset: 2px;
 }
 
+/* ===================================
+   Utilities
+   =================================== */
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+}
+
+.external-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.icon-external {
+    width: 1em;
+    height: 1em;
+}
+
 /* Interactive Elements Overrides */
 .radar-play-btn:focus-visible {
     outline: none;


### PR DESCRIPTION
Improved the accessibility and UX of the external GitHub link in the footer by adding a visual icon and screen-reader-only text. This ensures users are aware that the link opens in a new tab.

**Changes:**
- **CSS:** Added utility classes for screen-reader-only text (`.sr-only`) and external link styling (`.external-link`, `.icon-external`).
- **HTML:** Updated the GitHub link to include the external link icon and hidden text.
- **Journal:** Added an entry documenting the pattern for external links.

**Verification:**
- Visually verified using Playwright screenshots (removed before submission).
- Verified HTML structure and CSS application.

---
*PR created automatically by Jules for task [9974275402142134819](https://jules.google.com/task/9974275402142134819) started by @2fst4u*