### PR TITLE
🧹 Sweep: Remove unused historic circuit config

### DIFF
--- a/public/src/config.js
+++ b/public/src/config.js
@@ -60,7 +60,6 @@ export const CIRCUIT_MAP = {
     'jeddah': 'sa-2021',
     'las_vegas': 'us-2023',
     'losail': 'qa-2004',
-    'magny_cours': 'fr-1960', // Historic
     'marina_bay': 'sg-2008',
     'miami': 'us-2022',
     'monaco': 'mc-1929',


### PR DESCRIPTION
Removed the unused `'magny_cours': 'fr-1960'` entry from `CIRCUIT_MAP` in `public/src/config.js`. This entry is historic and never accessed because the app only fetches current season data.

---
*PR created automatically by Jules for task [11292289039443651399](https://jules.google.com/task/11292289039443651399) started by @2fst4u*