### PR TITLE
🧹 Sweep: Remove unused destroy method from WeatherRadar

### DIFF
--- a/public/src/map/WeatherRadar.js
+++ b/public/src/map/WeatherRadar.js
@@ -895,14 +895,4 @@ export class WeatherRadar {
     showControls(visible) {
         if (this.ui.controls) this.ui.controls.style.display = visible ? 'flex' : 'none';
     }
-
-    destroy() {
-        this.stopPolling();
-        this.pause();
-        this.layers.forEach(layer => {
-            if (layer) this.map.removeLayer(layer);
-        });
-        this.layers = [];
-        this.showControls(false);
-    }
 }


### PR DESCRIPTION
💡 **What**: Removed the `destroy()` method from `public/src/map/WeatherRadar.js`.
🎯 **Why**: This method was dead code. It was never called by the application (as verified by codebase search), and the `WeatherRadar` instance is designed to persist for the lifetime of the SPA session.
🔬 **Verification**: 
- `grep -r "destroy" .` confirmed zero references to the method (other than its definition).
- `npm test` passed, ensuring no syntax errors or regressions in tested code.
- Reviewed dependencies to ensure `stopPolling` and `pause` (called by destroy) are still used elsewhere (confirmed).

---
*PR created automatically by Jules for task [11647867194737243674](https://jules.google.com/task/11647867194737243674) started by @2fst4u*