### PR TITLE
🧹 Sweep: Remove unused mobileCard reference in CountdownTimer

### DIFF
--- a/public/src/ui/CountdownTimer.js
+++ b/public/src/ui/CountdownTimer.js
@@ -10,8 +10,7 @@ export class CountdownTimer {
             session: document.getElementById('countdownSession'),
             mobileTimer: document.getElementById('mobileCountdownTimer'),
             mobileSession: document.getElementById('mobileCountdownSession'),
-            card: document.getElementById('countdownCard'),
-            mobileCard: document.getElementById('mobileCountdown')
+            card: document.getElementById('countdownCard')
         };
     }
 

--- a/tests/countdown-timer.test.js
+++ b/tests/countdown-timer.test.js
@@ -77,7 +77,6 @@ describe('CountdownTimer', () => {
                 mobileTimer: { textContent: '', setAttribute: vi.fn(), removeAttribute: vi.fn() },
                 mobileSession: { textContent: '' },
                 card: { style: {} },
-                mobileCard: null,
             };
         });
 
@@ -126,7 +125,6 @@ describe('CountdownTimer', () => {
                 mobileTimer: { textContent: '', setAttribute: vi.fn(), removeAttribute: vi.fn() },
                 mobileSession: { textContent: '' },
                 card: { style: {} },
-                mobileCard: null,
             };
         });
 
@@ -191,7 +189,6 @@ describe('CountdownTimer', () => {
                 mobileTimer: { textContent: '', setAttribute: vi.fn(), removeAttribute: vi.fn() },
                 mobileSession: { textContent: '' },
                 card: { style: {} },
-                mobileCard: null,
             };
         });
 
@@ -223,7 +220,6 @@ describe('CountdownTimer', () => {
                 mobileTimer: null,
                 mobileSession: null,
                 card: { style: {} },
-                mobileCard: null,
             };
         });
 


### PR DESCRIPTION
Removes the unused `mobileCard` property from the `CountdownTimer` class and its associated mock in tests. The visibility of the mobile countdown element is managed externally by the `CircuitWeatherApp` class, making this internal reference dead code. This cleanup reduces clutter and potential confusion about component responsibilities.

---
*PR created automatically by Jules for task [11573727303285719474](https://jules.google.com/task/11573727303285719474) started by @2fst4u*