### PR TITLE
🧹 Sweep: Remove unused DOM references in CircuitWeatherApp.js

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -51,11 +51,6 @@ export class CircuitWeatherApp {
             forecastContent: document.getElementById('forecastContent'),
             forecastUnavailable: document.getElementById('forecastUnavailable'),
             sessionEmptyState: document.getElementById('sessionEmptyState'),
-            weatherTemp: document.getElementById('weatherTemp'),
-            weatherRain: document.getElementById('weatherRain'),
-            weatherWind: document.getElementById('weatherWind'),
-            weatherWindDir: document.getElementById('weatherWindDir'),
-            weatherTimeline: document.getElementById('weatherTimeline'),
             // Mobile Race Info
             mobileRaceInfo: document.getElementById('mobileRaceInfo'),
             mobileCountryFlag: document.getElementById('mobileCountryFlag'),


### PR DESCRIPTION
* 💡 What: Removed unused properties (`weatherTemp`, `weatherRain`, `weatherWind`, `weatherWindDir`, `weatherTimeline`) from `this.ui` in `CircuitWeatherApp.js`.
* 🎯 Why: These properties were initialized with references to elements that were immediately overwritten by `renderForecast` using `innerHTML`. The properties were never used in the application logic.
* 🔬 Verification:
    - Performed a grep search to confirm these properties were not accessed anywhere in the file.
    - Verified the frontend still initializes and renders the dashboard correctly using a Playwright script.
    - Confirmed no console errors were introduced.

---
*PR created automatically by Jules for task [4585512892069594458](https://jules.google.com/task/4585512892069594458) started by @2fst4u*