### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix upstream header leakage in tile proxy

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - Header Allowlist for Worker Proxy
+**Vulnerability:** Upstream headers (like `X-Secret-Header` or `Server`) were being leaked to the client because `handleTileRequest` in `src/worker.js` copied all headers and only removed a few specific ones (denylist approach).
+**Learning:** Cloudflare Workers' `fetch` returns all upstream headers. Simply copying `new Headers(response.headers)` is insecure for proxying public traffic to internal or third-party upstreams.
+**Prevention:** Use an allowlist approach when constructing the response headers. Explicitly copy only safe/necessary headers like `Content-Type`, `Content-Length`, `ETag`, `Last-Modified`.

--- a/src/worker.js
+++ b/src/worker.js
@@ -666,21 +666,23 @@ async function handleTileRequest(request, env, ctx) {
     // 4. Cache Success Response
     const [cacheBody, clientBody] = upstreamResponse.body.tee();
 
-    const cacheHeaders = new Headers(upstreamResponse.headers);
+    // SEC: Allowlist headers to prevent leaking sensitive upstream headers
+    const cacheHeaders = new Headers();
+    const allowedHeaders = ['Content-Type', 'Content-Length', 'Last-Modified', 'ETag', 'Date'];
+    for (const header of allowedHeaders) {
+      const value = upstreamResponse.headers.get(header);
+      if (value) cacheHeaders.set(header, value);
+    }
+
     cacheHeaders.set('Cache-Control', 'public, max-age=7200'); // 2 Hours TTL
     cacheHeaders.set('X-Cache', 'MISS');
     cacheHeaders.set('Access-Control-Allow-Origin', '*');
 
-    // SEC: Add security headers (missing in previous version)
+    // SEC: Add security headers
     // Ensures X-Content-Type-Options: nosniff is set on cached tiles
     Object.entries(DEFAULT_SECURITY_HEADERS).forEach(([key, value]) => {
       cacheHeaders.set(key, value);
     });
-
-    // Clean up headers
-    cacheHeaders.delete('Set-Cookie');
-    cacheHeaders.delete('Server');
-    cacheHeaders.delete('Vary'); // Robustness: Prevent cache fragmentation based on User-Agent/Origin
 
     const cacheResponse = new Response(cacheBody, {
       status: upstreamResponse.status,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `handleTileRequest` function in `src/worker.js` was copying all upstream headers to the client response, only removing a few specific ones (denylist). This could leak sensitive headers like `Server`, `X-Powered-By`, or internal `X-` headers from the upstream provider (RainViewer).
🎯 Impact: Leakage of internal infrastructure details or sensitive tokens.
🔧 Fix: Implemented a strict allowlist for headers. Only `Content-Type`, `Content-Length`, `Last-Modified`, `ETag`, and `Date` are forwarded.
✅ Verification: Created reproduction script `tests/repro_header_leak.mjs` which confirmed the leak, and `tests/verify_allowlist.mjs` which confirmed the fix.

---
*PR created automatically by Jules for task [2068475372308442032](https://jules.google.com/task/2068475372308442032) started by @2fst4u*