### PR TITLE
🛡️ Sentinel: Enforce SRI checks in asset proxy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** Loading CSS/JS from public CDNs (like `unpkg.com`) in CSP `style-src`/`script-src` allows any malicious file from that CDN to be executed if injected.
 **Learning:** Even with SRI, a broad CSP allowance (`https://unpkg.com`) permits loading arbitrary styles/scripts if an XSS vulnerability exists.
 **Prevention:** Use a Cloudflare Worker proxy (`/api/assets/*`) to fetch specific, versioned files from the CDN and validate their Content-Type. This allows the CSP to be tightened to `self` only, removing the CDN origin entirely.
+
+## 2026-02-16 - [Strict Asset Proxy with Integrity Verification]
+**Vulnerability:** The application proxied Leaflet assets from `unpkg.com` via a Cloudflare Worker to enforce strict CSP. However, the worker did not verify the integrity of the upstream response, meaning a compromised CDN or supply chain attack could serve malicious code that the worker would cache and serve as "trusted" (same-origin).
+**Learning:** Relying solely on client-side SRI allows the worker to be poisoned. A trusted proxy must verify the integrity of the content it serves, especially when it acts as a gatekeeper for CSP.
+**Prevention:** Implemented SHA-256 hash verification in the worker proxy (`handleLeafletRequest`). The worker now calculates the hash of the upstream response body and compares it against a hardcoded allowlist of known-good hashes before serving or caching the file. This effectively pins the dependencies in the backend.

--- a/src/worker.js
+++ b/src/worker.js
@@ -589,35 +589,42 @@ async function handleLeafletRequest(request, env, ctx) {
   const url = new URL(request.url);
   const path = url.pathname.replace('/api/assets/', '');
 
-  // Whitelist of allowed files
+  // Whitelist of allowed files with SRI integrity hashes
   const allowedFiles = new Map([
     ['leaflet.js', {
       upstream: 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js',
-      contentTypes: ['application/javascript', 'text/javascript'] // Allow both standard and legacy
+      contentTypes: ['application/javascript', 'text/javascript'], // Allow both standard and legacy
+      integrity: 'sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo='
     }],
     ['leaflet.css', {
       upstream: 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css',
-      contentTypes: ['text/css']
+      contentTypes: ['text/css'],
+      integrity: 'sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY='
     }],
     ['images/layers.png', {
       upstream: 'https://unpkg.com/leaflet@1.9.4/dist/images/layers.png',
-      contentTypes: ['image/png']
+      contentTypes: ['image/png'],
+      integrity: 'sha256-Hbvp0CjikvNvy6j4s6KNXokydU/CIVuaxp5M3s9RB8Y='
     }],
     ['images/layers-2x.png', {
       upstream: 'https://unpkg.com/leaflet@1.9.4/dist/images/layers-2x.png',
-      contentTypes: ['image/png']
+      contentTypes: ['image/png'],
+      integrity: 'sha256-Bm2sqFDY/77wB68AsG6sABVyje4nnFHzy2xxbffELt8='
     }],
     ['images/marker-icon.png', {
       upstream: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
-      contentTypes: ['image/png']
+      contentTypes: ['image/png'],
+      integrity: 'sha256-V0w6XMqF9BFAhbaEFZbWLwDXyJLHsD8oy/owHesdxDc='
     }],
     ['images/marker-icon-2x.png', {
       upstream: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
-      contentTypes: ['image/png']
+      contentTypes: ['image/png'],
+      integrity: 'sha256-ABecTB7oMNOhCEEq4NKU9Vd2z+sIXGASmjmqb8SuJSg='
     }],
     ['images/marker-shadow.png', {
       upstream: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
-      contentTypes: ['image/png']
+      contentTypes: ['image/png'],
+      integrity: 'sha256-Jk9cZAM58ELdcpBiz8BMF/jqDymIK1OOOEjtjxDttNo='
     }],
   ]);
 
@@ -672,8 +679,21 @@ async function handleLeafletRequest(request, env, ctx) {
       return new Response('Invalid upstream content type', { status: 502, headers: getErrorHeaders(request) });
     }
 
-    const [cacheBody, clientBody] = upstreamResponse.body.tee();
+    // SEC: Validate Content Integrity (SRI)
+    // Buffer the response body to calculate hash
+    const buffer = await upstreamResponse.arrayBuffer();
+    const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    // Convert to base64 string
+    const hashBase64 = btoa(String.fromCharCode(...hashArray));
+    const calculatedIntegrity = `sha256-${hashBase64}`;
 
+    if (calculatedIntegrity !== config.integrity) {
+      console.error(`Leaflet Integrity Mismatch (${path}): Expected ${config.integrity}, Got ${calculatedIntegrity}`);
+      return new Response('Integrity check failed', { status: 502, headers: getErrorHeaders(request) });
+    }
+
+    // Use the buffered body for caching and response
     // Use the first allowed content type as the canonical one for the client response
     const canonicalType = config.contentTypes[0];
 
@@ -685,7 +705,7 @@ async function handleLeafletRequest(request, env, ctx) {
     });
 
     // Cache it
-    ctx.waitUntil(cache.put(cacheKey, new Response(cacheBody, { headers: cacheHeaders })));
+    ctx.waitUntil(cache.put(cacheKey, new Response(buffer, { headers: cacheHeaders })));
 
     const clientHeaders = new Headers(cacheHeaders);
     const allowedOrigin = getAllowedOrigin(request);
@@ -694,7 +714,7 @@ async function handleLeafletRequest(request, env, ctx) {
       clientHeaders.set('Vary', 'Origin');
     }
 
-    return new Response(clientBody, {
+    return new Response(buffer, {
       status: 200,
       headers: clientHeaders
     });
@@ -704,6 +724,7 @@ async function handleLeafletRequest(request, env, ctx) {
     return new Response('Leaflet fetch failed', { status: 502, headers: getErrorHeaders(request) });
   }
 }
+
 
 /**
  * Handle Radar Tile requests with robust caching


### PR DESCRIPTION
Added SHA-256 hash verification to `handleLeafletRequest` in `src/worker.js` to ensure proxied assets from unpkg.com match the expected versions, preventing supply chain attacks or cache poisoning.

Changes:
- Added `integrity` field to `allowedFiles` map in `src/worker.js`.
- Implemented buffering and SHA-256 hash calculation of upstream response body.
- Verify calculated hash against expected hash before serving or caching.
- Updated `.jules/sentinel.md` with the new security pattern.

Verification:
- Created and ran a temporary test script (`tests/verify_integrity.mjs`) mocking the Cloudflare Worker environment.
- Verified that correct content passes (200 OK) and modified content fails (502 Bad Gateway).
- Verified hashes match the SRI attributes in `public/index.html`.


---
*PR created automatically by Jules for task [10453053248637992990](https://jules.google.com/task/10453053248637992990) started by @2fst4u*