### PR TITLE
🧹 Sweep: Remove unused visibleCount property

### DIFF
--- a/public/src/map/RangeCircles.js
+++ b/public/src/map/RangeCircles.js
@@ -7,7 +7,6 @@ export class RangeCircles {
         this.labels = [];
         this.unit = this.getInitialUnit();
         this.center = null;
-        this.visibleCount = 4; // How many circles to show based on zoom
         this.currentSteps = null;
         this.centerMarker = null;
         this.bindEvents();


### PR DESCRIPTION
💡 What: Removed unused `this.visibleCount` property from `public/src/map/RangeCircles.js`.
🎯 Why: It was initialized but never read or used in the logic.
🔬 Verification: Ran `grep -r "visibleCount" .` to confirm no usages. Ran `npm test` to ensure no regressions.

---
*PR created automatically by Jules for task [16471408204105108564](https://jules.google.com/task/16471408204105108564) started by @2fst4u*