### PR TITLE
🧹 Sweep: Remove unused delete method from mockCache in worker tests

### DIFF
--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -16,7 +16,6 @@ const mockCache = {
     cacheStore.set(key, response.clone());
     return Promise.resolve();
   }),
-  delete: vi.fn(async (key) => cacheStore.delete(key)),
 };
 
 // Mock Global Caches


### PR DESCRIPTION
Removed the unused `delete` method from the `mockCache` object in `tests/worker.test.js`. Verified that `src/worker.js` does not use `cache.delete` and that all tests pass without this mock method.

---
*PR created automatically by Jules for task [8535333446171667790](https://jules.google.com/task/8535333446171667790) started by @2fst4u*