### PR TITLE
🔭 Scout: Add Twitter Card metadata

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -1,0 +1,3 @@
+## 2025-02-14 - Project Structure Limitation
+**Learning:** This project lacks a root `package.json`, which prevents standard dependency management and testing workflows (e.g., `npm test`, `npm lint`). This makes automated verification challenging.
+**Action:** Rely on manual verification and custom scripts where possible, or suggest adding a root `package.json` if the project scales.

--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,13 @@
     <meta property="og:site_name" content="Circuit Weather">
     <meta property="og:locale" content="en_NZ">
 
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://circuit-weather.racing">
+    <meta name="twitter:title" content="Circuit Weather — Live F1 Race Weather Radar &amp; Forecasts">
+    <meta name="twitter:description" content="Real-time weather radar and forecasts for every Formula 1 circuit. Track rain and conditions live during every Grand Prix session.">
+    <meta name="twitter:image" content="https://circuit-weather.racing/icon-512.png">
+
     <link rel="canonical" href="https://circuit-weather.racing">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="Content-Security-Policy"


### PR DESCRIPTION
Scout identified a missing SEO opportunity: the absence of Twitter Card metadata. While Open Graph tags were present, Twitter Cards provide a more optimized sharing experience on X.

Changes:
- Added `twitter:card` (summary_large_image)
- Added `twitter:url`, `title`, `description`, `image` (mirroring OG tags)
- Created `.jules/scout.md` for SEO learnings.

Verification:
- Verified presence of tags in `public/index.html`.
- Verified valid HTML structure.
- Verified frontend rendering via temporary Playwright script.

---
*PR created automatically by Jules for task [8079183438417101301](https://jules.google.com/task/8079183438417101301) started by @2fst4u*