### PR TITLE
🧹 Sweep: Remove unused DOM element references in MapWeatherWidget.js

### DIFF
--- a/public/src/map/MapWeatherWidget.js
+++ b/public/src/map/MapWeatherWidget.js
@@ -31,11 +31,7 @@ export const MapWeatherWidget = L.Control.extend({
             temp: this._div.querySelector('.temp-value'),
             rain: this._div.querySelector('.rain-value'),
             humid: this._div.querySelector('.humid-value'),
-            wind: this._div.querySelector('.wind-value'),
-            tempGroup: this._div.querySelector('.weather-widget-metric[title="Temperature"]'),
-            rainGroup: this._div.querySelector('.weather-widget-metric[title="Rain Chance"]'),
-            humidGroup: this._div.querySelector('.weather-widget-metric[title="Humidity"]'),
-            windGroup: this._div.querySelector('.weather-widget-metric[title="Wind"]')
+            wind: this._div.querySelector('.wind-value')
         };
 
         return this._div;


### PR DESCRIPTION
🧹 Sweep: Remove unused DOM element references in MapWeatherWidget.js

💡 What:
Removed the initialization of `tempGroup`, `rainGroup`, `humidGroup`, and `windGroup` from the `_ui` object in `public/src/map/MapWeatherWidget.js`.

🎯 Why:
These properties store references to DOM elements that are never used in the component's logic (only their children `temp`, `rain`, `humid`, `wind` are updated). Removing them reduces memory usage slightly and cleans up the code.

🔬 Verification:
- Verified that `tempGroup`, `rainGroup`, `humidGroup`, `windGroup` appear only in the `_ui` initialization block and nowhere else in the file.
- Ran `grep` to confirm zero occurrences after deletion.
- Checked for syntax errors in the modified file.

---
*PR created automatically by Jules for task [2699574796218582332](https://jules.google.com/task/2699574796218582332) started by @2fst4u*