### PR TITLE
🧹 Sweep: Remove unused `currentTheme` from MapManager

### DIFF
--- a/public/src/map/MapManager.js
+++ b/public/src/map/MapManager.js
@@ -7,7 +7,6 @@ export class MapManager {
     constructor() {
         this.map = null;
         this.tileLayer = null;
-        this.currentTheme = 'light';
         this.resizeObserver = null;
     }
 
@@ -35,7 +34,6 @@ export class MapManager {
     }
 
     setTheme(theme) {
-        this.currentTheme = theme;
         const tileUrl = theme === 'dark' ? CONFIG.mapTilesDark : CONFIG.mapTiles;
 
         if (this.tileLayer) this.map.removeLayer(this.tileLayer);


### PR DESCRIPTION
Removes the `currentTheme` property from `public/src/map/MapManager.js` as it was initialized and assigned but never read or used for any logic. The `setTheme` method correctly uses its argument instead of this property.

Verification:
- Grep search confirmed `currentTheme` is only assigned, never read.
- Manual code review confirmed `setTheme` logic relies on the function argument, not the class property.

---
*PR created automatically by Jules for task [15975490811945270741](https://jules.google.com/task/15975490811945270741) started by @2fst4u*