### PR TITLE
📚 Archivist: Fix config file path in AGENTS.md

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -35,3 +35,9 @@ Issue: AGENTS.md omitted Unpkg (Leaflet) from the Third-Party Services table, de
 Cause: Oversight when documenting proxied services vs direct services.
 Fix: Added Unpkg (Leaflet) to AGENTS.md with "Proxied (Cached)" connection type.
 Prevention: Cross-reference PRIVACY.md and src/worker.js when updating AGENTS.md.
+
+2026-02-18 - Incorrect File Path Documentation
+Issue: AGENTS.md referenced `src/config.js` as the location for feature flags, but the file is located at `public/src/config.js`.
+Cause: Documentation error or file relocation without updating documentation.
+Fix: Updated AGENTS.md to point to the correct path `public/src/config.js`.
+Prevention: Verify file paths in documentation against the actual file system.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,7 @@ mode = "smart"
 1. **RainViewer Zoom Limit** - Free tier limits to zoom level 10. We use **512px tiles** with `zoomOffset: -1` and `maxNativeZoom: 8` to emulate higher resolution while reducing requests.
 2. **Radar Opacity** - Tiles must be added with small opacity (0.01) initially to trigger loading.
 3. **F1 API Rate Limits** - Edge caching via Worker mitigates this.
-4. **Current Weather Rate Limits** - The live current weather widget is enabled via `FEATURE_FLAGS.enableCurrentWeather` in `src/config.js`, but be aware that it triggers an Open-Meteo API call per circuit change which may hit 429 rate limits during high traffic.
+4. **Current Weather Rate Limits** - The live current weather widget is enabled via `FEATURE_FLAGS.enableCurrentWeather` in `public/src/config.js`, but be aware that it triggers an Open-Meteo API call per circuit change which may hit 429 rate limits during high traffic.
 
 ---
 


### PR DESCRIPTION
Identified and fixed a documentation error in `AGENTS.md` where the configuration file path was incorrect.

**Problem:**
`AGENTS.md` referenced `src/config.js` as the location for feature flags. However, the file is actually located at `public/src/config.js`.

**Fix:**
- Updated `AGENTS.md` to point to `public/src/config.js`.
- Added an entry to `.jules/archivist.md` documenting the issue and fix.

**Verification:**
- Verified `public/src/config.js` exists.
- Verified `src/config.js` does not exist.
- Verified `AGENTS.md` update via grep.

---
*PR created automatically by Jules for task [18228438312154355916](https://jules.google.com/task/18228438312154355916) started by @2fst4u*