### PR TITLE
🧪 Spec: Add RateLimiter expiry logic tests

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -1,3 +1,7 @@
 ## 2026-02-24 - [Testing LRU Eviction Policies]
 **Learning:** When testing cache eviction (like in `RateLimiter`), simply checking if an item "exists" isn't enough. You must verify that the evicted item is treated as a *fresh* entry (e.g., full token bucket) upon re-access, distinguishing it from an existing but depleted entry.
 **Action:** Use small capacity limits (e.g., `maxIps=2`) in tests to force eviction with minimal setup, and verify the state reset of the evicted item.
+
+## 2026-03-01 - [Testing Generational Cache Expiry]
+**Learning:** In generational caches (like `RateLimiter`), "Migration" (valid old entry) and "Expiration" (stale old entry) can appear functionally identical (both result in a valid/full bucket). To distinguish them, assert on internal state side-effects: a migrated entry is *removed* from the old generation, while an expired entry is *abandoned* in the old generation (and a new one created).
+**Action:** When testing cache lifecycle, don't just check the return value; inspect the internal storage structures (`oldGen` vs `currentGen`) to verify the correct path was taken.

--- a/tests/rate-limiter-expiry.test.js
+++ b/tests/rate-limiter-expiry.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RateLimiter } from '../src/worker-utils.js';
+
+describe('RateLimiter Expiry Logic', () => {
+  let limiter;
+  const WINDOW_MS = 1000;
+  const LIMIT = 10;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    limiter = new RateLimiter(LIMIT, WINDOW_MS);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('migrates valid records from oldGen to currentGen (within window)', () => {
+    // 1. Arrange: Create a record and update its lastCheck so it survives cleanup
+    // T=0
+    limiter.check('valid-ip');
+
+    // Advance to T=500. Update lastCheck.
+    vi.setSystemTime(500);
+    limiter.check('valid-ip');
+
+    // 2. Act: Trigger cleanup (move to oldGen)
+    // Advance to T=1100 (diff > 1000 since lastCleanup=0)
+    vi.setSystemTime(1100);
+    limiter.check('trigger-cleanup');
+
+    // Verify state: 'valid-ip' is in oldGen
+    expect(limiter.oldGen.has('valid-ip')).toBe(true);
+    expect(limiter.currentGen.has('valid-ip')).toBe(false);
+
+    // 3. Act: Access 'valid-ip' again
+    // T=1100. lastCheck=500. Diff=600 <= 1000. Valid!
+    limiter.check('valid-ip');
+
+    // 4. Assert: Migration happened
+    // 'valid-ip' should be moved to currentGen
+    expect(limiter.currentGen.has('valid-ip')).toBe(true);
+    // 'valid-ip' should be REMOVED from oldGen
+    expect(limiter.oldGen.has('valid-ip')).toBe(false);
+  });
+
+  it('expires stale oldGen records without migration (beyond window)', () => {
+    // 1. Arrange: Create a record that will become stale
+    // T=0. lastCheck=0.
+    limiter.check('stale-ip');
+
+    // 2. Act: Trigger cleanup (move to oldGen)
+    // Advance to T=1100 (diff > 1000 since lastCleanup=0)
+    vi.setSystemTime(1100);
+    limiter.check('trigger-cleanup');
+
+    // Verify state: 'stale-ip' is in oldGen
+    expect(limiter.oldGen.has('stale-ip')).toBe(true);
+    expect(limiter.currentGen.has('stale-ip')).toBe(false);
+
+    // 3. Act: Access 'stale-ip' again
+    // T=1100. lastCheck=0. Diff=1100 > 1000. Expired!
+    limiter.check('stale-ip');
+
+    // 4. Assert: Expiration happened (New Record Created)
+    // 'stale-ip' should be in currentGen (as a new record)
+    expect(limiter.currentGen.has('stale-ip')).toBe(true);
+
+    // CRITICAL: 'stale-ip' should REMAIN in oldGen because migration logic was skipped
+    // The code path `if (now - record.lastCheck <= this.windowMs)` is false,
+    // so `this.oldGen.delete(ip)` inside that block is never called.
+    expect(limiter.oldGen.has('stale-ip')).toBe(true);
+
+    // Verify that the objects are different instances (new vs old)
+    const newRecord = limiter.currentGen.get('stale-ip');
+    const oldRecord = limiter.oldGen.get('stale-ip');
+    expect(newRecord).not.toBe(oldRecord);
+
+    // Verify tokens are reset for new record
+    // New record starts with limit - 1
+    expect(newRecord.tokens).toBe(LIMIT - 1);
+  });
+});


### PR DESCRIPTION
This PR fortifies the test suite by adding coverage for the `RateLimiter` class in `src/worker-utils.js`. Specifically, it targets the logic that distinguishes between migrating a valid record from the old generation to the current one versus handling an expired record that should be treated as new.

Changes:
- Created `tests/rate-limiter-expiry.test.js` with two targeted test cases.
- Validated that stale records in `oldGen` are correctly ignored (not migrated) and that new records are created in `currentGen`.
- Updated `.jules/spec.md` with a journal entry about testing generational cache expiry.

This ensures that the rate limiting logic correctly resets limits for returning users after a long absence, rather than incorrectly carrying over old state or failing to clean up.

---
*PR created automatically by Jules for task [17251342817479434373](https://jules.google.com/task/17251342817479434373) started by @2fst4u*