### PR TITLE
docs: Add missing attribution for Open-Meteo and track data in README

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -59,3 +59,9 @@ Issue: The previous update to README.md removed a specific "unashamedly vibe cod
 Cause: Over-correction towards objective tone without considering author's specific voice requirements.
 Fix: Restored the specific sentence while keeping the surrounding context in third-person, and mandated New Zealand English in AGENTS.md.
 Prevention: When refactoring tone, verify if specific stylized phrases should be preserved as part of the product identity.
+
+2026-02-23 - Missing Attribution in README
+Issue: README.md Credits section omitted Open-Meteo and bacinger/f1-circuits, despite their usage being core to the functionality and required by license/good practice.
+Cause: Documentation lagged behind feature implementation (forecasts and track data).
+Fix: Added Open-Meteo and bacinger/f1-circuits to the Credits section in README.md.
+Prevention: Audit data sources and licenses when adding new features or dependencies.

--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ This setup faithfully reproduces the production environment, running both the fr
 
 ## Credits
 
-Huge thanks to the free APIs that make this possible:
+Huge thanks to the free APIs and data sources that make this possible:
 *   **Jolpica F1** for the race data.
 *   **RainViewer** for the weather radar.
+*   **Open-Meteo** for the weather forecasts.
 *   **Carto & OpenStreetMap** for the map tiles.
+*   **bacinger/f1-circuits** for the circuit track data.
 
 ## License
 


### PR DESCRIPTION
This PR updates the `README.md` file to include missing credits for Open-Meteo and the `bacinger/f1-circuits` repository. Open-Meteo is used for weather forecasts and requires attribution under its CC BY 4.0 license. The `bacinger/f1-circuits` repository is the source of the track GeoJSON data used in the application.

This change ensures the project complies with license requirements and properly acknowledges its data sources.

A journal entry has been added to `.jules/archivist.md` to document this documentation fix.

---
*PR created automatically by Jules for task [4695731162299845241](https://jules.google.com/task/4695731162299845241) started by @2fst4u*