### PR TITLE
Fix Open-Meteo URL corruption using URLSearchParams

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -413,7 +413,15 @@ class WeatherClient {
             if (!data) {
                 // Bolt Optimization: Use rounded coordinates in URL to improve browser cache hit rate
                 // Direct call to Open-Meteo (Client-side)
-                const url = `${this.baseUrl}?latitude=${rLat}&longitude=${rLon}&hourly=temperature_2m,relative_humidity_2m,precipitation_probability,wind_speed_10m,wind_direction_10m,weather_code&current=temperature_2m,relative_humidity_2m,wind_speed_10m,wind_direction_10m,precipitation,precipitation_probability&timeformat=unixtime&forecast_days=16`;
+                const params = new URLSearchParams({
+                    latitude: rLat,
+                    longitude: rLon,
+                    hourly: 'temperature_2m,relative_humidity_2m,precipitation_probability,wind_speed_10m,wind_direction_10m,weather_code',
+                    current: 'temperature_2m,relative_humidity_2m,wind_speed_10m,wind_direction_10m,precipitation,precipitation_probability',
+                    timeformat: 'unixtime',
+                    forecast_days: '16'
+                });
+                const url = `${this.baseUrl}?${params.toString()}`;
 
                 const response = await fetch(url);
                 if (!response.ok) throw new Error('Weather API error');


### PR DESCRIPTION
The `WeatherClient.getForecast` method was building the Open-Meteo URL using string concatenation. This led to a bug where the `&current=` parameter was reportedly being corrupted into `¤t=`. 

This change refactors the URL construction to use the standard `URLSearchParams` API. This approach:
1. Eliminates the risk of character corruption by not having the literal sequence `&current` in the source code.
2. Automatically handles proper URL encoding for all parameters (e.g., converting commas to `%2C`).
3. Follows modern JavaScript best practices for URL manipulation.

Verification was performed using a standalone Node.js script to ensure the generated URL matches the expected structure and contains all required parameters.

Fixes #219

---
*PR created automatically by Jules for task [2091936178998986301](https://jules.google.com/task/2091936178998986301) started by @2fst4u*