### PR TITLE
🎨 Palette: Dynamic Theme Color for Mobile Browsers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-16 - [Dynamic Theme Color for Mobile Browsers]
+**Learning:** Users perceive a "native app" feel when the mobile browser's address bar matches the application's theme. Static `theme-color` meta tags create a jarring mismatch in dark mode. Updating this meta tag dynamically via JS (both on init and toggle) is a low-effort, high-impact polish.
+**Action:** When implementing dark mode support in future web apps, always include logic to synchronize the `<meta name="theme-color">` tag with the active theme state.

--- a/public/app.js
+++ b/public/app.js
@@ -172,6 +172,13 @@ class ThemeManager {
     applyTheme() {
         document.documentElement.setAttribute('data-theme', this.theme);
 
+        // Palette UX: Update theme-color meta tag for mobile browsers
+        // Matches sidebar color in dark mode (#1e293b) and brand color in light mode (#e10600)
+        const meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) {
+            meta.content = this.theme === 'dark' ? '#1e293b' : '#e10600';
+        }
+
         // Palette UX: Update toggle button labels for better accessibility
         // Dynamic labels clarify the action (e.g., "Switch to light mode") rather than just describing the current state
         const nextTheme = this.theme === 'dark' ? 'light' : 'dark';

--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,12 @@
                 const stored = localStorage.getItem('theme');
                 const theme = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
                 document.documentElement.setAttribute('data-theme', theme);
+
+                // Palette: Set theme-color meta tag for mobile browsers
+                const meta = document.querySelector('meta[name="theme-color"]');
+                if (meta) {
+                    meta.content = theme === 'dark' ? '#1e293b' : '#e10600';
+                }
             } catch (e) { }
         })();
     </script>


### PR DESCRIPTION
Implemented dynamic updates to the `meta[name="theme-color"]` tag to ensure the mobile browser address bar matches the application theme (Dark/Light).

- Updated `public/index.html` inline script to set the initial color on load (preventing FOUC).
- Updated `ThemeManager` in `public/app.js` to update the color when the user toggles the theme.
- Uses `#1e293b` for Dark Mode (matching sidebar) and `#e10600` for Light Mode (matching brand).
- Verified with Playwright script (deleted after use).


---
*PR created automatically by Jules for task [3611498123878462158](https://jules.google.com/task/3611498123878462158) started by @2fst4u*