### PR TITLE
🎨 Palette: Accessible Unit Toggle Labels

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -106,10 +106,10 @@
                     <div class="control-group control-group--units">
                         <span id="unitsLabel" class="control-label">Units</span>
                         <div class="unit-toggle" id="unitToggle" role="group" aria-labelledby="unitsLabel">
-                            <button class="unit-option" data-unit="metric" type="button"
-                                aria-pressed="false">km</button>
-                            <button class="unit-option active" data-unit="imperial" type="button"
-                                aria-pressed="true">mi</button>
+                            <button class="unit-option" data-unit="metric" type="button" aria-label="Kilometers"
+                                title="Kilometers" aria-pressed="false">km</button>
+                            <button class="unit-option active" data-unit="imperial" type="button" aria-label="Miles"
+                                title="Miles" aria-pressed="true">mi</button>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
🎨 **Palette: Improved Accessibility for Unit Toggle Buttons**

**💡 What:**
Added explicit `aria-label` and `title` attributes to the unit toggle buttons (km/mi).

**🎯 Why:**
The abbreviations "km" and "mi" can be ambiguous or less clear for screen reader users. Adding "Kilometers" and "Miles" as labels ensures the content is accessible and understandable. The `title` attribute adds a tooltip for mouse users, providing further clarity.

**📸 Before/After:**
*   **Before:** Screen reader announced "km button" / "mi button". No tooltip.
*   **After:** Screen reader announces "Kilometers button" / "Miles button". Tooltip on hover shows full name.

**♿ Accessibility:**
-   Expanded abbreviations for AT users.
-   Added tooltips for cognitive accessibility.

---
*PR created automatically by Jules for task [14732140934730511446](https://jules.google.com/task/14732140934730511446) started by @2fst4u*