### PR TITLE
🧹 Sweep: Remove unused radar status CSS

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -1,3 +1,7 @@
 # Sweep Journal
 
 This file tracks critical learnings from Sweep's cleanup operations.
+
+## 2024-05-24 - Duplicate Keyframes in CSS
+**Learning:** I discovered that `@keyframes` rules can be duplicated in CSS files without causing syntax errors, which can lead to confusing behavior and code rot. In this case, `radar-status-pulse` was defined twice with conflicting values.
+**Action:** When auditing CSS, always search for duplicate definitions of classes and keyframes. Use `grep` to find all occurrences before assuming a block is unique.

--- a/public/styles.css
+++ b/public/styles.css
@@ -819,35 +819,6 @@ body {
     border-color: var(--color-primary);
 }
 
-/* Radar Status Indicator */
-.radar-status {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.25rem 0.5rem;
-    background: rgba(239, 68, 68, 0.15);
-    border: 1px solid rgba(239, 68, 68, 0.4);
-    border-radius: var(--radius-md);
-    font-size: 0.65rem;
-    color: #ef4444;
-    white-space: nowrap;
-    animation: radar-status-pulse 2s ease-in-out infinite;
-}
-
-@keyframes radar-status-pulse {
-    0% {
-        opacity: 0.7;
-    }
-
-    50% {
-        opacity: 1;
-    }
-
-    100% {
-        opacity: 0.7;
-    }
-}
-
 /* Error Toast */
 .error-toast {
     position: absolute;
@@ -906,26 +877,6 @@ body {
     font-size: 0.75rem;
     font-weight: 700;
     color: var(--color-primary);
-}
-
-.radar-status-icon {
-    font-size: 0.8rem;
-}
-
-.radar-status-text {
-    font-weight: 500;
-}
-
-@keyframes radar-status-pulse {
-
-    0%,
-    100% {
-        opacity: 1;
-    }
-
-    50% {
-        opacity: 0.7;
-    }
 }
 
 /* ===================================


### PR DESCRIPTION
This PR removes dead CSS code related to an old radar status indicator that is no longer used in the application.

### Changes
- Removed `.radar-status` class block.
- Removed `.radar-status-icon` and `.radar-status-text` classes.
- Removed two conflicting definitions of `@keyframes radar-status-pulse`.

### Verification
- `grep -r "radar-status" .` confirms no references remain in the codebase.
- Verified `public/styles.css` syntax is valid.
- Ran `npm test` to ensuring no regressions in the worker tests.

---
*PR created automatically by Jules for task [10120811917321771299](https://jules.google.com/task/10120811917321771299) started by @2fst4u*