### PR TITLE
🛡️ Sentinel: Cache /api/health to prevent DoS amplification

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -613,6 +613,32 @@ async function handleHealthRequest(request, env, ctx) {
     });
   }
 
+  // Caching Strategy: Cache the health check for 60 seconds
+  // Prevents abuse of the health endpoint as a DDOS vector against upstreams
+  const cacheKey = new Request(request.url);
+  const cache = caches.default;
+
+  let response = await cache.match(cacheKey);
+
+  if (response) {
+    const headers = new Headers(response.headers);
+    headers.set('X-Cache', 'HIT');
+
+    // Apply strict CORS
+    const allowedOrigin = getAllowedOrigin(request);
+    if (allowedOrigin) {
+      headers.set('Access-Control-Allow-Origin', allowedOrigin);
+      headers.set('Vary', 'Origin');
+    } else {
+      headers.delete('Access-Control-Allow-Origin');
+    }
+
+    return new Response(response.body, {
+      status: response.status,
+      headers
+    });
+  }
+
   const upstreams = {
     jolpica: 'https://api.jolpi.ca/ergast/f1/current.json',
     rainviewer: 'https://api.rainviewer.com/public/weather-maps.json',
@@ -635,15 +661,41 @@ async function handleHealthRequest(request, env, ctx) {
 
   await Promise.all(checks);
 
-  return new Response(JSON.stringify({
+  // Create cacheable response
+  const body = JSON.stringify({
     status: 'ok',
     version: '1.1.1',
     upstreams: results,
     timestamp: new Date().toISOString(),
     environment: env.ENVIRONMENT || 'production'
-  }), {
+  });
+
+  const headers = new Headers({
+    'Content-Type': 'application/json',
+    'Cache-Control': 'public, max-age=60', // Cache for 60s
+    'X-Cache': 'MISS',
+    ...API_SECURITY_HEADERS
+  });
+
+  const newResponse = new Response(body, {
     status: 200,
-    headers: getErrorHeaders(request)
+    headers: headers
+  });
+
+  // Save to cache
+  ctx.waitUntil(cache.put(cacheKey, newResponse.clone()));
+
+  // Return to client (strict CORS)
+  const clientHeaders = new Headers(headers);
+  const allowedOrigin = getAllowedOrigin(request);
+  if (allowedOrigin) {
+    clientHeaders.set('Access-Control-Allow-Origin', allowedOrigin);
+    clientHeaders.set('Vary', 'Origin');
+  }
+
+  return new Response(body, {
+    status: 200,
+    headers: clientHeaders
   });
 }
 

--- a/tests/worker-health-cache.test.js
+++ b/tests/worker-health-cache.test.js
@@ -1,0 +1,96 @@
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import worker from '../src/worker.js';
+
+// --- Mocks ---
+
+// Mock Cache API
+const cacheStore = new Map();
+const mockCache = {
+  match: vi.fn(async (request) => {
+    const key = request.url;
+    return cacheStore.get(key) || undefined;
+  }),
+  put: vi.fn(async (request, response) => {
+    const key = request.url;
+    cacheStore.set(key, response.clone());
+    return Promise.resolve();
+  }),
+};
+
+// Mock Global Caches
+vi.stubGlobal('caches', {
+  default: mockCache,
+});
+
+// Mock Crypto (needed for worker imports)
+Object.defineProperty(global, 'crypto', {
+  value: {
+    subtle: {
+      digest: vi.fn(async () => new ArrayBuffer(32))
+    }
+  },
+  writable: true
+});
+
+describe('Worker Health Check Caching', () => {
+  let mockFetch;
+
+  beforeEach(() => {
+    cacheStore.clear();
+    vi.clearAllMocks();
+
+    mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+
+    vi.stubGlobal('env', { ENVIRONMENT: 'test' });
+    vi.stubGlobal('ctx', {
+      waitUntil: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createRequest = (path) => {
+    const url = `https://circuit-weather.racing${path}`;
+    const headers = new Headers();
+    headers.set('Sec-Fetch-Site', 'same-origin');
+    return new Request(url, {
+      method: 'GET',
+      headers: headers,
+    });
+  };
+
+  it('serves subsequent requests from cache (cache hit)', async () => {
+    // Mock upstream responses
+    mockFetch.mockResolvedValue({
+      status: 200,
+      ok: true,
+      text: async () => 'ok'
+    });
+
+    // First Request (Cache Miss)
+    const req1 = createRequest('/api/health');
+    const res1 = await worker.fetch(req1, global.env, global.ctx);
+    expect(res1.status).toBe(200);
+    // Should call 3 upstreams
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    // Should save to cache
+    expect(mockCache.put).toHaveBeenCalled();
+
+    // Verify headers
+    expect(res1.headers.get('Cache-Control')).toBe('public, max-age=60');
+
+    // Second Request (Cache Hit)
+    const req2 = createRequest('/api/health');
+    const res2 = await worker.fetch(req2, global.env, global.ctx);
+    expect(res2.status).toBe(200);
+
+    // Should NOT call any more upstreams
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    // Should return cache hit
+    expect(res2.headers.get('X-Cache')).toBe('HIT');
+  });
+});


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix DoS amplification risk in /api/health

**Severity:** MEDIUM
**Vulnerability:** The `/api/health` endpoint triggered 3 external API calls (Jolpica, RainViewer, GitHub) on every request without caching. This could be exploited to launch a Denial of Service (DoS) amplification attack against these upstream services or exhaust the worker's execution time.
**Impact:** High latency or service disruption for upstream APIs; potential IP ban from third-party providers due to excessive request volume.
**Fix:** Implemented a 60-second cache using the Worker's Cache API. The response is stored neutrally and served with dynamic CORS headers to ensure correct browser access controls while sharing the cached data.
**Verification:** Added `tests/worker-health-cache.test.js` which confirms that the first request triggers upstream fetches (cache miss) and subsequent requests within the window do not (cache hit).

---
*PR created automatically by Jules for task [2585175373385758352](https://jules.google.com/task/2585175373385758352) started by @2fst4u*