### PR TITLE
🧹 Sweep: Remove unused exports from worker-utils.js

### DIFF
--- a/src/worker-utils.js
+++ b/src/worker-utils.js
@@ -3,9 +3,9 @@
 export const VALID_API_PATH_REGEX = /^[a-zA-Z0-9/._-]*$/;
 export const VALID_TRACK_ID_REGEX = /^[a-z0-9-]+$/;
 export const PRODUCTION_DOMAIN = 'https://circuit-weather.racing';
-export const ALLOWED_ORIGIN_LOCALHOST_REGEX = /^http:\/\/localhost(:\d+)?(\/|$)/;
-export const ALLOWED_ORIGIN_127_REGEX = /^http:\/\/127\.0\.0\.1(:\d+)?(\/|$)/;
-export const ALLOWED_PREVIEW_REGEX = /^https:\/\/(.*\.)?circuit-weather\.pages\.dev(\/|$)/;
+const ALLOWED_ORIGIN_LOCALHOST_REGEX = /^http:\/\/localhost(:\d+)?(\/|$)/;
+const ALLOWED_ORIGIN_127_REGEX = /^http:\/\/127\.0\.0\.1(:\d+)?(\/|$)/;
+const ALLOWED_PREVIEW_REGEX = /^https:\/\/(.*\.)?circuit-weather\.pages\.dev(\/|$)/;
 export const DOTFILE_REGEX = /(?:^|\/)\./;
 
 // Bolt Optimization: Reduced header set for API responses (removed HTML-specific headers)


### PR DESCRIPTION
This PR removes the `export` keyword from three regex constants in `src/worker-utils.js`:
- `ALLOWED_ORIGIN_LOCALHOST_REGEX`
- `ALLOWED_ORIGIN_127_REGEX`
- `ALLOWED_PREVIEW_REGEX`

These constants are used internally by `getAllowedOrigin` and `checkRequestSource` functions within the same file, but they are not imported or used by `src/worker.js` or any test files (verified via grep and inspection). Removing the `export` keyword makes them module-private, which is a cleaner practice for internal implementation details.

Verified by running `npm test`, which passed all 211 tests.

---
*PR created automatically by Jules for task [3515093988375794002](https://jules.google.com/task/3515093988375794002) started by @2fst4u*