### PR TITLE
🛡️ Sentinel: [HIGH] Remove RainViewer from CSP

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** Loading CSS/JS from public CDNs (like `unpkg.com`) in CSP `style-src`/`script-src` allows any malicious file from that CDN to be executed if injected.
 **Learning:** Even with SRI, a broad CSP allowance (`https://unpkg.com`) permits loading arbitrary styles/scripts if an XSS vulnerability exists.
 **Prevention:** Use a Cloudflare Worker proxy (`/api/assets/*`) to fetch specific, versioned files from the CDN and validate their Content-Type. This allows the CSP to be tightened to `self` only, removing the CDN origin entirely.
+
+## 2026-06-15 - [Strict CSP Alignment with Proxy Architecture]
+**Vulnerability:** The `public/index.html` CSP allowed `connect-src` to `https://api.rainviewer.com`, even though the application architecture mandated proxying all such requests through `src/worker.js` to protect user privacy (IP masking). This created a loophole where a compromised script could potentially leak user IPs directly to the third-party provider.
+**Learning:** CSP directives can easily drift from architectural intent if not manually synchronized. A "working" CSP is not necessarily a "secure" or "correct" CSP.
+**Prevention:** Audit CSP `connect-src` against the actual network requests made by the frontend (e.g., via `grep` or network logs). If a proxy is used for privacy, the direct upstream origin MUST be removed from the CSP to enforce the privacy guarantee.

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="Content-Security-Policy"
-        content="upgrade-insecure-requests; default-src 'self'; script-src 'self' https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://*.basemaps.cartocdn.com https://flagcdn.com https://*.buymeacoffee.com; font-src https://fonts.gstatic.com; connect-src 'self' https://api.open-meteo.com https://api.rainviewer.com https://*.buymeacoffee.com; worker-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';">
+        content="upgrade-insecure-requests; default-src 'self'; script-src 'self' https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://*.basemaps.cartocdn.com https://flagcdn.com https://*.buymeacoffee.com; font-src https://fonts.gstatic.com; connect-src 'self' https://api.open-meteo.com https://*.buymeacoffee.com; worker-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';">
     <title>Circuit Weather - F1 Race Circuit Weather Radar</title>
 
     <!-- Theme Initialization -->


### PR DESCRIPTION
Removed `https://api.rainviewer.com` from `connect-src` in `public/index.html`. The application proxies all RainViewer requests via the worker to protect user privacy, so allowing direct browser connections was unnecessary and violated the principle of least privilege. This change aligns the CSP with the privacy guarantees documented in `PRIVACY.md` and ensures no IP leakage can occur via direct requests to the radar provider.

---
*PR created automatically by Jules for task [10776620537590643888](https://jules.google.com/task/10776620537590643888) started by @2fst4u*