### PR TITLE
🎨 Palette: Reduce screen reader verbosity and improve empty state announcements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 ## 2026-02-20 - Empty State for Selection Flows
 **Learning:** When a user action (selecting a round) clears a dependent selection (session), leaving a blank space where the result (forecast) usually appears causes confusion.
 **Action:** Always provide a descriptive empty state that guides the user to the next required action ("Select a session...").
+
+## 2026-02-23 - ARIA Redundancy in Weather Widgets
+**Learning:** Dynamic `aria-label` updates that duplicate visible content (e.g., "Temperature: 20°C" when "20°C" is visible inside a group named "Temperature") cause verbose, stuttering announcements in screen readers.
+**Action:** Prefer static `aria-label` on grouping containers and let the inner content speak for itself, unless the content is purely visual/icon-based.

--- a/public/app.js
+++ b/public/app.js
@@ -1928,12 +1928,6 @@ const MapWeatherWidget = L.Control.extend({
         this._ui.rain.textContent = `${rain}%`;
         this._ui.humid.textContent = `${humidity}%`;
         this._ui.wind.textContent = `${wind} ${weather.units.wind_speed_10m}`;
-
-        // Palette Accessibility: Dynamic ARIA labels
-        if (this._ui.tempGroup) this._ui.tempGroup.setAttribute('aria-label', `Temperature: ${this._ui.temp.textContent}`);
-        if (this._ui.rainGroup) this._ui.rainGroup.setAttribute('aria-label', `Rain Chance: ${this._ui.rain.textContent}`);
-        if (this._ui.humidGroup) this._ui.humidGroup.setAttribute('aria-label', `Humidity: ${this._ui.humid.textContent}`);
-        if (this._ui.windGroup) this._ui.windGroup.setAttribute('aria-label', `Wind Speed: ${this._ui.wind.textContent}`);
     }
 });
 
@@ -2115,11 +2109,6 @@ class WeatherWidget {
         if (tempEl) tempEl.textContent = `${temp}${weather.units.temperature_2m}`;
         if (humidEl) humidEl.textContent = `${humidity}%`;
         if (windEl) windEl.textContent = `${wind} ${weather.units.wind_speed_10m}`;
-
-        // Palette Accessibility: Dynamic ARIA labels
-        if (tempGroup && tempEl) tempGroup.setAttribute('aria-label', `Temperature: ${tempEl.textContent}`);
-        if (humidGroup && humidEl) humidGroup.setAttribute('aria-label', `Humidity: ${humidEl.textContent}`);
-        if (windGroup && windEl) windGroup.setAttribute('aria-label', `Wind Speed: ${windEl.textContent}`);
     }
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -164,7 +164,7 @@
                 </div>
 
                 <!-- Session Empty State -->
-                <div id="sessionEmptyState" class="empty-state" style="display: none;">
+                <div id="sessionEmptyState" class="empty-state" style="display: none;" aria-live="polite">
                     <svg class="empty-state-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none"
                         stroke="currentColor" stroke-width="1.5">
                         <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>


### PR DESCRIPTION
🎨 **Palette: Reduce screen reader verbosity and improve empty state announcements**

💡 **What:**
- Removed redundant `aria-label` updates in `MapWeatherWidget` and `WeatherWidget`.
- Added `aria-live="polite"` to the session selection empty state.

🎯 **Why:**
- Screen reader users were hearing duplicate information ("Temperature: 20 degrees, group. 20 degrees"). The static label "Temperature" combined with the visible content provides a cleaner experience.
- When selecting a round, the "Select a session" prompt appeared visually but was silent for screen reader users. The live region ensures they are guided to the next step.

♿ **Accessibility:**
- Reduced verbosity for weather metrics.
- Added dynamic announcement for form instructions.


---
*PR created automatically by Jules for task [10500141748664151960](https://jules.google.com/task/10500141748664151960) started by @2fst4u*