### PR TITLE
Docs: Correct RainViewer zoom limit and update file structure

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -71,3 +71,9 @@ Issue: Multiple H1 tags (sidebar and mobile header) were present on the page, wh
 Cause: The design used H1 tags for the site title in both the desktop sidebar and the mobile top bar.
 Fix: Converted the mobile header H1 to a span with class 'header-title' and updated CSS to maintain styling.
 Prevention: Ensure that only the primary desktop sidebar title uses H1, and other instances of the site title use non-heading elements or classes.
+
+2026-02-24 - Inaccurate RainViewer Limits & File Structure
+Issue: Documentation claimed RainViewer limit was zoom 10, but code enforces zoom 7 based on Jan 2026 findings. File structure missed sitemap.xml.
+Cause: Documentation drift after API changes/findings were implemented in code but not fully updated in high-level docs.
+Fix: Updated AGENTS.md zoom limit to 7 and added sitemap.xml to file tree.
+Prevention: Check code comments (especially recent ones) when verifying documentation claims.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ circuit-weather/
 │   ├── icon-512.png  # PWA icon (512×512)
 │   ├── manifest.json # PWA web app manifest
 │   ├── robots.txt    # Search engine directives
+│   ├── sitemap.xml   # XML Sitemap for SEO
 │   ├── sw.js         # Service worker (app shell caching)
 │   ├── _headers      # Cloudflare Pages custom headers (CSP, security)
 │   └── PRIVACY.md
@@ -251,7 +252,7 @@ mode = "smart"
 
 ## Known Limitations
 
-1. **RainViewer Zoom Limit** - Free tier limits to zoom level 10. We use **512px tiles** with `zoomOffset: -1` and `maxNativeZoom: 8` to emulate higher resolution while reducing requests.
+1. **RainViewer Zoom Limit** - Free tier limits to zoom level 7 (Jan 2026). We use **512px tiles** with `zoomOffset: -1` and `maxNativeZoom: 8` to emulate higher resolution while reducing requests.
 2. **Radar Opacity** - Tiles must be added with small opacity (0.01) initially to trigger loading.
 3. **F1 API Rate Limits** - Edge caching via Worker mitigates this.
 4. **Current Weather Rate Limits** - The live current weather widget is enabled via `FEATURE_FLAGS.enableCurrentWeather` in `public/src/config.js`, but be aware that it triggers an Open-Meteo API call per circuit change which may hit 429 rate limits during high traffic.


### PR DESCRIPTION
Updated AGENTS.md to accurately reflect the RainViewer free tier zoom limit (level 7) as implemented in the code, and added missing sitemap.xml to the repository structure documentation.

---
*PR created automatically by Jules for task [9120413371987727073](https://jules.google.com/task/9120413371987727073) started by @2fst4u*