### PR TITLE
📚 Archivist: Fix PRIVACY.md Unpkg claim

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -11,3 +11,9 @@ Issue: Initialized a new journal file potentially overwriting existing content w
 Cause: Assumed file did not exist based on root directory listing.
 Fix: (Self-correction) Always check for existence before writing new files.
 Prevention: Use `list_files` on subdirectories or `read_file` before creating/writing.
+
+2026-01-28 - Privacy Policy Inaccuracy: Unpkg Usage
+Issue: PRIVACY.md claimed Leaflet assets were loaded directly from Unpkg, while the codebase (worker.js) proxied them for strict CSP compliance.
+Cause: Documentation drift after implementing strict Content Security Policy (CSP) and asset proxying.
+Fix: Updated PRIVACY.md to correctly list Leaflet as a proxied data source.
+Prevention: Review PRIVACY.md when modifying CSP or external asset loading strategies.

--- a/public/PRIVACY.md
+++ b/public/PRIVACY.md
@@ -51,7 +51,6 @@ While we proxy some data, your browser connects directly to the following servic
 
 **Content Delivery Networks (CDNs)**
 To improve performance and reliability, we load standard libraries and assets from public CDNs:
-- **Unpkg:** Serves the Leaflet.js mapping library.
 - **Google Fonts:** Serves typography files.
 - **FlagCDN:** Serves country flag icons.
 
@@ -69,6 +68,7 @@ The following services provide the raw data that we process and cache via Cloudf
 - **Jolpica F1:** Historical and current F1 schedule data.
 - **GitHub:** Stores static track layout files (GeoJSON).
 - **RainViewer:** Weather radar tiles and metadata (2-hour edge cache).
+- **Leaflet (via Unpkg):** Map interaction library assets (proxied for security).
 
 ## Local Storage
 


### PR DESCRIPTION
Updated `public/PRIVACY.md` to correct the inaccuracy regarding Unpkg usage. Leaflet assets are proxied via the worker for security, not loaded directly. Added a journal entry to `.jules/archivist.md` documenting this fix.

---
*PR created automatically by Jules for task [2925875717419479732](https://jules.google.com/task/2925875717419479732) started by @2fst4u*