### PR TITLE
Style AdSense ad overlay as floating card with mobile responsiveness

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -555,16 +555,21 @@ body {
 /* AdSense Overlay */
 .ad-overlay {
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
+    top: var(--spacing-md);
+    left: 50%;
+    transform: translateX(-50%);
     z-index: 500;
+    width: 90%;
+    max-width: 728px;
     background: var(--sidebar-bg);
     backdrop-filter: var(--glass-blur);
     -webkit-backdrop-filter: var(--glass-blur);
-    border-bottom: 1px solid var(--color-border);
-    padding: var(--spacing-xs);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    padding: var(--spacing-sm);
     min-height: 50px;
+    overflow: hidden;
 }
 
 /* Leaflet Customization */
@@ -1177,6 +1182,15 @@ body {
         right: 0;
         bottom: 0;
         height: auto;
+    }
+
+    /* Ad overlay below mobile header */
+    .ad-overlay {
+        top: calc(56px + var(--spacing-sm));
+        width: 95%;
+        max-width: none;
+        padding: var(--spacing-xs);
+        min-height: 50px;
     }
 
     /* Compact header */


### PR DESCRIPTION
## Changes

Restyled the AdSense ad overlay from a full-width bar to a centered floating card that matches the design language of other map overlay elements (radar controls, mobile countdown, etc.):

- **Desktop**: Centered card with max-width 728px, glassmorphism background, rounded corners, shadow, and border
- **Mobile**: Offset below the 56px mobile header, 95% width, compact padding

## Context

The initial ad overlay spanned the full width and sat behind other elements. This update brings it in line with the existing card-based UI overlays.