### PR TITLE
📚 Archivist: Document CI test coverage thresholds

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -101,3 +101,9 @@ Issue: The `enableCurrentWeather` flag was removed entirely after code review re
 Cause: Code review feedback indicated that the flag was unnecessary and the feature should be permanently enabled.
 Fix: Removed `FEATURE_FLAGS` from `public/src/config.js` and removed conditional checks in `public/src/CircuitWeatherApp.js`.
 Prevention: Revisit feature flags periodically to remove those that are no longer needed (e.g., permanently enabled features).
+
+2026-02-27 - Undocumented Test Coverage Thresholds
+Issue: vitest.config.js enforces strict coverage thresholds (Lines: 87.14%, etc.) which are not documented in AGENTS.md, causing CI failures for unaware contributors.
+Cause: CI configuration (vitest.config.js) was updated without reflecting changes in developer documentation.
+Fix: Documented the specific thresholds and the verification command in AGENTS.md.
+Prevention: Review vitest.config.js when updating testing documentation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,6 +328,21 @@ This project uses `vitest` for unit testing the Worker logic.
 npm test
 ```
 
+#### Test Coverage
+
+The CI pipeline enforces strict code coverage thresholds. Pull requests will fail if coverage drops below these values:
+
+- **Statements**: 87.14%
+- **Branches**: 90.34%
+- **Functions**: 92.25%
+- **Lines**: 87.14%
+
+To verify coverage locally before pushing:
+
+```bash
+npm run test:coverage
+```
+
 ### Terminating Background Processes
 
 > **Important for Google Antigravity**: The `send_command_input` tool's `Terminate` flag does **NOT** reliably kill background processes on this system. It may report success but the process continues running and holding its port. **Do not use it.** Instead, always use the following manual methods to stop background processes:


### PR DESCRIPTION
💡 Problem: The project's CI pipeline enforces strict test coverage thresholds (e.g., 87.14% line coverage), but these requirements were not documented in `AGENTS.md`. This could lead to unexpected build failures for contributors.

🎯 Fix: 
- Documented the specific coverage thresholds in `AGENTS.md` under a new "Test Coverage" subsection.
- Added the `npm run test:coverage` command to the documentation to encourage local verification.
- Recorded this learning in `.jules/archivist.md`.

🧪 Verification: Ran `npm run test:coverage` locally and confirmed that the output matches the newly documented thresholds.

🔎 Scope: Documentation only (`AGENTS.md` and `.jules/archivist.md`).

---
*PR created automatically by Jules for task [16775863100100919967](https://jules.google.com/task/16775863100100919967) started by @2fst4u*