### PR TITLE
docs: fix RainViewer cache duration inaccuracies

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -41,3 +41,9 @@ Issue: AGENTS.md referenced `src/config.js` as the location for feature flags, b
 Cause: Documentation error or file relocation without updating documentation.
 Fix: Updated AGENTS.md to point to the correct path `public/src/config.js`.
 Prevention: Verify file paths in documentation against the actual file system.
+
+2026-02-22 - RainViewer Cache Duration Inaccuracy
+Issue: Documentation claimed "RainViewer: Weather radar tiles and metadata (2-hour edge cache)" in both AGENTS.md and PRIVACY.md.
+Cause: Likely a simplification during documentation writing that conflated tile cache (2h) with metadata cache (1m).
+Fix: Updated both files to explicitly distinguish between tile cache (2h) and metadata cache (1m).
+Prevention: Verify cache control headers in src/worker.js against documentation claims during updates.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Circuit Weather is a real-time F1 race circuit weather radar application. It dis
 | Service | Purpose | Connection |
 |---------|---------|------------|
 | Jolpica F1 API | Race schedule data | Proxied (Cached) |
-| RainViewer | Weather radar tiles | Proxied (Cached) |
+| RainViewer | Weather radar tiles (2-hour cache) and metadata (1-minute cache) | Proxied (Cached) |
 | Open-Meteo | Weather forecasts | Direct (Client-side) |
 | Carto | Map basemap tiles | Direct (Client-side) |
 | GitHub | Track GeoJSON data | Proxied (Cached) |

--- a/public/PRIVACY.md
+++ b/public/PRIVACY.md
@@ -67,7 +67,7 @@ The following services provide the raw data that we process and cache via Cloudf
 
 - **Jolpica F1:** Historical and current F1 schedule data.
 - **GitHub:** Stores static track layout files (GeoJSON).
-- **RainViewer:** Weather radar tiles and metadata (2-hour edge cache).
+- **RainViewer:** Weather radar tiles (2-hour edge cache) and metadata (1-minute cache).
 - **Leaflet (via Unpkg):** Map interaction library assets (proxied for security).
 
 ## Local Storage


### PR DESCRIPTION
Corrects documentation in AGENTS.md and public/PRIVACY.md to explicitly distinguish between RainViewer tile cache (2h) and metadata cache (1m), aligning with src/worker.js behavior. Adds entry to .jules/archivist.md.

---
*PR created automatically by Jules for task [8568807558895508401](https://jules.google.com/task/8568807558895508401) started by @2fst4u*