### PR TITLE
🧪 Spec: Add autoSelectNextRound tests

### DIFF
--- a/tests/circuit-weather-app.test.js
+++ b/tests/circuit-weather-app.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // --- Global Mocks (same pattern as seo.test.js) ---
 const createMockElement = (id) => {
@@ -592,6 +592,102 @@ describe('CircuitWeatherApp Pure Methods', () => {
             app.ui.loadingOverlay = createMockElement('loadingOverlay');
             app.showLoading(false);
             expect(app.ui.loadingOverlay.classList.toggle).toHaveBeenCalledWith('visible', false);
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // autoSelectNextRound — outcome: correct round and session selected based on time
+    // ---------------------------------------------------------------
+    describe('autoSelectNextRound', () => {
+        beforeEach(() => {
+            // Setup races with sessions
+            app.races = [
+                {
+                    round: '1',
+                    name: 'Past GP',
+                    date: '2024-01-01',
+                    sessions: [{ id: 'race', date: '2024-01-01', time: '14:00:00' }]
+                },
+                {
+                    round: '2',
+                    name: 'Next GP',
+                    date: '2024-02-01',
+                    sessions: [
+                        { id: 'fp1', date: '2024-02-01', time: '10:00:00' },
+                        { id: 'race', date: '2024-02-03', time: '14:00:00' }
+                    ]
+                }
+            ];
+
+            // Mock UI elements
+            app.ui.roundSelect = createMockElement('roundSelect');
+            app.ui.sessionSelect = createMockElement('sessionSelect');
+
+            // Spy on methods called to verify side effects without executing them
+            vi.spyOn(app, 'selectRound').mockImplementation(() => {});
+            vi.spyOn(app, 'selectSession').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('selects the next race and its first future session', () => {
+            // Time: Before Round 2 FP1
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2024-01-15T12:00:00Z'));
+
+            app.autoSelectNextRound();
+
+            expect(app.selectRound).toHaveBeenCalledWith('2');
+            // The value is set on the DOM element too
+            expect(app.ui.roundSelect.value).toBe('2');
+
+            expect(app.selectSession).toHaveBeenCalledWith('fp1');
+            expect(app.ui.sessionSelect.value).toBe('fp1');
+        });
+
+        it('selects the next session if strictly between sessions (logic check)', () => {
+            // Time: After FP1 (Feb 1) but before Race (Feb 3)
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2024-02-02T12:00:00Z'));
+
+            app.autoSelectNextRound();
+
+            expect(app.selectRound).toHaveBeenCalledWith('2');
+            expect(app.selectSession).toHaveBeenCalledWith('race');
+        });
+
+        it('does nothing if no future races exist', () => {
+            // Time: Way in the future
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2025-01-01T00:00:00Z'));
+
+            app.autoSelectNextRound();
+
+            expect(app.selectRound).not.toHaveBeenCalled();
+            expect(app.selectSession).not.toHaveBeenCalled();
+        });
+
+        it('ignores sessions with missing date or time', () => {
+            // Setup a race with sessions missing time
+            app.races = [
+                 {
+                    round: '1',
+                    date: '2024-02-01',
+                    sessions: [
+                        { id: 'fp1', date: '2024-02-01' }, // Missing time
+                        { id: 'fp2', date: '2024-02-01', time: '14:00:00' }
+                    ]
+                 }
+            ];
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2024-01-01T00:00:00Z')); // Before everything
+
+            app.autoSelectNextRound();
+
+            // Should skip fp1 and pick fp2
+            expect(app.selectSession).toHaveBeenCalledWith('fp2');
         });
     });
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -16,10 +16,10 @@ export default defineConfig({
       ],
       // Coverage thresholds — CI will fail if coverage drops below these
       thresholds: {
-        lines: 86.63,
-        functions: 91.61,
-        branches: 90.29,
-        statements: 86.63,
+        lines: 87.14,
+        functions: 92.25,
+        branches: 90.34,
+        statements: 87.14,
       },
       // Report formats: text for CI logs, lcov for future GitHub integration
       reporter: ['text', 'text-summary'],


### PR DESCRIPTION
* 💡 What: Added unit tests for `autoSelectNextRound` in `CircuitWeatherApp.js` covering logic for future races, mid-weekend sessions, and missing data scenarios.
* 🎯 Why: This critical navigation logic was previously uncovered. The tests ensure users are correctly routed to the next relevant session based on the current time.
* 📈 Ratchet: Increased coverage thresholds in `vitest.config.js` to lock in gains:
    * Functions: +0.64%
    * Statements: +0.51%
    * Lines: +0.51%
    * Branches: +0.05%

---
*PR created automatically by Jules for task [10208349562040892123](https://jules.google.com/task/10208349562040892123) started by @2fst4u*