### PR TITLE
🧹 Sweep: Remove unused VALID_COORD_REGEX from src/worker.js

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -17,7 +17,6 @@ const TIMEOUT_API_ASSETS = 10000;
 
 // Bolt Optimization: Pre-compile regexes for hot-path performance
 const VALID_API_PATH_REGEX = /^[a-zA-Z0-9/._-]*$/;
-const VALID_COORD_REGEX = /^-?\d+(\.\d+)?$/;
 const VALID_TRACK_ID_REGEX = /^[a-z0-9-]+$/;
 const PRODUCTION_DOMAIN = 'https://circuit-weather.racing';
 const ALLOWED_ORIGIN_LOCALHOST_REGEX = /^http:\/\/localhost(:\d+)?(\/|$)/;


### PR DESCRIPTION
Removed the unused `VALID_COORD_REGEX` constant from `src/worker.js`.
Verified that the constant was not used anywhere in the codebase.
This cleanup reduces code bloat and improves maintainability.

---
*PR created automatically by Jules for task [11755068230872921736](https://jules.google.com/task/11755068230872921736) started by @2fst4u*