### PR TITLE
Use per-upstream timeouts in Worker

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -8,8 +8,12 @@
  * via wrangler.toml's run_worker_first and not_found_handling settings.
  */
 
-// Global timeout for all upstream API calls to prevent resource exhaustion
-const API_TIMEOUT = 5000;
+// Per-upstream timeouts to prevent resource exhaustion while allowing for slow upstreams
+const TIMEOUT_API_F1 = 5000;
+const TIMEOUT_API_RADAR = 8000;
+const TIMEOUT_API_TILES = 5000;
+const TIMEOUT_API_TRACKS = 10000;
+const TIMEOUT_API_ASSETS = 10000;
 
 // Bolt Optimization: Pre-compile regexes for hot-path performance
 const VALID_API_PATH_REGEX = /^[a-zA-Z0-9/._-]*$/;
@@ -519,7 +523,7 @@ async function handleApiRequest(request, env, ctx) {
         'Accept': 'application/json',
         'User-Agent': 'CircuitWeather/1.0',
       },
-      signal: AbortSignal.timeout(API_TIMEOUT),
+      signal: AbortSignal.timeout(TIMEOUT_API_F1),
     });
 
     const status = upstreamResponse.status;
@@ -645,7 +649,7 @@ async function handleTrackRequest(request, env, ctx) {
       headers: {
         'User-Agent': 'CircuitWeather/1.0',
       },
-      signal: AbortSignal.timeout(API_TIMEOUT),
+      signal: AbortSignal.timeout(TIMEOUT_API_TRACKS),
     });
 
     const upstreamStatus = upstreamResponse.status;
@@ -747,7 +751,7 @@ async function handleLeafletRequest(request, env, ctx) {
   try {
     const upstreamResponse = await fetch(upstreamUrl, {
       headers: { 'User-Agent': 'CircuitWeather/1.0' },
-      signal: AbortSignal.timeout(API_TIMEOUT),
+      signal: AbortSignal.timeout(TIMEOUT_API_ASSETS),
     });
 
     const status = upstreamResponse.status;
@@ -920,7 +924,7 @@ async function handleTileRequest(request, env, ctx) {
         'User-Agent': 'CircuitWeather/1.0',
         'Accept': 'image/png,image/*;q=0.8'
       },
-      signal: AbortSignal.timeout(API_TIMEOUT),
+      signal: AbortSignal.timeout(TIMEOUT_API_TILES),
     });
 
     const status = upstreamResponse.status;
@@ -1057,7 +1061,7 @@ async function handleRadarRequest(request, env, ctx) {
         'Accept': 'application/json',
         'User-Agent': 'CircuitWeather/1.0',
       },
-      signal: AbortSignal.timeout(API_TIMEOUT),
+      signal: AbortSignal.timeout(TIMEOUT_API_RADAR),
     });
 
     const status = upstreamResponse.status;


### PR DESCRIPTION
Replaced the single global `API_TIMEOUT` with more granular, per-upstream timeouts in `src/worker.js`. 

Specific timeouts implemented:
- Jolpica F1 API: 5s
- RainViewer maps JSON: 8s
- RainViewer tiles: 5s
- GitHub raw (track GeoJSON): 10s
- Leaflet assets: 10s

These values align with the requested ranges and improve reliability under slow network conditions. All relevant fetch calls have been updated to use these new constants. Manual verification confirmed correct syntax and logic.

Fixes #223

---
*PR created automatically by Jules for task [7572273128950805740](https://jules.google.com/task/7572273128950805740) started by @2fst4u*