### PR TITLE
Sweep: Remove unused `isLocal` constant from config

### DIFF
--- a/public/src/config.js
+++ b/public/src/config.js
@@ -2,10 +2,6 @@
  * Circuit Weather - Configuration & Constants
  */
 
-export const isLocal = window.location.hostname === 'localhost' ||
-    window.location.hostname === '127.0.0.1' ||
-    window.location.protocol === 'file:';
-
 export const CONFIG = {
     f1ApiBase: '/api/f1',
     rainViewerApi: '/api/radar',


### PR DESCRIPTION
Removed the unused `isLocal` constant from `public/src/config.js`. This constant was exported but never imported or used throughout the application.

Verified by searching the entire codebase for usage of `isLocal`. The removal reduces clutter and dead code.

---
*PR created automatically by Jules for task [13301725739574913005](https://jules.google.com/task/13301725739574913005) started by @2fst4u*