### PR TITLE
🎨 Palette: Improve mobile sidebar accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2026-02-23 - Status Indicators in Selection Dropdowns
 **Learning:** For time-sensitive selections (like race schedules), simple text labels are insufficient. Users need to quickly identify "Live" or "Next" items without mentally parsing dates.
 **Action:** Enhance dropdown options with clear, emoji-based status indicators ("🔴 LIVE", "(Next)") to reduce cognitive load and guide selection.
+
+## 2026-02-23 - [Mobile Sidebar Accessibility]
+**Learning:** CSS `transform` on mobile navigation menus hides content visually but leaves it focusable for keyboard users, trapping them in invisible UI.
+**Action:** Pair `transform` transitions with `visibility: hidden` (using a transition delay) to remove off-screen elements from the accessibility tree, and implement a focus trap when open.

--- a/public/src/ui/SidebarManager.js
+++ b/public/src/ui/SidebarManager.js
@@ -6,6 +6,7 @@ export class SidebarManager {
         this.backdrop = document.getElementById('sidebarBackdrop');
         this.isOpen = false;
         this.mobileBreakpoint = 768;
+        this._handleFocusTrap = this.handleFocusTrap.bind(this);
         this.bindEvents();
     }
 
@@ -68,6 +69,9 @@ export class SidebarManager {
             // Prevent body scroll when sidebar is open
             document.body.style.overflow = 'hidden';
 
+            // Palette A11y: Enable focus trap
+            this.sidebar.addEventListener('keydown', this._handleFocusTrap);
+
             // Update ARIA states
             if (this.mobileMenuBtn) this.mobileMenuBtn.setAttribute('aria-expanded', 'true');
             if (this.toggleBtn) this.toggleBtn.setAttribute('aria-expanded', 'true');
@@ -86,6 +90,9 @@ export class SidebarManager {
             this.isOpen = false;
             document.body.style.overflow = '';
 
+            // Palette A11y: Disable focus trap
+            this.sidebar.removeEventListener('keydown', this._handleFocusTrap);
+
             // Update ARIA states
             if (this.mobileMenuBtn) this.mobileMenuBtn.setAttribute('aria-expanded', 'false');
             if (this.toggleBtn) this.toggleBtn.setAttribute('aria-expanded', 'false');
@@ -94,6 +101,31 @@ export class SidebarManager {
             // This restores context to the user after closing the menu
             if (this.mobileMenuBtn && window.getComputedStyle(this.mobileMenuBtn).display !== 'none') {
                 this.mobileMenuBtn.focus();
+            }
+        }
+    }
+
+    handleFocusTrap(e) {
+        if (e.key !== 'Tab') return;
+
+        // We only want to trap focus within the sidebar
+        const focusableSelectors = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+        const focusableElements = this.sidebar.querySelectorAll(focusableSelectors);
+
+        if (focusableElements.length === 0) return;
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (e.shiftKey) {
+            if (document.activeElement === firstElement) {
+                e.preventDefault();
+                lastElement.focus();
+            }
+        } else {
+            if (document.activeElement === lastElement) {
+                e.preventDefault();
+                firstElement.focus();
             }
         }
     }

--- a/public/styles.css
+++ b/public/styles.css
@@ -1115,12 +1115,16 @@ body {
         transform: translateX(calc(-1 * var(--sidebar-width)));
         z-index: 2000;
         box-shadow: var(--shadow-lg);
-        transition: transform 300ms ease;
+        /* Palette A11y: Visibility transition ensures off-screen elements aren't focusable */
+        visibility: hidden;
+        transition: transform 300ms ease, visibility 0s 300ms;
     }
 
     /* When sidebar is open on mobile, slide it back into view */
     .sidebar.sidebar--open {
         transform: translateX(0);
+        visibility: visible;
+        transition: transform 300ms ease, visibility 0s 0s;
     }
 
     /* Show sidebar toggle button */


### PR DESCRIPTION
💡 What:
- Updated `public/styles.css` to use `visibility: hidden` (with transition) for the closed mobile sidebar, ensuring it is removed from the accessibility tree.
- Implemented a keyboard focus trap in `public/src/ui/SidebarManager.js` to constrain tabbing within the open sidebar.

🎯 Why:
- Previously, keyboard users on mobile (or small viewports) could tab into the off-screen sidebar while it was closed, focusing on invisible elements.
- When open, users could tab *out* of the sidebar into the obscured main content, losing context.

📸 Before/After:
- No visual change (behavioral change for keyboard/screen reader users).
- Verified with Playwright script: Sidebar is correctly hidden/visible and focus is trapped.

♿ Accessibility:
- Meets WCAG 2.1 Success Criterion 2.4.3 (Focus Order) and 2.4.7 (Focus Visible) for modal dialogs.
- Ensures screen readers do not announce hidden content.

---
*PR created automatically by Jules for task [6530674474520992613](https://jules.google.com/task/6530674474520992613) started by @2fst4u*