### PR TITLE
🎨 Palette: Disable Series Select dropdown to clarify UI state

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -101,7 +101,8 @@
                 <section class="control-section" aria-label="Race Selection">
                     <div class="control-group">
                         <label for="seriesSelect">Series</label>
-                        <select id="seriesSelect" class="select">
+                        <select id="seriesSelect" class="select" disabled aria-disabled="true"
+                            title="Only Formula 1 is currently supported">
                             <option value="f1">Formula 1</option>
                         </select>
                     </div>


### PR DESCRIPTION
This PR implements a micro-UX improvement for the Series selection dropdown.

**Changes:**
- The `select#seriesSelect` element in `public/index.html` is now disabled.
- A tooltip (`title`) has been added to explain that "Only Formula 1 is currently supported".
- `aria-disabled="true"` has been added for accessibility.

**Why:**
Users were presented with a dropdown that appeared interactive but only contained a single option ("Formula 1"). This could lead to frustration or confusion about whether other series were available or if the control was broken. By explicitly disabling it and providing a tooltip, the UI clearly communicates the system's current capabilities.

**Verification:**
- Verified visually via Playwright screenshot that the control appears disabled (faded).
- Verified via Playwright script that the element has the correct attributes.
- Ran `npm test` to ensure no regressions.

---
*PR created automatically by Jules for task [18011321630929443061](https://jules.google.com/task/18011321630929443061) started by @2fst4u*