### PR TITLE
🎨 Palette: Add external link indicators to Privacy Policy

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2355,7 +2355,9 @@ class PrivacyModal {
             .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
             // Links
             .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, text, url) => {
-                return `<a href="${sanitizeUrl(url)}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+                // Palette A11y: Add external link indicator and SR text
+                const icon = `<svg class="icon-external" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>`;
+                return `<a href="${sanitizeUrl(url)}" target="_blank" rel="noopener noreferrer" class="external-link">${text} ${icon}<span class="sr-only">(opens in a new tab)</span></a>`;
             })
             // List items
             .replace(/^- (.+)$/gm, '<li>$1</li>')


### PR DESCRIPTION
This PR improves the accessibility of the Privacy Policy modal by adding visual and auditory indicators for external links.

### Changes
- Updated `PrivacyModal.parseMarkdown` in `public/app.js` to append an SVG icon and `.sr-only` text to links.
- Verified that the generated HTML matches the structure of existing footer links.
- Verified that the necessary CSS classes (`.external-link`, `.icon-external`, `.sr-only`) exist in `styles.css`.

### Verification
- Ran a Playwright script (`tests/verify_privacy_links.py`) to simulate user interaction:
  - Opened the Privacy modal.
  - Verified the presence of external links with the correct classes and internal structure.
  - Confirmed via screenshot that the modal loads correctly.

### Accessibility
- **Screen Readers:** Now announce "(opens in a new tab)" for all privacy policy links.
- **Visual:** Users see the standard external link icon, consistent with the rest of the application.

---
*PR created automatically by Jules for task [13852570291957456560](https://jules.google.com/task/13852570291957456560) started by @2fst4u*