### PR TITLE
Improve Service Worker Cache Versioning/Invalidation

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -8,11 +8,13 @@
  * - Network-first with cache fallback for navigation
  */
 
-const CACHE_NAME = 'circuit-weather-v1';
+const CACHE_VERSION = '1.1.1';
+const CACHE_NAME = `circuit-weather-v${CACHE_VERSION}`;
 
 // App shell resources to pre-cache on install
 const APP_SHELL = [
     '/',
+    '/index.html',
     '/styles.css',
     '/app.js',
     '/favicon.svg',

--- a/src/worker.js
+++ b/src/worker.js
@@ -844,7 +844,7 @@ async function handleHealthRequest(request, env, ctx) {
 
   return new Response(JSON.stringify({
     status: 'ok',
-    version: '1.1.0',
+    version: '1.1.1',
     upstreams: results,
     timestamp: new Date().toISOString(),
     environment: env.ENVIRONMENT || 'production'


### PR DESCRIPTION
This change improves the PWA's cache management by introducing a versioned cache name. This ensures that when the service worker is updated, old caches are automatically purged, and users receive the latest application assets without requiring a hard refresh. Additionally, /index.html is now explicitly pre-cached, improving offline reliability.

Fixes #221

---
*PR created automatically by Jules for task [9858066262813097722](https://jules.google.com/task/9858066262813097722) started by @2fst4u*