### PR TITLE
🧹 Sweep: Remove debug logs from WeatherRadar

### DIFF
--- a/public/src/map/WeatherRadar.js
+++ b/public/src/map/WeatherRadar.js
@@ -480,7 +480,6 @@ export class WeatherRadar {
                 layer.redraw();
             }
         });
-        console.log('[Radar] Retrying tiles after cooldown...');
     }
 
     showErrorToast(title, message, durationSec = 5) {
@@ -657,8 +656,6 @@ export class WeatherRadar {
      * Prevents the "Wall of Requests" (50+ pending) issue.
      */
     async preloadSequence() {
-        console.log('[Radar] Starting serial preload sequence...');
-
         // Order: Start from current frame + 1, wrap around.
         const sequence = [];
         for (let i = 0; i < this.frames.length; i++) {


### PR DESCRIPTION
💡 **What:** Removed `console.log` statements from `public/src/map/WeatherRadar.js`.
🎯 **Why:** These were leftover debug artifacts (`[Radar] Starting serial preload sequence...`, `[Radar] Retrying tiles after cooldown...`) that cluttered the browser console during normal operation.
🔬 **Verification:**
- Ran `npm test` to ensure no tests relied on these logs (all 134 tests passed).
- Verified `WeatherRadar.js` still contains the logic, just without the logging.

---
*PR created automatically by Jules for task [16698266247702805399](https://jules.google.com/task/16698266247702805399) started by @2fst4u*