### PR TITLE
🛡️ Sentinel: Fix Loose Content-Type Validation in Worker Proxy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -54,3 +54,8 @@
 **Vulnerability:** When tightening regex validation for Worker origins, it is easy to inadvertently block legitimate development or preview build formats (e.g., `038ad3cf-circuit-weather.user.workers.dev`).
 **Learning:** Always verify regex changes against all known environment URL patterns, including dynamic preview builds which may have random hash prefixes.
 **Prevention:** Include examples of all environment URL formats in the test suite to ensure the regex is both secure (blocks attackers) and functional (allows dev builds).
+
+## 2026-06-25 - Loose Content-Type Validation in Worker Proxy
+**Vulnerability:** The Worker Proxy validated `Content-Type` headers using partial substring matches (e.g., `.includes('application/json')`). This allowed deceptive MIME types like `application/jsonp` (executable JSONP) or `text/javascript-malicious` to bypass security checks, potentially enabling cache poisoning or XSS via MIME confusion.
+**Learning:** Using `includes()` or `startsWith()` for MIME type validation is insufficient as it matches malicious subtypes or extensions that share the same prefix/substring.
+**Prevention:** Always parse the `Content-Type` header (splitting by `;` to remove parameters) and perform a strict equality check against the allowed MIME type (e.g., `mime === 'application/json'`).

