### PR TITLE
🧹 Sweep: Remove unused radar methods

### DIFF
--- a/public/src/map/WeatherRadar.js
+++ b/public/src/map/WeatherRadar.js
@@ -157,7 +157,6 @@ export class WeatherRadar {
 
             // Wait for tiles to load before starting animation
             await this.waitForTilesToLoad();
-            this.hideTileError();
 
             // Start serial preload of remaining frames
             // This prevents "hammering" by loading one frame at a time in the background
@@ -521,10 +520,6 @@ export class WeatherRadar {
         this.ui.errorToast.classList.remove('visible');
         this.ui.errorToast.style.opacity = '0';
     }
-
-    // Legacy method stubs
-    showTileError() { }
-    hideTileError() { }
 
     // Bolt Optimization: Reuse Leaflet layers to reduce DOM churn
     reconcileLayers(newFrames) {
@@ -909,7 +904,6 @@ export class WeatherRadar {
     destroy() {
         this.stopPolling();
         this.pause();
-        this.hideTileError();
         this.layers.forEach(layer => {
             if (layer) this.map.removeLayer(layer);
         });


### PR DESCRIPTION
Removed unused `showTileError` and `hideTileError` methods from `public/src/map/WeatherRadar.js`. These methods were empty stubs and `hideTileError` was called but did nothing. Removed the calls as well. Confirmed by `grep` that they are no longer present.

---
*PR created automatically by Jules for task [11528677548816704868](https://jules.google.com/task/11528677548816704868) started by @2fst4u*