### PR TITLE
Fix CI failure by increasing test coverage

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -607,7 +607,7 @@ export class CircuitWeatherApp {
     }
 
 
-    renderForecast(weather, sessionTime, sessionId) {
+    renderForecast(weather, sessionTime, sessionId, overrideNow = null) {
         // Updates Sidebar Forecast Panel ONLY
 
         // Guard: If no session is currently selected (e.g., user switched rounds while fetching),
@@ -631,7 +631,7 @@ export class CircuitWeatherApp {
                 const p = unavailable.querySelector('p');
                 if (p) {
                     if (weather.reason === 'too_far' && weather.availableFrom) {
-                        const now = new Date();
+                        const now = overrideNow || new Date();
                         if (weather.availableFrom > now) {
                             const dateStr = weather.availableFrom.toLocaleDateString(undefined, {
                                 month: 'short',

--- a/tests/circuit-weather-app.test.js
+++ b/tests/circuit-weather-app.test.js
@@ -1,25 +1,31 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // --- Global Mocks (same pattern as seo.test.js) ---
-const createMockElement = (id) => ({
-    id,
-    addEventListener: vi.fn(),
-    classList: {
-        add: vi.fn(),
-        remove: vi.fn(),
-        contains: vi.fn().mockReturnValue(true),
-        toggle: vi.fn(),
-    },
-    style: {},
-    setAttribute: vi.fn(),
-    removeAttribute: vi.fn(),
-    textContent: '',
-    value: '',
-    innerHTML: '',
-    disabled: false,
-    querySelector: vi.fn(() => createMockElement('child')),
-    appendChild: vi.fn(),
-});
+const createMockElement = (id) => {
+    const el = {
+        id,
+        addEventListener: vi.fn(),
+        classList: {
+            add: vi.fn(),
+            remove: vi.fn(),
+            contains: vi.fn().mockReturnValue(true),
+            toggle: vi.fn(),
+        },
+        style: {},
+        setAttribute: vi.fn(),
+        removeAttribute: vi.fn(),
+        textContent: '',
+        value: '',
+        innerHTML: '',
+        disabled: false,
+        querySelector: vi.fn((sel) => {
+            if (sel === 'p') return el._p || (el._p = createMockElement('p'));
+            return createMockElement('child');
+        }),
+        appendChild: vi.fn(),
+    };
+    return el;
+};
 
 const documentMock = {
     title: 'Circuit Weather — Live F1 Race Weather Radar & Forecasts',
@@ -474,6 +480,63 @@ describe('CircuitWeatherApp Pure Methods', () => {
 
             // forecastContent should not be modified since session IDs don't match
             expect(app.ui.forecastContent.style.display).toBeUndefined();
+        });
+
+        it('handles "too_far" with availableFrom in the past', () => {
+            const now = new Date('2024-04-02');
+            const weather = {
+                available: false,
+                reason: 'too_far',
+                availableFrom: new Date('2024-04-01')
+            };
+            app.renderForecast(weather, new Date(), 'race', now);
+
+            const p = app.ui.forecastUnavailable.querySelector('p');
+            expect(p.textContent).toBe('Forecast available shortly');
+        });
+
+        it('handles other unavailable reasons', () => {
+            const weather = { available: false, reason: 'unknown' };
+            app.renderForecast(weather, new Date(), 'race');
+
+            const p = app.ui.forecastUnavailable.querySelector('p');
+            expect(p.textContent).toBe('Forecast available closer to session');
+        });
+
+        it('handles "too_far" with availableFrom in the future', () => {
+             const now = new Date('2024-03-31');
+             const weather = {
+                 available: false,
+                 reason: 'too_far',
+                 availableFrom: new Date('2024-04-01T10:00:00')
+             };
+             app.renderForecast(weather, new Date(), 'race', now);
+
+             const p = app.ui.forecastUnavailable.querySelector('p');
+             // .toLocaleDateString output varies by locale, but we expect it to contain the date
+             expect(p.textContent).toContain('Forecast available from');
+        });
+
+        it('finds the closest hourly forecast point', () => {
+            const sessionTime = new Date('2024-03-01T14:00:00Z');
+            const weather = {
+                available: true,
+                current: { temperature_2m: 25 },
+                hourly: [
+                    { time: Math.floor(new Date('2024-03-01T13:00:00Z').getTime() / 1000), temp: 24, windSpeed: 10, windDir: 0, precipProb: 0, code: 0 },
+                    { time: Math.floor(new Date('2024-03-01T14:15:00Z').getTime() / 1000), temp: 26, windSpeed: 10, windDir: 0, precipProb: 0, code: 0 },
+                    { time: Math.floor(new Date('2024-03-01T16:00:00Z').getTime() / 1000), temp: 28, windSpeed: 10, windDir: 0, precipProb: 0, code: 0 },
+                ],
+                units: { temperature_2m: '°C', wind_speed_10m: 'km/h' }
+            };
+
+            app.renderForecast(weather, sessionTime, 'race');
+
+            // The closest point is 14:15 (26 degrees)
+            // We check that the primary temperature value is 26
+            expect(app.ui.forecastContent.innerHTML).toContain('id="weatherTemp">26°C</span>');
+            // 24 should still be in the timeline, but not the primary temp
+            expect(app.ui.forecastContent.innerHTML).toContain('<div>24°</div>');
         });
     });
 

--- a/tests/range-circles-logic.test.js
+++ b/tests/range-circles-logic.test.js
@@ -221,4 +221,41 @@ describe('RangeCircles Logic', () => {
             expect(rangeCircles.rangeColor).toBe('#e10600');
         });
     });
+
+    describe('Visibility & Clearing', () => {
+        beforeEach(() => {
+            rangeCircles = new RangeCircles(mockMap);
+        });
+
+        it('clears all layers including center marker', () => {
+            // Setup layers
+            const mockLabel = { addTo: vi.fn(), remove: vi.fn() };
+            rangeCircles.circles = [mockCircle];
+            rangeCircles.labels = [mockLabel];
+            rangeCircles.centerMarker = mockMarker;
+
+            rangeCircles.clear();
+
+            expect(mockMap.removeLayer).toHaveBeenCalledWith(mockCircle);
+            expect(mockMap.removeLayer).toHaveBeenCalledWith(mockLabel);
+            expect(mockMap.removeLayer).toHaveBeenCalledWith(mockMarker);
+            expect(rangeCircles.circles).toHaveLength(0);
+            expect(rangeCircles.labels).toHaveLength(0);
+            expect(rangeCircles.centerMarker).toBeNull();
+        });
+
+        it('updates visibility by redrawing if center is set', () => {
+            const spy = vi.spyOn(rangeCircles, 'draw').mockImplementation(() => {});
+
+            // No center -> no draw
+            rangeCircles.center = null;
+            rangeCircles.updateVisibility();
+            expect(spy).not.toHaveBeenCalled();
+
+            // Center set -> draw called
+            rangeCircles.center = [0, 0];
+            rangeCircles.updateVisibility();
+            expect(spy).toHaveBeenCalledWith([0, 0]);
+        });
+    });
 });

--- a/tests/track-layer.test.js
+++ b/tests/track-layer.test.js
@@ -40,6 +40,15 @@ vi.stubGlobal('document', documentMock);
 import { TrackLayer } from '../public/src/map/TrackLayer.js';
 import { CIRCUIT_MAP, CONFIG } from '../public/src/config.js';
 
+// Mock config to allow overriding frozen properties
+vi.mock('../public/src/config.js', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        CONFIG: { ...actual.CONFIG }
+    };
+});
+
 describe('TrackLayer', () => {
     let trackLayer;
     let mapMock;
@@ -201,5 +210,34 @@ describe('TrackLayer', () => {
         expect(mapMock.removeLayer).toHaveBeenCalledWith(layerMock);
         expect(trackLayer.layer).toBeNull();
         expect(trackLayer.currentCircuitId).toBeNull();
+    });
+
+    it('should handle unknown circuit ID', async () => {
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+        await trackLayer.loadTrack('non_existent_circuit');
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('No track map found'));
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should support full URL for trackApi (GitHub mode)', async () => {
+        const originalApi = CONFIG.trackApi;
+        // @ts-ignore - overriding for test
+        CONFIG.trackApi = 'https://raw.githubusercontent.com/bacinger/f1-circuits/master/circuits';
+
+        const circuitId = 'monaco';
+        const geoJsonId = CIRCUIT_MAP[circuitId];
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ type: 'FeatureCollection', features: [] })
+        });
+
+        await trackLayer.loadTrack(circuitId);
+
+        // Should include .geojson extension in GitHub mode
+        expect(fetchMock).toHaveBeenCalledWith(`${CONFIG.trackApi}/${geoJsonId}.geojson`);
+
+        // Restore
+        // @ts-ignore
+        CONFIG.trackApi = originalApi;
     });
 });