--- a/src/worker.js
+++ b/src/worker.js
@@ -306,9 +306,12 @@ async function handleApiRequest(request, env, ctx) {
 
     // SEC: Strict Content-Type Validation
     // Prevent cache poisoning if upstream returns HTML error page with 200 OK
+    // Bolt Security: Use strict MIME comparison, not substring check
     const contentType = upstreamResponse.headers.get('Content-Type');
-    if (!contentType || !contentType.includes('application/json')) {
-      console.error(`Upstream Invalid Content-Type: ${contentType}`);
+    const mime = contentType ? contentType.split(';')[0].trim() : '';
+
+    if (mime !== 'application/json') {
+      console.error(`Upstream Invalid Content-Type: ${contentType} (parsed: ${mime})`);
       return cacheAndReturnError(request, cache, cacheKey, 502, {
         error: 'Invalid upstream content type',
       }, ctx);
@@ -540,9 +543,10 @@ async function handleLeafletRequest(request, env, ctx) {
     }
 
     // SEC: Validate Content-Type
+    // Bolt Security: Use strict MIME comparison, not substring check
     const contentType = upstreamResponse.headers.get('Content-Type');
-    // Allow partial match (e.g. text/css; charset=utf-8) against any allowed type
-    const isValidType = config.contentTypes.some(type => contentType && contentType.includes(type));
+    const mime = contentType ? contentType.split(';')[0].trim() : '';
+    const isValidType = config.contentTypes.includes(mime);
 
     if (!isValidType) {
       console.error(`Leaflet Invalid Content-Type (${path}): ${contentType} (expected ${config.contentTypes.join(' or ')})`);
@@ -728,13 +732,15 @@ async function handleTileRequest(request, env, ctx) {
 
     if (shouldCache) {
       const contentType = upstreamResponse.headers.get('Content-Type');
-      const isPng = contentType && contentType.startsWith('image/png');
+      // Bolt Security: Use strict MIME comparison, not substring check
+      const mime = contentType ? contentType.split(';')[0].trim() : '';
+      const isPng = mime === 'image/png';
 
       // SEC: Strict Content-Type Validation (ONLY for success responses)
       // Prevent XSS via MIME sniffing if upstream returns non-image content (e.g. HTML)
       // Only allow PNG as we enforced .png extension in URL. Blocks image/svg+xml.
       if (upstreamResponse.ok && !isPng) {
-        console.error(`Upstream Tile Invalid Content-Type: ${contentType}`);
+        console.error(`Upstream Tile Invalid Content-Type: ${contentType} (parsed: ${mime})`);
         return new Response(JSON.stringify({ error: 'Invalid upstream content type' }), {
           status: 502,
           headers: getErrorHeaders(request)
@@ -922,9 +928,12 @@ async function handleRadarRequest(request, env, ctx) {
 
     // SEC: Strict Content-Type Validation
     // Prevent cache poisoning if upstream returns HTML error page (e.g. WAF/Maintenance) with 200 OK
+    // Bolt Security: Use strict MIME comparison, not substring check
     const contentType = upstreamResponse.headers.get('Content-Type');
-    if (!contentType || !contentType.includes('application/json')) {
-      console.error(`Upstream Radar Invalid Content-Type: ${contentType}`);
+    const mime = contentType ? contentType.split(';')[0].trim() : '';
+
+    if (mime !== 'application/json') {
+      console.error(`Upstream Radar Invalid Content-Type: ${contentType} (parsed: ${mime})`);
       return getEmptyRadarResponse(request);
     }
 

--- a/tests/worker-security-content-type.test.js
+++ b/tests/worker-security-content-type.test.js
@@ -1,0 +1,227 @@
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import worker from '../src/worker.js';
+
+// --- Mocks ---
+
+// Mock Cache API
+const cacheStore = new Map();
+const mockCache = {
+  match: vi.fn(async (request) => {
+    const key = request.url;
+    return cacheStore.get(key) || undefined;
+  }),
+  put: vi.fn(async (request, response) => {
+    const key = request.url;
+    cacheStore.set(key, response.clone());
+    return Promise.resolve();
+  }),
+};
+
+// Mock Global Caches
+vi.stubGlobal('caches', {
+  default: mockCache,
+});
+
+// Mock Crypto for SRI checks
+// Use vi.stubGlobal or defineProperty since global.crypto is read-only in some envs
+Object.defineProperty(global, 'crypto', {
+  value: {
+    subtle: {
+      digest: vi.fn(async (algo, buffer) => {
+        return new ArrayBuffer(32);
+      })
+    }
+  },
+  writable: true
+});
+
+// --- Tests ---
+
+describe('Worker Security: Strict Content-Type Validation', () => {
+  let mockFetch;
+
+  beforeEach(() => {
+    cacheStore.clear();
+    vi.clearAllMocks();
+
+    mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+
+    vi.stubGlobal('env', { ENVIRONMENT: 'test' });
+    vi.stubGlobal('ctx', {
+      waitUntil: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createRequest = (path, options = {}) => {
+    const url = `https://circuit-weather.racing${path}`;
+    const headers = new Headers(options.headers || {});
+    if (!headers.has('Sec-Fetch-Site')) {
+      headers.set('Sec-Fetch-Site', 'same-origin');
+    }
+    return new Request(url, {
+      method: options.method || 'GET',
+      headers: headers,
+    });
+  };
+
+  describe('F1 API Proxy (/api/f1/*)', () => {
+    it('allows application/json; charset=utf-8', async () => {
+      mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json; charset=utf-8' }
+      }));
+
+      const req = createRequest('/api/f1/current');
+      const res = await worker.fetch(req, global.env, global.ctx);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Content-Type')).toBe('application/json'); // Worker strips charset in cache headers
+    });
+
+    it('blocks deceptive type: application/jsonp', async () => {
+      mockFetch.mockResolvedValueOnce(new Response('callback({})', {
+        status: 200,
+        headers: { 'Content-Type': 'application/jsonp' }
+      }));
+
+      const req = createRequest('/api/f1/current');
+      const res = await worker.fetch(req, global.env, global.ctx);
+
+      // Should fail if loose matching is used (includes 'application/json')
+      // Currently fails (returns 200) because validation is loose.
+      // After fix, should return 502.
+      if (res.status === 200) {
+        throw new Error('FAILED: Accepted application/jsonp');
+      }
+      expect(res.status).toBe(502);
+    });
+
+    it('blocks deceptive type: application/json-evil', async () => {
+        mockFetch.mockResolvedValueOnce(new Response('{}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json-evil' }
+        }));
+
+        const req = createRequest('/api/f1/current');
+        const res = await worker.fetch(req, global.env, global.ctx);
+
+        if (res.status === 200) {
+            throw new Error('FAILED: Accepted application/json-evil');
+        }
+        expect(res.status).toBe(502);
+      });
+  });
+
+  describe('Radar API Proxy (/api/radar)', () => {
+    it('blocks deceptive type: application/json-evil', async () => {
+      mockFetch.mockResolvedValueOnce(new Response('{}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json-evil' }
+      }));
+
+      const req = createRequest('/api/radar');
+      const res = await worker.fetch(req, global.env, global.ctx);
+
+      // Check if it returned the "empty radar" response which is used for errors
+      // The current implementation returns getEmptyRadarResponse() on error.
+      // So status is 200, but content is empty radar.
+      const data = await res.json();
+
+      // If validation fails, it should return empty radar.
+      // If validation passes (bug), it returns the upstream data ({}).
+      // Wait, handleRadarRequest:
+      // if (!contentType || !contentType.includes('application/json')) { return getEmptyRadarResponse(request); }
+      // So if it accepts json-evil, it returns the upstream data.
+
+      // Our mock returns {}, empty radar has radar: { past: [], ... }
+      if (!data.radar) { // Upstream mocked data
+          throw new Error('FAILED: Accepted application/json-evil (returned upstream data)');
+      }
+
+      // Correct behavior: returns empty radar structure
+      expect(data.radar).toBeDefined();
+    });
+  });
+
+  describe('Leaflet Assets Proxy (/api/assets/*)', () => {
+    it('allows text/css; charset=utf-8', async () => {
+        // Valid hash for leaflet.css
+        const hash = 'p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=';
+        const buffer = Uint8Array.from(atob(hash), c => c.charCodeAt(0)).buffer;
+
+        Object.defineProperty(global, 'crypto', {
+            value: { subtle: { digest: vi.fn(async () => buffer) } },
+            writable: true
+        });
+
+        mockFetch.mockResolvedValueOnce(new Response('css', {
+            status: 200,
+            headers: { 'Content-Type': 'text/css; charset=utf-8' }
+        }));
+
+        const req = createRequest('/api/assets/leaflet.css');
+        const res = await worker.fetch(req, global.env, global.ctx);
+        expect(res.status).toBe(200);
+    });
+
+    it('blocks deceptive type: text/javascript-evil', async () => {
+        // Valid hash for leaflet.js
+        const hash = '20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=';
+        const buffer = Uint8Array.from(atob(hash), c => c.charCodeAt(0)).buffer;
+
+        Object.defineProperty(global, 'crypto', {
+            value: { subtle: { digest: vi.fn(async () => buffer) } },
+            writable: true
+        });
+
+        mockFetch.mockResolvedValueOnce(new Response('evil', {
+            status: 200,
+            headers: { 'Content-Type': 'text/javascript-evil' }
+        }));
+
+        const req = createRequest('/api/assets/leaflet.js');
+        const res = await worker.fetch(req, global.env, global.ctx);
+
+        if (res.status === 200) {
+            throw new Error('FAILED: Accepted text/javascript-evil');
+        }
+        expect(res.status).toBe(502);
+    });
+  });
+
+  describe('Tile Proxy (/api/tiles/*)', () => {
+    it('allows image/png', async () => {
+        mockFetch.mockResolvedValueOnce(new Response(new ArrayBuffer(10), {
+            status: 200,
+            headers: { 'Content-Type': 'image/png' }
+        }));
+
+        const req = createRequest('/api/tiles/test.png');
+        const res = await worker.fetch(req, global.env, global.ctx);
+        expect(res.status).toBe(200);
+    });
+
+    it('blocks deceptive type: image/png-evil', async () => {
+        mockFetch.mockResolvedValueOnce(new Response(new ArrayBuffer(10), {
+            status: 200,
+            headers: { 'Content-Type': 'image/png-evil' }
+        }));
+
+        const req = createRequest('/api/tiles/test.png');
+        const res = await worker.fetch(req, global.env, global.ctx);
+
+        // handleTileRequest uses startsWith('image/png')
+        // So image/png-evil passes!
+        if (res.status === 200) {
+            throw new Error('FAILED: Accepted image/png-evil');
+        }
+        expect(res.status).toBe(502);
+    });
+  });
+
+});


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix Loose Content-Type Validation in Worker Proxy

🚨 Severity: HIGH
💡 Vulnerability: The Worker Proxy validated `Content-Type` headers using partial substring matches (e.g., `.includes('application/json')`). This allowed deceptive MIME types like `application/jsonp` (executable JSONP) or `text/javascript-malicious` to bypass security checks, potentially enabling cache poisoning or XSS via MIME confusion.
🎯 Impact: An attacker could trick the proxy into caching and serving malicious content (e.g., executable scripts) as trusted types, leading to XSS if served to a victim's browser, or cache poisoning where invalid data is permanently stored in the edge cache.
🔧 Fix: Refactored `src/worker.js` to parse the `Content-Type` header (splitting by `;` to remove parameters) and perform a strict equality check against the allowed MIME type.
✅ Verification: Added `tests/worker-security-content-type.test.js` which confirms that deceptive types are now blocked (502 Bad Gateway) while valid types with parameters (e.g., `application/json; charset=utf-8`) are still accepted. All existing tests pass.

---
*PR created automatically by Jules for task [9984712520406092795](https://jules.google.com/task/9984712520406092795) started by @2fst4u*