### PR TITLE
📚 Archivist: Fix incomplete API endpoint documentation

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -1,0 +1,6 @@
+2025-02-18 - Missing API Endpoints in Documentation
+
+Issue: The "API Endpoints" table in AGENTS.md was incomplete, listing only 2 of the 5 active worker routes.
+Cause: Documentation drift as new features (tracks, radar JSON, asset proxying) were added to `worker.js` without updating `AGENTS.md`.
+Fix: Updated AGENTS.md to include `/api/radar`, `/api/track/*`, and `/api/assets/*` with accurate caching policies derived from source code.
+Prevention: When modifying `worker.js`, cross-reference `AGENTS.md` to ensure documentation matches the implementation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,7 +217,10 @@ mode = "smart"
 | Endpoint | Purpose |
 |----------|---------|
 | `/api/f1/*` | Proxies to Jolpica F1 API with 1-hour edge caching |
+| `/api/radar` | Proxies to RainViewer Maps API with 1-minute caching (initializes animation) |
 | `/api/tiles/*` | Proxies to RainViewer tile API with 2-hour edge caching (512px optimized) |
+| `/api/track/*` | Proxies to GitHub for GeoJSON track data with 24-hour caching |
+| `/api/assets/*` | Proxies to unpkg for Leaflet assets with 1-year immutable caching (strict CSP) |
 
 ---
 


### PR DESCRIPTION
This PR updates `AGENTS.md` to accurately document all API endpoints currently handled by the Cloudflare Worker (`src/worker.js`). 

Previously, the documentation only listed `/api/f1/*` and `/api/tiles/*`. This update adds:
- `/api/radar`: Proxies RainViewer Maps API (1-minute cache).
- `/api/track/*`: Proxies GitHub for GeoJSON track data (24-hour cache).
- `/api/assets/*`: Proxies unpkg for Leaflet assets (1-year immutable cache).

This ensures developers and agents have a complete understanding of the API surface area and caching policies. A journal entry has been added to `.jules/archivist.md` as per the Archivist role protocol.

---
*PR created automatically by Jules for task [524467848482317309](https://jules.google.com/task/524467848482317309) started by @2fst4u*