### PR TITLE
🔭 Scout: Fix heading hierarchy for improved SEO

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -147,7 +147,7 @@
 
                 <!-- Weather Forecast -->
                 <section class="forecast-section" id="forecastSection" aria-labelledby="forecastHeading" style="display: none;">
-                    <h3 id="forecastHeading">Session Forecast</h3>
+                    <h2 id="forecastHeading">Session Forecast</h2>
                     <div class="forecast-content" id="forecastContent">
                         <!-- Content injected by JS -->
                         <div class="weather-dashboard">

--- a/public/styles.css
+++ b/public/styles.css
@@ -363,7 +363,7 @@ body {
     border-radius: var(--radius-lg);
 }
 
-.forecast-section h3 {
+.forecast-section h2 {
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -1228,7 +1228,7 @@ body {
         padding: var(--spacing-sm) var(--spacing-md);
     }
 
-    .forecast-section h3 {
+    .forecast-section h2 {
         font-size: 0.6rem;
         margin-bottom: var(--spacing-xs);
     }


### PR DESCRIPTION
💡 What: Upgraded the "Session Forecast" heading from `<h3>` to `<h2>`.
🎯 Why: The page skipped from `<h1>` (Circuit Weather) directly to `<h3>` (Session Forecast), violating the sequential heading hierarchy recommended for SEO and accessibility.
📊 Value: Helps search engines better understand the page structure and improves accessibility navigation.
🔬 Measurement: Verified that the tag is now `<h2>` and the computed font size/style remains identical (12px, uppercase, secondary color). Verified with Playwright.

---
*PR created automatically by Jules for task [756586033569667206](https://jules.google.com/task/756586033569667206) started by @2fst4u*