### PR TITLE
Adjust default circuit zoom level to 10

### DIFF
--- a/public/src/config.js
+++ b/public/src/config.js
@@ -16,7 +16,7 @@ export const CONFIG = {
     mapTilesDark: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
     defaultCenter: [48.8566, 2.3522],
     defaultZoom: 3,
-    circuitZoom: 11,
+    circuitZoom: 10,
     radarOpacity: 0.65,
     radarAnimationSpeed: 1000, // Default to 1x speed (1000ms per frame)
     // Speed options: slower = higher ms, faster = lower ms

--- a/public/src/map/TrackLayer.js
+++ b/public/src/map/TrackLayer.js
@@ -20,8 +20,7 @@ export class TrackLayer {
         let weight = 4;
 
         if (zoom >= 12) weight = 5;
-        else if (zoom >= 11) weight = 4;
-        else if (zoom >= 10) weight = 3;
+        else if (zoom >= 10) weight = 4;
         else if (zoom >= 8) weight = 2;
         else weight = 1;
 


### PR DESCRIPTION
The default zoom level for F1 circuits has been adjusted from 11 to 10 to provide a broader view of the surrounding area upon selection. To ensure the circuit track remains clearly visible at this slightly more zoomed-out level, the track line weight logic was also updated to use weight 4 starting from zoom level 10 (previously starting from level 11). These changes ensure a consistent and informative initial view for all circuits.

Fixes #255

---
*PR created automatically by Jules for task [798094602683582316](https://jules.google.com/task/798094602683582316) started by @2fst4u*