### PR TITLE
🧹 Sweep: Remove unused `radarAnimationSpeed` from config

### DIFF
--- a/public/src/config.js
+++ b/public/src/config.js
@@ -18,7 +18,6 @@ export const CONFIG = {
     defaultZoom: 3,
     circuitZoom: 10,
     radarOpacity: 0.65,
-    radarAnimationSpeed: 1000, // Default to 1x speed (1000ms per frame)
     // Speed options: slower = higher ms, faster = lower ms
     radarSpeeds: [
         { label: '0.5x', speed: 2000 },


### PR DESCRIPTION
Removed unused `radarAnimationSpeed` property from `public/src/config.js`. This property was redundant as the application uses `radarSpeeds` array for animation control.

---
*PR created automatically by Jules for task [8530373627816645861](https://jules.google.com/task/8530373627816645861) started by @2fst4u*