### PR TITLE
⚡ Bolt: Cache theme colors to reduce style recalculations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2024-05-26 - URL Parsing Overhead
 **Learning:** `new URL()` instantiation in high-traffic request handlers (like Referer/Origin validation) is significantly slower (measured ~20x) than direct string matching or pre-compiled regex checks.
 **Action:** Replace `new URL()` with `startsWith()` or Regex checks for origin validation in hot paths, especially in serverless environments where every millisecond of execution time counts.
+
+## 2024-05-27 - CSS Variable Access in Animation Loops
+**Learning:** `getComputedStyle(element).getPropertyValue()` forces a synchronous style recalculation (reflow), which causes significant layout thrashing when called inside frequent event handlers (like `zoomend` or `draw` loops).
+**Action:** Cache CSS variable values in component state and update them only when the theme changes (via `MutationObserver` or explicit callback), rather than querying the DOM on every render frame.

--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -83,11 +83,14 @@ export class CircuitWeatherApp {
             // Bolt Optimization: Initialized after overlays so they can respond to the initial theme apply
             this.themeManager = new ThemeManager((theme) => {
                 this.mapManager.setTheme(theme);
-                if (this.rangeCircles && this.currentCircuitCenter) {
-                    this.rangeCircles.draw(this.currentCircuitCenter);
+                if (this.rangeCircles) {
+                    this.rangeCircles.updateTheme();
+                    if (this.currentCircuitCenter) {
+                        this.rangeCircles.draw(this.currentCircuitCenter);
+                    }
                 }
                 if (this.trackLayer) {
-                    this.trackLayer.updateStyle();
+                    this.trackLayer.updateTheme();
                 }
             });
 

--- a/public/src/map/RangeCircles.js
+++ b/public/src/map/RangeCircles.js
@@ -9,6 +9,8 @@ export class RangeCircles {
         this.center = null;
         this.currentSteps = null;
         this.centerMarker = null;
+        // Bolt Optimization: Cache range color to avoid getComputedStyle thrashing
+        this.rangeColor = this.resolveRangeColor();
         this.bindEvents();
         this.updateToggleUI();
     }
@@ -52,7 +54,7 @@ export class RangeCircles {
         });
     }
 
-    getRangeColor() {
+    resolveRangeColor() {
         const style = getComputedStyle(document.documentElement);
         const color = style.getPropertyValue('--color-range-circle').trim();
         if (color) return color;
@@ -60,6 +62,10 @@ export class RangeCircles {
         // Fallback if CSS variables are not yet loaded (e.g. during early init)
         const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
         return isDark ? '#ff6b5b' : '#e10600';
+    }
+
+    updateTheme() {
+        this.rangeColor = this.resolveRangeColor();
     }
 
     draw(center) {
@@ -70,7 +76,7 @@ export class RangeCircles {
         const steps = this.calculateSteps(center);
         const stepsChanged = !this.currentSteps || JSON.stringify(steps) !== JSON.stringify(this.currentSteps);
 
-        const rangeColor = this.getRangeColor();
+        const rangeColor = this.rangeColor;
         const colorChanged = this.currentColor !== rangeColor;
 
         // Optimization: Only redraw if nothing material has changed

--- a/public/src/map/TrackLayer.js
+++ b/public/src/map/TrackLayer.js
@@ -6,6 +6,8 @@ export class TrackLayer {
         this.layer = null;
         this.currentCircuitId = null;
         this.cache = new Map();
+        // Bolt Optimization: Cache track color to avoid getComputedStyle thrashing
+        this.trackColor = this.resolveTrackColor();
         this.bindEvents();
     }
 
@@ -13,7 +15,7 @@ export class TrackLayer {
         this.map.on('zoomend', () => this.updateStyle());
     }
 
-    getTrackColor() {
+    resolveTrackColor() {
         const style = getComputedStyle(document.documentElement);
         const color = style.getPropertyValue('--color-range-circle').trim();
         if (color) return color;
@@ -21,6 +23,11 @@ export class TrackLayer {
         // Fallback if CSS variables are not yet loaded (e.g. during early init)
         const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
         return isDark ? '#ff6b5b' : '#e10600';
+    }
+
+    updateTheme() {
+        this.trackColor = this.resolveTrackColor();
+        this.updateStyle();
     }
 
     updateStyle() {
@@ -34,8 +41,8 @@ export class TrackLayer {
         else if (zoom >= 8) weight = 2;
         else weight = 1;
 
-        const trackColor = this.getTrackColor();
-        this.layer.setStyle({ weight: weight, color: trackColor });
+        // Use cached color
+        this.layer.setStyle({ weight: weight, color: this.trackColor });
     }
 
     async loadTrack(circuitId) {
@@ -86,7 +93,7 @@ export class TrackLayer {
             // Double check before rendering
             if (this.currentCircuitId !== circuitId) return;
 
-            const trackColor = this.getTrackColor();
+            const trackColor = this.trackColor;
             this.layer = L.geoJSON(data, {
                 style: {
                     interactive: false,


### PR DESCRIPTION
This PR optimizes the map rendering performance by caching CSS variable values (`--color-range-circle`) in `TrackLayer` and `RangeCircles`. Previously, these components called `getComputedStyle(document.documentElement)` on every `zoomend` or `draw` event, forcing synchronous style recalculations (layout thrashing). Now, the color values are cached and only updated when the theme changes via the `ThemeManager` callback.

This change reduces the overhead of `getComputedStyle` during frequent map interactions like zooming and panning, leading to smoother animations and less jank.

Tests passed: `npm test` passed 145/145 tests. No regressions introduced.

---
*PR created automatically by Jules for task [3888350787379006750](https://jules.google.com/task/3888350787379006750) started by @2fst4u*