### PR TITLE
🛡️ Sentinel: [HIGH] Fix Tile Proxy HTML Injection via 404

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The `handleTileRequest` in `src/worker.js` piped raw upstream response bodies (potentially HTML error pages) to the client with `Content-Type: application/json` for non-cacheable errors (429, 5xx). This could leak upstream implementation details or internal IP addresses from error pages.
 **Learning:** Always sanitize upstream error responses in a proxy. Even if the client expects an image, returning a structured JSON error is safer than passing through raw HTML content which might be misinterpreted or leak information.
 **Prevention:** Consume the upstream response body for error statuses and return a clean, generated JSON response with only necessary headers (like `Retry-After`).
+
+## 2026-02-21 - Tile Proxy HTML Injection via 404
+**Vulnerability:** The `handleTileRequest` in `src/worker.js` proxied upstream 404 responses from `rainviewer.com` regardless of content type. The upstream returned `text/html` error pages, which the worker cached and served. This allowed Reflected/Stored XSS if a user was tricked into visiting a non-existent tile URL, as the browser would render the HTML in the application's origin.
+**Learning:** API proxies must never assume the upstream response matches the requested file extension or content type, especially for error codes. Browsers may sniff or respect `Content-Type: text/html` even on `.png` URLs.
+**Prevention:** Strictly validate `Content-Type` for all proxied responses, including errors (404). If the upstream returns HTML for an image request, intercept and replace it with a safe response (JSON or generated image).

--- a/src/worker.js
+++ b/src/worker.js
@@ -942,18 +942,50 @@ async function handleTileRequest(request, env, ctx) {
     const ttl = upstreamResponse.ok ? 7200 : 60;
 
     if (shouldCache) {
+      const contentType = upstreamResponse.headers.get('Content-Type');
+      const isPng = contentType && contentType.startsWith('image/png');
+
       // SEC: Strict Content-Type Validation (ONLY for success responses)
       // Prevent XSS via MIME sniffing if upstream returns non-image content (e.g. HTML)
       // Only allow PNG as we enforced .png extension in URL. Blocks image/svg+xml.
-      if (upstreamResponse.ok) {
-        const contentType = upstreamResponse.headers.get('Content-Type');
-        if (!contentType || !contentType.startsWith('image/png')) {
-          console.error(`Upstream Tile Invalid Content-Type: ${contentType}`);
-          return new Response(JSON.stringify({ error: 'Invalid upstream content type' }), {
-            status: 502,
-            headers: getErrorHeaders(request)
-          });
+      if (upstreamResponse.ok && !isPng) {
+        console.error(`Upstream Tile Invalid Content-Type: ${contentType}`);
+        return new Response(JSON.stringify({ error: 'Invalid upstream content type' }), {
+          status: 502,
+          headers: getErrorHeaders(request)
+        });
+      }
+
+      // SEC: Safe 404 Handling
+      // If upstream 404 is not an image (e.g. HTML error page), generate a safe response
+      // to prevent XSS via proxy. We cache this safe 404 to prevent upstream hammering.
+      if (status === 404 && !isPng) {
+        const safeBody = JSON.stringify({ error: 'Tile not found' });
+        const safeHeaders = new Headers({
+          'Content-Type': 'application/json',
+          'Cache-Control': `public, max-age=${ttl}`,
+          'X-Cache': 'MISS',
+          'X-Upstream-Status': '404',
+          'Access-Control-Allow-Origin': '*', // Store permissive, override on delivery
+          ...DEFAULT_SECURITY_HEADERS
+        });
+
+        const safeResponse = new Response(safeBody, { status: 404, headers: safeHeaders });
+
+        // Cache the safe response
+        ctx.waitUntil(cache.put(cacheKey, safeResponse.clone()));
+
+        // Return to client (strict CORS)
+        const clientHeaders = new Headers(safeHeaders);
+        const allowedOrigin = getAllowedOrigin(request);
+        if (allowedOrigin) {
+          clientHeaders.set('Access-Control-Allow-Origin', allowedOrigin);
+          clientHeaders.set('Vary', 'Origin');
+        } else {
+          clientHeaders.delete('Access-Control-Allow-Origin');
         }
+
+        return new Response(safeBody, { status: 404, headers: clientHeaders });
       }
 
       // 4. Cache Response


### PR DESCRIPTION
This PR fixes a high-severity security vulnerability where the worker proxy could serve malicious HTML from an upstream provider (RainViewer) disguised as a 404 error for a tile image. This could allow XSS attacks. The fix ensures that only valid PNG images are proxied, and non-image 404s are replaced with safe JSON errors.

---
*PR created automatically by Jules for task [15109459263023570620](https://jules.google.com/task/15109459263023570620) started by @2fst4u*