### PR TITLE
🛡️ Sentinel: Fix Privacy Leak in Radar Health Check

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,7 +5,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: accelerometer=(), autoplay=(), camera=(), fullscreen=(), geolocation=(), gyroscope=(), interest-cohort=(), magnetometer=(), microphone=(), payment=(), picture-in-picture=(), usb=(), sync-xhr=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-  Content-Security-Policy: upgrade-insecure-requests; default-src 'self'; script-src 'self' https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://*.basemaps.cartocdn.com https://flagcdn.com https://*.buymeacoffee.com; font-src https://fonts.gstatic.com; connect-src 'self' https://api.open-meteo.com https://api.rainviewer.com https://*.buymeacoffee.com; worker-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';
+  Content-Security-Policy: upgrade-insecure-requests; default-src 'self'; script-src 'self' https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://*.basemaps.cartocdn.com https://flagcdn.com https://*.buymeacoffee.com; font-src https://fonts.gstatic.com; connect-src 'self' https://api.open-meteo.com https://*.buymeacoffee.com; worker-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';
   X-Frame-Options: DENY
   Cross-Origin-Opener-Policy: same-origin-allow-popups
   Cross-Origin-Resource-Policy: cross-origin

--- a/public/app.js
+++ b/public/app.js
@@ -1023,8 +1023,9 @@ class WeatherRadar {
         if (this.isCheckingStatus) return;
         this.isCheckingStatus = true;
 
-        // Use direct API URL to avoid proxy nuances and ensure we check the source
-        const checkUrl = 'https://api.rainviewer.com/public/weather-maps.json';
+        // Use proxied API URL to avoid privacy leak (direct connection exposes IP)
+        // Worker now passes through 429 status for this check
+        const checkUrl = CONFIG.rainViewerApi;
 
         fetch(checkUrl, { method: 'HEAD' })
             .then(response => {

--- a/src/worker.js
+++ b/src/worker.js
@@ -895,6 +895,15 @@ async function handleRadarRequest(request, env, ctx) {
 
     if (!upstreamResponse.ok) {
       console.error(`Upstream Radar API Error: Status ${upstreamResponse.status}`);
+      if (upstreamResponse.status === 429) {
+        return new Response(JSON.stringify({ error: 'Upstream Rate Limit' }), {
+          status: 429,
+          headers: {
+            ...getErrorHeaders(request),
+            'Retry-After': '60'
+          }
+        });
+      }
       return getEmptyRadarResponse(request);
     }
 


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Privacy Leak via Direct API Access

🚨 Severity: MEDIUM
💡 Vulnerability: The application was performing direct client-side requests to `api.rainviewer.com` for health checks, bypassing the backend proxy and exposing user IP addresses to a third-party service.
🎯 Impact: Privacy violation; user IPs were leaked to RainViewer despite the project's goal of proxying all traffic.
🔧 Fix:
1.  Modified `src/worker.js` to propagate 429 status codes from the upstream API instead of masking them as 200 OK, allowing the frontend to detect rate limits via the proxy.
2.  Updated `public/app.js` to use the proxied endpoint (`/api/radar`) for health checks.
3.  Updated `public/_headers` to remove the direct API domain from the CSP `connect-src` directive.
✅ Verification:
- Created a reproduction test case (`tests/verify_worker_privacy.mjs`) confirming the worker now returns 429 when upstream is rate-limited.
- Manually verified that `public/app.js` uses the correct configuration for the health check URL.

---
*PR created automatically by Jules for task [16651421030752769734](https://jules.google.com/task/16651421030752769734) started by @2fst4u*