--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -183,6 +183,103 @@ describe('Worker Logic', () => {
       expect(data.radar.past).toEqual([]);
       expect(res.headers.get('X-Upstream-Status')).toBe('500');
     });
+
+    it('handles fetch exceptions gracefully', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const req = createRequest('/api/radar');
+      const res = await worker.fetch(req, global.env, global.ctx);
+
+      expect(res.status).toBe(502);
+      const data = await res.json();
+      expect(data.error).toBe('Failed to fetch radar data');
+    });
+
+    it('blocks invalid content-type from upstream radar', async () => {
+      mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' }
+      }));
+
+      const req = createRequest('/api/radar');
+      const res = await worker.fetch(req, global.env, global.ctx);
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      // Returns empty radar response for invalid content type
+      expect(data.radar.past).toEqual([]);
+    });
+
+    it('sets CORS headers when valid Origin is provided', async () => {
+      mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({ radar: { past: [] } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      }));
+
+      const req = createRequest('/api/radar', {
+        headers: { 'Origin': 'https://circuit-weather.racing' }
+      });
+      const res = await worker.fetch(req, global.env, global.ctx);
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://circuit-weather.racing');
+      expect(res.headers.get('Vary')).toBe('Origin');
+    });
+
+    it('handles upstream rate limit (429) for radar', async () => {
+      mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({ error: 'Rate Limit' }), {
+        status: 429,
+        headers: { 'Content-Type': 'application/json', 'Retry-After': '60' }
+      }));
+
+      const req = createRequest('/api/radar');
+      const res = await worker.fetch(req, global.env, global.ctx);
+
+      expect(res.status).toBe(429);
+      const data = await res.json();
+      expect(data.error).toBe('Upstream Rate Limit');
+      expect(res.headers.get('Retry-After')).toBe('60');
+    });
+
+    it('returns cached response for radar with valid origin', async () => {
+        const cachedData = { version: '2.0', host: 'https://x.com', radar: {} };
+        const cacheResponse = new Response(JSON.stringify(cachedData), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+        cacheStore.set('https://api.rainviewer.com/public/weather-maps.json', cacheResponse);
+
+        const req = createRequest('/api/radar', {
+          headers: { 'Origin': 'https://circuit-weather.racing' }
+        });
+        const res = await worker.fetch(req, global.env, global.ctx);
+
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual(cachedData);
+        expect(res.headers.get('X-Cache')).toBe('HIT');
+        expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://circuit-weather.racing');
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+    it('blocks radar request with invalid fetch destination', async () => {
+      const req = new Request('https://circuit-weather.racing/api/radar', {
+        headers: { 'Sec-Fetch-Dest': 'script', 'Sec-Fetch-Site': 'same-origin' }
+      });
+      const res = await worker.fetch(req, global.env, global.ctx);
+      expect(res.status).toBe(403);
+    });
+
+    it('returns radar response without CORS when origin is missing', async () => {
+        mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({ radar: { past: [] } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        }));
+
+        const req = createRequest('/api/radar'); // No Origin header by default
+        const res = await worker.fetch(req, global.env, global.ctx);
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
+      });
   });
 
   describe('Track Proxy (/api/track/*)', () => {


### PR DESCRIPTION
The CI was failing because branch coverage (90.28%) was slightly below the required threshold (90.29%). I analyzed the uncovered lines and added targeted unit tests to cover those branches. This included adding tests for error handling in the worker, edge cases in the track and range circle layers, and UI logic in the main app. I also made a small change to `CircuitWeatherApp.js` to allow overriding the current time in tests, which was necessary to cover the forecast availability logic.

Fixes #333

---
*PR created automatically by Jules for task [14286703899693898064](https://jules.google.com/task/14286703899693898064) started by @2fst4u*