### PR TITLE
🧪 Spec: Add MapWeatherWidget tests and ratchet coverage thresholds

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -13,3 +13,7 @@
 ## 2026-05-22 - Testing DOM-Dependent Logic in Node Environment
 **Learning:** Testing frontend classes (like `ThemeManager`) that rely on browser globals (`window`, `document`, `localStorage`) in a Node-based test runner (Vitest) requires comprehensive global stubbing. Partial mocking of `window` (e.g., just `matchMedia`) can be sufficient if the code accesses other globals directly.
 **Action:** Use `vi.stubGlobal` to mock `document`, `window`, and `localStorage`. Ensure `document.documentElement` and event listeners are mocked to simulate browser behavior without a full DOM implementation (like jsdom) if the logic is simple enough.
+
+## 2026-01-02 - Mocking Leaflet Class Extension
+**Learning:** Testing components that use `L.Control.extend` (or `L.Class.extend`) requires mocking the inheritance mechanism, as `extend` returns a constructor, not an instance.
+**Action:** Mock `L.Control.extend` to return a class (constructor) that: 1. Accepts `options` and assigns them to `this.options`. 2. Mixes in the passed prototype methods (via `Object.assign`). 3. Explicitly implements base methods like `addTo` and `remove` which would normally be inherited from `L.Control`, to allow chaining and lifecycle management in tests.

