### PR TITLE
Reduce number of H1 tags to one

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -65,3 +65,9 @@ Issue: README.md Credits section omitted Open-Meteo and bacinger/f1-circuits, de
 Cause: Documentation lagged behind feature implementation (forecasts and track data).
 Fix: Added Open-Meteo and bacinger/f1-circuits to the Credits section in README.md.
 Prevention: Audit data sources and licenses when adding new features or dependencies.
+
+2025-05-15 - [SEO] Reduced H1 tag count to one
+Issue: Multiple H1 tags (sidebar and mobile header) were present on the page, which is suboptimal for SEO.
+Cause: The design used H1 tags for the site title in both the desktop sidebar and the mobile top bar.
+Fix: Converted the mobile header H1 to a span with class 'header-title' and updated CSS to maintain styling.
+Prevention: Ensure that only the primary desktop sidebar title uses H1, and other instances of the site title use non-heading elements or classes.

--- a/public/index.html
+++ b/public/index.html
@@ -227,7 +227,7 @@
                     </svg>
                 </button>
                 <div class="mobile-header-brand">
-                    <h1>Circuit Weather</h1>
+                    <span class="header-title">Circuit Weather</span>
                     <span class="header-badge">
                         <svg viewBox="0 0 24 24" fill="currentColor">
                             <path fill-rule="evenodd"

--- a/public/styles.css
+++ b/public/styles.css
@@ -1071,7 +1071,7 @@ body {
     min-width: 0;
 }
 
-.mobile-header-brand h1 {
+.mobile-header-brand .header-title {
     font-size: 1.1rem;
     font-weight: 700;
     letter-spacing: -0.025em;


### PR DESCRIPTION
This change reduces the number of H1 tags on the page to exactly one for SEO purposes. The mobile header's H1 tag was converted to a span, and the CSS was updated to ensure the appearance remains unchanged. Verification was performed using grep to count tags and Playwright to check visual consistency.

Fixes #252

---
*PR created automatically by Jules for task [694416894296923849](https://jules.google.com/task/694416894296923849) started by @2fst4u*