### PR TITLE
📚 Archivist: Fix inconsistent version numbering and redundant metadata

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -77,3 +77,9 @@ Issue: Documentation claimed RainViewer limit was zoom 10, but code enforces zoo
 Cause: Documentation drift after API changes/findings were implemented in code but not fully updated in high-level docs.
 Fix: Updated AGENTS.md zoom limit to 7 and added sitemap.xml to file tree.
 Prevention: Check code comments (especially recent ones) when verifying documentation claims.
+
+2026-02-24 - Inconsistent Version Numbering and Redundant Metadata
+Issue: Project version was inconsistent across files (package.json: 1.0.0, worker.js: 1.1.1). Additionally, redundant JSON-LD structured data existed in both index.html (static, outdated) and main.js (dynamic).
+Cause: Manual version bump in worker code without updating package metadata. Redundant JSON-LD likely due to migration to dynamic injection for CSP compliance without removing the static block.
+Fix: Updated package.json to 1.1.1, added softwareVersion to dynamic JSON-LD in main.js, and removed static JSON-LD from index.html.
+Prevention: Verify all version sources (package.json, worker.js, metadata) during release. Audit index.html for redundant metadata when using dynamic injection.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "circuit-weather",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "circuit-weather",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "vitest": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circuit-weather",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "Real-time F1 race circuit weather radar application.",
   "type": "module",
   "scripts": {

--- a/public/index.html
+++ b/public/index.html
@@ -51,25 +51,6 @@
     <!-- App CSS -->
     <link rel="stylesheet" href="/styles.css">
 
-    <!-- JSON-LD Structured Data -->
-    <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "WebApplication",
-        "name": "Circuit Weather",
-        "url": "https://circuit-weather.racing",
-        "description": "Real-time weather radar and forecasts for every Formula 1 circuit. Track rain and conditions live during every Grand Prix session.",
-        "applicationCategory": "SportsApplication",
-        "operatingSystem": "Any",
-        "offers": {
-            "@type": "Offer",
-            "price": "0",
-            "priceCurrency": "USD"
-        },
-        "browserRequirements": "Requires JavaScript. Works on modern browsers.",
-        "softwareVersion": "1.0.0"
-    }
-    </script>
 </head>
 
 <body>

--- a/public/src/main.js
+++ b/public/src/main.js
@@ -16,6 +16,7 @@ function initStructuredData() {
         "description": "Real-time weather radar and forecasts for Formula 1 race circuits. Track precipitation and conditions at every F1 track.",
         "applicationCategory": "WeatherApplication, SportsApplication",
         "operatingSystem": "Any",
+        "softwareVersion": "1.1.1",
         "offers": {
             "@type": "Offer",
             "price": "0",


### PR DESCRIPTION
This PR addresses inconsistent version numbering and redundant metadata in the project.

**Changes:**
- Updated `package.json` and `package-lock.json` to version `1.1.1` to match the version reported by the `/api/health` endpoint in `src/worker.js`.
- Updated `public/src/main.js` to include `"softwareVersion": "1.1.1"` in the dynamically injected JSON-LD structured data.
- Removed the redundant static JSON-LD script block from `public/index.html`, which contained outdated version information (`1.0.0`) and duplicated the metadata injected by `main.js`.
- Documented the fix in `.jules/archivist.md`.

**Verification:**
- Verified file contents match the expected version `1.1.1`.
- Ran `npm test` to ensure no regressions (all tests passed).
- Confirmed removal of redundant code.

**Scope:**
- Documentation and metadata updates only. No functional code changes beyond metadata injection.

---
*PR created automatically by Jules for task [7782561428828751503](https://jules.google.com/task/7782561428828751503) started by @2fst4u*