### PR TITLE
🛡️ Sentinel: Add SRI verification to Leaflet proxy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** `CircuitWeatherApp.renderForecast` injected weather unit strings from the Open-Meteo API directly into the DOM using `innerHTML` without sanitization. While the API is trusted, this created a potential XSS vector if the API response was compromised or spoofed.
 **Learning:** Even trusted third-party APIs should be treated as untrusted sources when rendering data into the DOM. Always sanitize or escape any external data before injecting it via `innerHTML`.
 **Prevention:** Use `textContent` where possible, or strictly escape all dynamic values when building HTML strings.
+
+## 2026-02-20 - Worker Proxy SRI Verification
+**Vulnerability:** The Cloudflare Worker proxied external Leaflet assets from `unpkg.com` without verifying their integrity. While the frontend enforced SRI via `integrity` attributes, a compromised upstream file would still be fetched and cached by the worker, causing a Denial of Service for all users as browsers blocked the mismatched resource.
+**Learning:** When building a reverse proxy for external assets, frontend-only SRI is insufficient as it protects the client but poisons the edge cache. The proxy itself must verify the integrity of the upstream response before caching it.
+**Prevention:** Implement server-side SRI verification in the proxy layer by buffering the response, calculating its SHA-256 hash, and comparing it against a strict allowlist before committing to cache or serving.

--- a/src/worker.js
+++ b/src/worker.js
@@ -69,35 +69,51 @@ function checkRequestSource(request) {
 const LEAFLET_ASSETS = new Map([
   ['leaflet.js', {
     upstream: 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js',
-    contentTypes: ['application/javascript', 'text/javascript'] // Allow both standard and legacy
+    contentTypes: ['application/javascript', 'text/javascript'], // Allow both standard and legacy
+    integrity: '20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo='
   }],
   ['leaflet.css', {
     upstream: 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css',
-    contentTypes: ['text/css']
+    contentTypes: ['text/css'],
+    integrity: 'p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY='
   }],
   ['images/layers.png', {
     upstream: 'https://unpkg.com/leaflet@1.9.4/dist/images/layers.png',
-    contentTypes: ['image/png']
+    contentTypes: ['image/png'],
+    integrity: 'Hbvp0CjikvNvy6j4s6KNXokydU/CIVuaxp5M3s9RB8Y='
   }],
   ['images/layers-2x.png', {
     upstream: 'https://unpkg.com/leaflet@1.9.4/dist/images/layers-2x.png',
-    contentTypes: ['image/png']
+    contentTypes: ['image/png'],
+    integrity: 'Bm2sqFDY/77wB68AsG6sABVyje4nnFHzy2xxbffELt8='
   }],
   ['images/marker-icon.png', {
     upstream: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
-    contentTypes: ['image/png']
+    contentTypes: ['image/png'],
+    integrity: 'V0w6XMqF9BFAhbaEFZbWLwDXyJLHsD8oy/owHesdxDc='
   }],
   ['images/marker-icon-2x.png', {
     upstream: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
-    contentTypes: ['image/png']
+    contentTypes: ['image/png'],
+    integrity: 'ABecTB7oMNOhCEEq4NKU9Vd2z+sIXGASmjmqb8SuJSg='
   }],
   ['images/marker-shadow.png', {
     upstream: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
-    contentTypes: ['image/png']
+    contentTypes: ['image/png'],
+    integrity: 'Jk9cZAM58ELdcpBiz8BMF/jqDymIK1OOOEjtjxDttNo='
   }],
 ]);
 
 const ALLOWED_TILE_HEADERS = ['Content-Type', 'Content-Length', 'Last-Modified', 'ETag', 'Date'];
+
+/**
+ * Calculates SHA-256 hash of a buffer and returns it as base64 string
+ */
+async function calculateHash(buffer) {
+  const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return btoa(String.fromCharCode(...hashArray));
+}
 
 /**
  * Simple In-Memory Rate Limiter
@@ -752,7 +768,19 @@ async function handleLeafletRequest(request, env, ctx) {
       return new Response('Invalid upstream content type', { status: 502, headers: getErrorHeaders(request) });
     }
 
-    const [cacheBody, clientBody] = upstreamResponse.body.tee();
+    // SEC: Buffer response for SRI Verification
+    const buffer = await upstreamResponse.arrayBuffer();
+
+    // Verify Hash
+    if (config.integrity) {
+      const hash = await calculateHash(buffer);
+      if (hash !== config.integrity) {
+        console.error(`SRI Mismatch for ${path}: expected ${config.integrity}, got ${hash}`);
+        const errorHeaders = getErrorHeaders(request);
+        errorHeaders['X-SRI-Status'] = 'mismatch';
+        return new Response('SRI Integrity Check Failed', { status: 502, headers: errorHeaders });
+      }
+    }
 
     // Use the first allowed content type as the canonical one for the client response
     const canonicalType = config.contentTypes[0];
@@ -765,8 +793,8 @@ async function handleLeafletRequest(request, env, ctx) {
       ...DEFAULT_SECURITY_HEADERS
     });
 
-    // Cache it
-    ctx.waitUntil(cache.put(cacheKey, new Response(cacheBody, { headers: cacheHeaders })));
+    // Cache it (Clone the response from buffer)
+    ctx.waitUntil(cache.put(cacheKey, new Response(buffer, { headers: cacheHeaders })));
 
     const clientHeaders = new Headers(cacheHeaders);
     const allowedOrigin = getAllowedOrigin(request);
@@ -775,7 +803,8 @@ async function handleLeafletRequest(request, env, ctx) {
       clientHeaders.set('Vary', 'Origin');
     }
 
-    return new Response(clientBody, {
+    // Return to client (from buffer)
+    return new Response(buffer, {
       status: 200,
       headers: clientHeaders
     });


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Proxied Leaflet assets from unpkg.com were cached without integrity verification, allowing potential supply chain attacks or corrupted files to poison the edge cache.
🎯 Impact: Users would receive compromised files or be blocked by browser SRI mismatch, causing DoS.
🔧 Fix: Implemented server-side SHA-256 hash verification in src/worker.js before caching.
✅ Verification: Verified with local test script and negative test case.

---
*PR created automatically by Jules for task [11512019472862821053](https://jules.google.com/task/11512019472862821053) started by @2fst4u*