### PR TITLE
🧹 Sweep: Remove unused import in worker security tests

### DIFF
--- a/tests/worker-security.test.js
+++ b/tests/worker-security.test.js
@@ -4,8 +4,7 @@ import {
   checkFetchDest,
   RateLimiter,
   VALID_API_PATH_REGEX,
-  PRODUCTION_DOMAIN,
-  ALLOWED_ORIGIN_LOCALHOST_REGEX
+  PRODUCTION_DOMAIN
 } from '../src/worker-utils.js';
 
 // Mock Request object helper


### PR DESCRIPTION
🧹 Sweep: Remove unused import in worker security tests

💡 What: Removed `ALLOWED_ORIGIN_LOCALHOST_REGEX` from the import list in `tests/worker-security.test.js`.
🎯 Why: It was imported but never used in the test file, making it dead code.
🔬 Verification: Ran `grep "ALLOWED_ORIGIN_LOCALHOST_REGEX" tests/worker-security.test.js` to confirm usage (none found except import), and ran `npm test` to ensure no regressions.

---
*PR created automatically by Jules for task [5919437164859432474](https://jules.google.com/task/5919437164859432474) started by @2fst4u*