### PR TITLE
Fix inconsistent range circle colors in dark mode

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -65,11 +65,6 @@ export class CircuitWeatherApp {
         try {
             const map = this.mapManager.init();
 
-            // Theme manager with callback to update map tiles
-            this.themeManager = new ThemeManager((theme) => {
-                this.mapManager.setTheme(theme);
-            });
-
             // Sidebar manager for mobile
             this.sidebarManager = new SidebarManager();
 
@@ -82,6 +77,18 @@ export class CircuitWeatherApp {
             this.rangeCircles = new RangeCircles(map);
             this.trackLayer = new TrackLayer(map);
             this.radar = new WeatherRadar(map);
+
+            // Theme manager with callback to update map tiles and overlays
+            // Bolt Optimization: Initialized after overlays so they can respond to the initial theme apply
+            this.themeManager = new ThemeManager((theme) => {
+                this.mapManager.setTheme(theme);
+                if (this.rangeCircles && this.currentCircuitCenter) {
+                    this.rangeCircles.draw(this.currentCircuitCenter);
+                }
+                if (this.trackLayer) {
+                    this.trackLayer.updateStyle();
+                }
+            });
 
             // Map weather widget (Leaflet control)
             this.mapWeatherWidget = new MapWeatherWidget({ position: 'topright' });

--- a/public/src/map/RangeCircles.js
+++ b/public/src/map/RangeCircles.js
@@ -53,28 +53,40 @@ export class RangeCircles {
         });
     }
 
+    getRangeColor() {
+        const style = getComputedStyle(document.documentElement);
+        const color = style.getPropertyValue('--color-range-circle').trim();
+        if (color) return color;
+
+        // Fallback if CSS variables are not yet loaded (e.g. during early init)
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        return isDark ? '#ff6b5b' : '#e10600';
+    }
+
     draw(center) {
-        // Check if center has changed
+        // Check if material state has changed
         const centerChanged = !this.center || this.center[0] !== center[0] || this.center[1] !== center[1];
         const unitChanged = this.unit !== this.currentUnit;
 
         const steps = this.calculateSteps(center);
         const stepsChanged = !this.currentSteps || JSON.stringify(steps) !== JSON.stringify(this.currentSteps);
 
+        const rangeColor = this.getRangeColor();
+        const colorChanged = this.currentColor !== rangeColor;
+
         // Optimization: Only redraw if nothing material has changed
-        if (!centerChanged && !stepsChanged && !unitChanged) {
+        if (!centerChanged && !stepsChanged && !unitChanged && !colorChanged) {
             return;
         }
 
         this.center = [...center];
         this.currentSteps = steps;
         this.currentUnit = this.unit;
+        this.currentColor = rangeColor;
 
         // Bolt Optimization: Reuse existing layers (Object Pooling)
         // prevents DOM thrashing during frequent zoom events.
         const multiplier = this.unit === 'metric' ? 1000 : 1609.34;
-        // Get theme-aware color from CSS variable
-        const rangeColor = getComputedStyle(document.documentElement).getPropertyValue('--color-range-circle').trim() || '#e10600';
 
         steps.forEach((distance, index) => {
             const radius = distance * multiplier;

--- a/public/src/map/TrackLayer.js
+++ b/public/src/map/TrackLayer.js
@@ -13,6 +13,16 @@ export class TrackLayer {
         this.map.on('zoomend', () => this.updateStyle());
     }
 
+    getTrackColor() {
+        const style = getComputedStyle(document.documentElement);
+        const color = style.getPropertyValue('--color-range-circle').trim();
+        if (color) return color;
+
+        // Fallback if CSS variables are not yet loaded (e.g. during early init)
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        return isDark ? '#ff6b5b' : '#e10600';
+    }
+
     updateStyle() {
         if (!this.layer) return;
 
@@ -24,7 +34,8 @@ export class TrackLayer {
         else if (zoom >= 8) weight = 2;
         else weight = 1;
 
-        this.layer.setStyle({ weight: weight });
+        const trackColor = this.getTrackColor();
+        this.layer.setStyle({ weight: weight, color: trackColor });
     }
 
     async loadTrack(circuitId) {
@@ -75,10 +86,11 @@ export class TrackLayer {
             // Double check before rendering
             if (this.currentCircuitId !== circuitId) return;
 
+            const trackColor = this.getTrackColor();
             this.layer = L.geoJSON(data, {
                 style: {
                     interactive: false,
-                    color: '#e10600',
+                    color: trackColor,
                     weight: 4, // Initial, will be updated immediately
                     opacity: 0.8,
                     fillOpacity: 0,


### PR DESCRIPTION
The range circles and track layers were defaulting to the light-mode red color (#e10600) on initial load, even when the system/browser was in dark mode. This was due to a race condition where the map components rendered before the dark mode CSS variables were fully parsed, combined with hardcoded light-mode fallbacks in the JavaScript code.

Key changes:
1. **CircuitWeatherApp.js**: Moved map overlay instantiation before `ThemeManager` and added explicit redraw/update calls to the theme change callback.
2. **RangeCircles.js**: Replaced hardcoded color with a `getRangeColor()` method that checks the `data-theme` attribute for a fallback if the CSS variable `--color-range-circle` is not yet available. Added state tracking for the current color to trigger redraws only when necessary.
3. **TrackLayer.js**: Implemented similar theme-aware color retrieval for the circuit track.

Verified via Playwright that the initial load in dark mode now correctly displays the coral color (#ff6b5b) and switches seamlessly when toggled. All existing unit tests pass.

Fixes #295

---
*PR created automatically by Jules for task [12681491141552518626](https://jules.google.com/task/12681491141552518626) started by @2fst4u*