### PR TITLE
🧹 Sweep: Remove unused .icon-precip CSS class

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1522,7 +1522,6 @@ body {
     /* Slate-500 */
 }
 
-.icon-precip,
 .icon-rain {
     color: #3b82f6;
     /* Blue-500 for rain/precip */


### PR DESCRIPTION
Removed unused `.icon-precip` class from `public/styles.css`.
Verified via global search and `npm test`.
Visual verification confirmed no impact on `MapWeatherWidget` which uses `.icon-rain`.

---
*PR created automatically by Jules for task [5146167836023991554](https://jules.google.com/task/5146167836023991554) started by @2fst4u*