### PR TITLE
🧪 Spec: Refactor RateLimiter tests to dedicated file

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -1,3 +1,7 @@
 ## 2026-01-01 - Testing Recursive Polling with Vitest
 **Learning:** Testing methods that recursively call themselves via `setTimeout` (like `WeatherRadar.scheduleNextPoll`) creates a tricky spying scenario. If you spy on the method *before* the first manual call, you might double-count invocations or interfere with the initial setup.
 **Action:** The robust pattern is: 1. Mock dependencies (timers, fetch). 2. Call the method manually (Call #1). 3. *Then* spy on the method. 4. Advance timers to trigger the recursive call (Call #2). 5. Assert the spy was called once (verifying the recursion). This isolates the recursive behavior from the initial trigger.
+
+## 2026-10-24 - Manual Date.now Mocking vs Fake Timers
+**Learning:** Found legacy tests manually overriding `global.Date.now` for time-dependent logic. This is brittle and can leak into other tests or interfere with libraries relying on real time.
+**Action:** Always prefer `vi.useFakeTimers()` and `vi.setSystemTime()`/`vi.advanceTimersByTime()` for robust, isolated time manipulation in tests.

--- a/tests/rate-limiter-basic.test.js
+++ b/tests/rate-limiter-basic.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { RateLimiter } from '../src/worker-utils.js';
+
+describe('RateLimiter Basic Functionality', () => {
+    let limiter;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        // Start at a known time (e.g., T=1000)
+        vi.setSystemTime(1000);
+        // 10 requests per 1000ms
+        limiter = new RateLimiter(10, 1000);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('allows requests under the limit', () => {
+        expect(limiter.check('1.1.1.1')).toBe(true);
+        expect(limiter.check('1.1.1.1')).toBe(true);
+    });
+
+    it('blocks requests over the limit', () => {
+        // Consume all 10 tokens
+        for (let i = 0; i < 10; i++) {
+            expect(limiter.check('2.2.2.2')).toBe(true);
+        }
+        // 11th request should be blocked
+        expect(limiter.check('2.2.2.2')).toBe(false);
+    });
+
+    it('resets after window expires', () => {
+        // Fill bucket
+        for (let i = 0; i < 10; i++) {
+            limiter.check('3.3.3.3');
+        }
+        expect(limiter.check('3.3.3.3')).toBe(false);
+
+        // Advance time beyond window (1000ms) + small buffer
+        vi.advanceTimersByTime(1100);
+
+        // Should work again
+        expect(limiter.check('3.3.3.3')).toBe(true);
+    });
+
+    it('tracks distinct IPs independently', () => {
+        // Exhaust IP 4.4.4.4
+        for (let i = 0; i < 10; i++) {
+            limiter.check('4.4.4.4');
+        }
+        expect(limiter.check('4.4.4.4')).toBe(false);
+
+        // IP 5.5.5.5 should still be allowed
+        expect(limiter.check('5.5.5.5')).toBe(true);
+    });
+});

--- a/tests/worker-security.test.js
+++ b/tests/worker-security.test.js
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   checkRequestSource,
   checkFetchDest,
-  RateLimiter,
   VALID_API_PATH_REGEX,
   PRODUCTION_DOMAIN
 } from '../src/worker-utils.js';
@@ -84,57 +83,6 @@ describe('Worker Security Utils', () => {
 
     it('blocks iframe destination', () => {
       expect(checkFetchDest(createRequest({ 'Sec-Fetch-Dest': 'iframe' }))).toBe(false);
-    });
-  });
-
-  describe('RateLimiter', () => {
-    let limiter;
-
-    beforeEach(() => {
-      // 10 requests per 1000ms
-      limiter = new RateLimiter(10, 1000);
-    });
-
-    it('allows requests under the limit', () => {
-      expect(limiter.check('1.1.1.1')).toBe(true);
-      expect(limiter.check('1.1.1.1')).toBe(true);
-    });
-
-    it('blocks requests over the limit', () => {
-      for (let i = 0; i < 10; i++) {
-        expect(limiter.check('2.2.2.2')).toBe(true);
-      }
-      expect(limiter.check('2.2.2.2')).toBe(false);
-    });
-
-    it('resets after window expires', async () => {
-      // Mock Date.now
-      const originalNow = Date.now;
-      let mockTime = 1000000;
-      global.Date.now = () => mockTime;
-
-      // Fill bucket
-      for (let i = 0; i < 10; i++) {
-        limiter.check('3.3.3.3');
-      }
-      expect(limiter.check('3.3.3.3')).toBe(false);
-
-      // Advance time beyond window (1000ms)
-      mockTime += 1100;
-
-      // Should work again
-      expect(limiter.check('3.3.3.3')).toBe(true);
-
-      // Restore Date.now
-      global.Date.now = originalNow;
-    });
-
-    it('tracks distinct IPs independently', () => {
-      for (let i = 0; i < 10; i++) {
-        limiter.check('4.4.4.4');
-      }
-      expect(limiter.check('4.4.4.4')).toBe(false);
-      expect(limiter.check('5.5.5.5')).toBe(true);
     });
   });
 


### PR DESCRIPTION
Extracted RateLimiter tests from `tests/worker-security.test.js` to a dedicated `tests/rate-limiter-basic.test.js` file. Replaced brittle manual `Date.now` mocking with Vitest's `vi.useFakeTimers()` to improve test reliability and isolation. This clarifies the purpose of `worker-security.test.js` and ensures rate limiting logic is tested with robust time control.

---
*PR created automatically by Jules for task [9011360771843886024](https://jules.google.com/task/9011360771843886024) started by @2fst4u*