--- a/tests/map-weather-widget.test.js
+++ b/tests/map-weather-widget.test.js
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock Leaflet (L)
+const mapMock = {
+    // Add any map methods if needed
+};
+
+// Mock DOM Element
+const createMockElement = (tag, className) => {
+    const el = {
+        tagName: tag.toUpperCase(),
+        className: className || '',
+        innerHTML: '',
+        textContent: '',
+        children: [],
+        querySelector: vi.fn((selector) => {
+            // Simple mock: return a dummy element that can hold textContent
+            return {
+                textContent: '',
+                style: {},
+                classList: {
+                    add: vi.fn(),
+                    remove: vi.fn(),
+                    toggle: vi.fn()
+                }
+            };
+        }),
+        setAttribute: vi.fn(),
+        getAttribute: vi.fn(),
+    };
+    return el;
+};
+
+// Setup global mocks
+vi.stubGlobal('L', {
+    Control: {
+        extend: (proto) => {
+            // Return a class that mimics L.Control behavior + the prototype methods
+            return class MockControl {
+                constructor(options) {
+                    this.options = options || {};
+                    // Copy prototype methods to instance
+                    Object.assign(this, proto);
+                }
+                addTo(map) {
+                    this.onAdd(map);
+                    return this;
+                }
+                remove() {
+                    this.onRemove(this.map);
+                }
+            };
+        }
+    },
+    DomUtil: {
+        create: vi.fn((tag, className) => createMockElement(tag, className))
+    }
+});
+
+// Import the module under test
+const { MapWeatherWidget } = await import('../public/src/map/MapWeatherWidget.js');
+
+describe('MapWeatherWidget', () => {
+    let widget;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        widget = new MapWeatherWidget();
+        // Manually trigger onAdd as if added to map
+        widget.onAdd(mapMock);
+    });
+
+    it('should initialize with correct DOM structure', () => {
+        expect(L.DomUtil.create).toHaveBeenCalledWith('div', 'leaflet-control-weather');
+        expect(widget._div).toBeDefined();
+        // Check if innerHTML was set (contains SVG icons, etc.)
+        expect(widget._div.innerHTML).toContain('weather-widget-metric');
+
+        // Verify UI cache was created
+        expect(widget._ui).toBeDefined();
+        expect(widget._ui.temp).toBeDefined();
+        expect(widget._ui.rain).toBeDefined();
+        expect(widget._ui.humid).toBeDefined();
+        expect(widget._ui.wind).toBeDefined();
+    });
+
+    it('should update with valid weather data', () => {
+        const weatherData = {
+            current: {
+                temperature_2m: 25.4,
+                precipitation_probability: 10,
+                relative_humidity_2m: 65,
+                wind_speed_10m: 15.2
+            },
+            units: {
+                temperature_2m: '°C',
+                wind_speed_10m: 'km/h'
+            }
+        };
+
+        widget.update(weatherData);
+
+        expect(widget._ui.temp.textContent).toBe('25°C');
+        expect(widget._ui.rain.textContent).toBe('10%');
+        expect(widget._ui.humid.textContent).toBe('65%');
+        expect(widget._ui.wind.textContent).toBe('15 km/h');
+    });
+
+    it('should handle missing/null weather data gracefully', () => {
+        // Set some initial values
+        widget._ui.temp.textContent = '25°C';
+
+        // Update with null
+        widget.update(null);
+
+        expect(widget._ui.temp.textContent).toBe('--');
+        expect(widget._ui.rain.textContent).toBe('--%');
+        expect(widget._ui.humid.textContent).toBe('--%');
+        expect(widget._ui.wind.textContent).toBe('--');
+    });
+
+    it('should handle missing current weather object', () => {
+        widget.update({});
+
+        expect(widget._ui.temp.textContent).toBe('--');
+        expect(widget._ui.rain.textContent).toBe('--%');
+    });
+
+    it('should default missing metric values to 0', () => {
+        const partialData = {
+            current: {
+                temperature_2m: 20,
+                wind_speed_10m: 10
+                // Missing precipitation and humidity
+            },
+            units: {
+                temperature_2m: '°C',
+                wind_speed_10m: 'km/h'
+            }
+        };
+
+        widget.update(partialData);
+
+        // Code uses || 0 for precipitation and humidity
+        expect(widget._ui.rain.textContent).toBe('0%');
+        expect(widget._ui.humid.textContent).toBe('0%');
+        expect(widget._ui.temp.textContent).toBe('20°C');
+    });
+
+    it('should clean up references on remove', () => {
+        widget.onRemove(mapMock);
+        expect(widget._ui).toBeNull();
+    });
+
+    it('should not throw if update called before onAdd (no UI)', () => {
+        const uninitializedWidget = new MapWeatherWidget();
+        // Should return early and not throw
+        expect(() => uninitializedWidget.update(null)).not.toThrow();
+    });
+
+    it('should not throw if update called after onRemove', () => {
+        widget.onRemove(mapMock);
+        // Should return early
+        expect(() => widget.update({})).not.toThrow();
+    });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -17,10 +17,10 @@ export default defineConfig({
       // Coverage thresholds — CI will fail if coverage drops below these
       thresholds: {
         // Overall project thresholds (conservative baseline)
-        lines: 50,
-        functions: 55,
-        branches: 70,
-        statements: 50,
+        lines: 60,
+        functions: 70,
+        branches: 80,
+        statements: 60,
       },
       // Report formats: text for CI logs, lcov for future GitHub integration
       reporter: ['text', 'text-summary'],


### PR DESCRIPTION
This PR fortifies the test suite by adding comprehensive unit tests for the `MapWeatherWidget` component, which was previously uncovered (0% coverage).

The new test file `tests/map-weather-widget.test.js`:
- Mocks Leaflet's `L.Control.extend` and `L.DomUtil.create` to simulate the widget's lifecycle in a Node environment.
- Verifies that the widget creates the correct DOM structure on initialization (`onAdd`).
- Tests the `update` method with valid weather data, ensuring the UI reflects the temperature, rain chance, humidity, and wind speed.
- Tests edge cases such as missing or null data, ensuring the widget fails gracefully by displaying placeholder values (`--`).
- Verifies cleanup logic in `onRemove`.

Following the "Spec" philosophy, I have also ratcheted up the project's coverage thresholds in `vitest.config.js` to lock in the gains achieved by this new test. All metrics (Statements, Branches, Functions, Lines) have been increased to new baselines that the current codebase comfortably meets.

**Impact:**
- Prevents regressions in the weather widget's display logic.
- Enforces a higher standard of code coverage for future contributions.
- Provides a reusable pattern for testing Leaflet controls, documented in `.jules/spec.md`.

---
*PR created automatically by Jules for task [5913180386901500239](https://jules.google.com/task/5913180386901500239) started by @2fst4u*