### PR TITLE
📚 Archivist: Fix missing Unpkg/Leaflet in AGENTS.md

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -29,3 +29,9 @@ Issue: AGENTS.md omitted Google Fonts, FlagCDN, and Buy Me a Coffee from the Thi
 Cause: Frontend assets and widgets added directly to HTML/JS were not reflected in the high-level architecture documentation.
 Fix: Added missing services to AGENTS.md with "Direct (Client-side)" connection type.
 Prevention: Audit index.html and app.js for external URLs when updating documentation or adding new features.
+
+2026-02-17 - Missing Proxied Service in Documentation
+Issue: AGENTS.md omitted Unpkg (Leaflet) from the Third-Party Services table, despite it being proxied and listed in PRIVACY.md.
+Cause: Oversight when documenting proxied services vs direct services.
+Fix: Added Unpkg (Leaflet) to AGENTS.md with "Proxied (Cached)" connection type.
+Prevention: Cross-reference PRIVACY.md and src/worker.js when updating AGENTS.md.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Circuit Weather is a real-time F1 race circuit weather radar application. It dis
 | Open-Meteo | Weather forecasts | Direct (Client-side) |
 | Carto | Map basemap tiles | Direct (Client-side) |
 | GitHub | Track GeoJSON data | Proxied (Cached) |
+| Unpkg (Leaflet) | Map library assets | Proxied (Cached) |
 | Google Fonts | Typography | Direct (Client-side) |
 | FlagCDN | Country flags | Direct (Client-side) |
 | Buy Me a Coffee | Support widget | Direct (Client-side) |


### PR DESCRIPTION
Updated `AGENTS.md` to include `Unpkg (Leaflet)` in the "Third-Party Services" table, ensuring the documentation accurately reflects the codebase (`src/worker.js`) and privacy policy (`PRIVACY.md`). This service is proxied and cached for strict CSP compliance.

Also updated `.jules/archivist.md` to log this documentation fix.

---
*PR created automatically by Jules for task [14016617849584569548](https://jules.google.com/task/14016617849584569548) started by @2fst4u*