### PR TITLE
Fix ad overlay desktop width to clear weather widget

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -559,7 +559,7 @@ body {
     left: 50%;
     transform: translateX(-50%);
     z-index: 500;
-    width: 90%;
+    width: calc(100% - 200px);
     max-width: 728px;
     background: var(--sidebar-bg);
     backdrop-filter: var(--glass-blur);


### PR DESCRIPTION
Changes desktop ad width from 90% to calc(100% - 200px), leaving ~100px clearance on each side so the centered ad doesn't overlap with the weather widget in the top-right.