### PR TITLE
📚 Archivist: Fix AGENTS.md API documentation

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -17,3 +17,9 @@ Issue: PRIVACY.md claimed Leaflet assets were loaded directly from Unpkg, while 
 Cause: Documentation drift after implementing strict Content Security Policy (CSP) and asset proxying.
 Fix: Updated PRIVACY.md to correctly list Leaflet as a proxied data source.
 Prevention: Review PRIVACY.md when modifying CSP or external asset loading strategies.
+
+2026-01-29 - Inaccurate Third-Party Service Documentation
+Issue: AGENTS.md listed "Auth Required" as "No" for Jolpica, while failing to mention it is proxied, and inconsistently used "Proxied" for RainViewer in the same column. It also missed GitHub (Tracks) and Open-Meteo in the Technology Stack overview.
+Cause: Documentation drift as new services (GitHub tracks) and patterns (proxying for privacy) were adopted without updating the high-level agent guide.
+Fix: Renamed "Auth Required" to "Connection" in AGENTS.md, updated values to "Proxied (Cached)" or "Direct (Client-side)", and added missing services (GitHub, Open-Meteo).
+Prevention: Review AGENTS.md when adding new external dependencies or changing data fetching strategies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Circuit Weather is a real-time F1 race circuit weather radar application. It dis
 | Frontend | Vanilla HTML/CSS/JS |
 | Mapping | Leaflet.js with Carto basemaps |
 | Backend | Cloudflare Workers with Assets |
-| APIs | Jolpica F1 API, RainViewer API |
+| APIs | Jolpica F1, RainViewer, Open-Meteo, GitHub (Tracks) |
 
 ---
 
@@ -25,12 +25,13 @@ Circuit Weather is a real-time F1 race circuit weather radar application. It dis
 - **NO user authentication** - App is read-only, no user accounts
 
 ### Third-Party Services
-| Service | Purpose | Auth Required |
-|---------|---------|---------------|
-| Jolpica F1 API | Race schedule data | No |
+| Service | Purpose | Connection |
+|---------|---------|------------|
+| Jolpica F1 API | Race schedule data | Proxied (Cached) |
 | RainViewer | Weather radar tiles | Proxied (Cached) |
 | Open-Meteo | Weather forecasts | Direct (Client-side) |
-| Carto | Map basemap tiles | No |
+| Carto | Map basemap tiles | Direct (Client-side) |
+| GitHub | Track GeoJSON data | Proxied (Cached) |
 
 ### Data Handling
 - **No cookies** used


### PR DESCRIPTION
Updated AGENTS.md to correct misleading and incomplete information regarding third-party service connections and APIs.

The previous documentation listed "Auth Required" as "No" for proxied services without mentioning the proxy, and inconsistently labeled RainViewer. It also omitted GitHub (used for track data) and Open-Meteo from the high-level stack overview.

Changes:
- Renamed "Auth Required" to "Connection" in the Third-Party Services table.
- Standardized values to "Proxied (Cached)" or "Direct (Client-side)".
- Added GitHub (Tracks) to the services table.
- Added Open-Meteo and GitHub to the Technology Stack -> APIs list.
- Updated .jules/archivist.md with the finding.

---
*PR created automatically by Jules for task [8000473241695869420](https://jules.google.com/task/8000473241695869420) started by @2fst4u*