### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent upstream error leakage in tile proxy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The Cloudflare Worker proxied external Leaflet assets from `unpkg.com` without verifying their integrity. While the frontend enforced SRI via `integrity` attributes, a compromised upstream file would still be fetched and cached by the worker, causing a Denial of Service for all users as browsers blocked the mismatched resource.
 **Learning:** When building a reverse proxy for external assets, frontend-only SRI is insufficient as it protects the client but poisons the edge cache. The proxy itself must verify the integrity of the upstream response before caching it.
 **Prevention:** Implement server-side SRI verification in the proxy layer by buffering the response, calculating its SHA-256 hash, and comparing it against a strict allowlist before committing to cache or serving.
+
+## 2026-02-21 - Tile Proxy Upstream Leakage
+**Vulnerability:** The `handleTileRequest` in `src/worker.js` piped raw upstream response bodies (potentially HTML error pages) to the client with `Content-Type: application/json` for non-cacheable errors (429, 5xx). This could leak upstream implementation details or internal IP addresses from error pages.
+**Learning:** Always sanitize upstream error responses in a proxy. Even if the client expects an image, returning a structured JSON error is safer than passing through raw HTML content which might be misinterpreted or leak information.
+**Prevention:** Consume the upstream response body for error statuses and return a clean, generated JSON response with only necessary headers (like `Retry-After`).

--- a/src/worker.js
+++ b/src/worker.js
@@ -1001,10 +1001,22 @@ async function handleTileRequest(request, env, ctx) {
     }
 
     // 6. Non-cacheable Error Handling (429, 5xx, etc)
+    // SEC: Consume body to prevent leaking upstream details (HTML, stack traces)
     const errorHeaders = getErrorHeaders(request);
     errorHeaders['X-Upstream-Status'] = status.toString();
 
-    return new Response(upstreamResponse.body, {
+    // Preserve Retry-After for rate limits
+    if (status === 429) {
+      const retryAfter = upstreamResponse.headers.get('Retry-After');
+      if (retryAfter) {
+        errorHeaders['Retry-After'] = retryAfter;
+      }
+    }
+
+    return new Response(JSON.stringify({
+      error: 'Upstream tile error',
+      status: status
+    }), {
       status: status,
       headers: errorHeaders
     });


### PR DESCRIPTION
**Vulnerability:** The `handleTileRequest` in `src/worker.js` previously piped raw upstream response bodies to the client for error statuses (429, 5xx) while forcing a `Content-Type: application/json` header. This could lead to information leakage (e.g., upstream HTML error pages containing stack traces or internal IPs) and client confusion.

**Fix:**
*   Modified `handleTileRequest` to consume the upstream body and return a structured JSON error response `{ "error": "Upstream tile error", "status": ... }`.
*   Added logic to preserve the `Retry-After` header from the upstream response when a 429 status is encountered, ensuring clients can still handle rate limits correctly.
*   Updated `.jules/sentinel.md` with the finding.

**Verification:**
*   Created a reproduction script `repro_tile_leak.mjs` that simulated upstream 502 (HTML body) and 429 responses.
*   Verified that the fix returns clean JSON errors and preserves `Retry-After`.
*   Verified that valid tile requests (200 OK) are unaffected.

---
*PR created automatically by Jules for task [3960785481784976565](https://jules.google.com/task/3960785481784976565) started by @2fst4u*