### PR TITLE
feat(a11y): use dynamic aria labels for radar play/pause button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-01-26 - External Links Accessibility
 **Learning:** External links often lack visual or audible indicators, causing confusion when new tabs open unexpectedly.
 **Action:** Always include an external link icon and screen-reader-only text "(opens in a new tab)" for `target="_blank"` links.
+
+## 2026-01-27 - Dynamic Action Labels vs. ARIA Pressed
+**Learning:** For toggle buttons representing an action (like Play/Pause), dynamic labels (e.g., "Play", "Pause") are clearer than static labels with `aria-pressed` state. This aligns with the "Theme Toggle" pattern.
+**Action:** Use dynamic `aria-label` and `title` attributes for binary action toggles instead of `aria-pressed`.

--- a/public/app.js
+++ b/public/app.js
@@ -1481,7 +1481,8 @@ class WeatherRadar {
         this.isPlaying = true;
         if (this.ui.playBtn) {
             this.ui.playBtn.classList.add('playing');
-            this.ui.playBtn.setAttribute('aria-pressed', 'true');
+            this.ui.playBtn.setAttribute('aria-label', 'Pause radar animation');
+            this.ui.playBtn.setAttribute('title', 'Pause (Space)');
         }
 
         // Bolt Optimization: Use requestAnimationFrame instead of setInterval
@@ -1511,7 +1512,8 @@ class WeatherRadar {
         this.isPlaying = false;
         if (this.ui.playBtn) {
             this.ui.playBtn.classList.remove('playing');
-            this.ui.playBtn.setAttribute('aria-pressed', 'false');
+            this.ui.playBtn.setAttribute('aria-label', 'Play radar animation');
+            this.ui.playBtn.setAttribute('title', 'Play (Space)');
         }
 
         if (this.animationFrameId) {

--- a/public/index.html
+++ b/public/index.html
@@ -240,8 +240,8 @@
 
             <!-- Radar Timeline -->
             <div class="radar-controls" id="radarControls" style="display: none;">
-                <button class="radar-play-btn" id="radarPlayBtn" aria-label="Play/Pause radar animation"
-                    title="Play/Pause (Space)" aria-keyshortcuts="Space" aria-pressed="false">
+                <button class="radar-play-btn" id="radarPlayBtn" aria-label="Play radar animation"
+                    title="Play (Space)" aria-keyshortcuts="Space">
                     <svg class="icon-play" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
                         <polygon points="5,3 19,12 5,21"></polygon>
                     </svg>


### PR DESCRIPTION
Improved accessibility of the weather radar play/pause button by replacing the `aria-pressed` state with dynamic `aria-label` and `title` attributes. 

**Changes:**
- Replaced `aria-pressed` with explicit "Play radar animation" / "Pause radar animation" labels.
- Updated `title` tooltip to match the current action ("Play (Space)" / "Pause (Space)").
- Documented this pattern in `.Jules/palette.md`.

**Why:**
This aligns with the existing "Theme Toggle" pattern and clarifies the button's action for screen reader users, as "Play/Pause" is an action toggle rather than a persistent state toggle (like mute).

---
*PR created automatically by Jules for task [11105382348519047444](https://jules.google.com/task/11105382348519047444) started by @2fst4u*