### PR TITLE
🧹 Sweep: Remove unused --color-accent CSS variable

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -15,7 +15,6 @@
     /* Light blue for forecast */
     --color-primary: #e10600;
     --color-primary-hover: #b30500;
-    --color-accent: #15803d;
     --color-range-circle: #e10600;
 
     /* Sidebar */


### PR DESCRIPTION
Removed the unused `--color-accent` CSS variable from `public/styles.css`. This variable was defined but never referenced in the codebase (verified via `grep` and test suite).

**Verification:**
*   `grep -r "color-accent" .` confirms zero occurrences after removal.
*   `npm test` confirms no regressions.

---
*PR created automatically by Jules for task [13731922391882237076](https://jules.google.com/task/13731922391882237076) started by @2fst4u*