### PR TITLE
🧪 Spec: Add tests for Weather Refresh Interval Logic

### DIFF
--- a/tests/circuit-weather-app.test.js
+++ b/tests/circuit-weather-app.test.js
@@ -724,6 +724,80 @@ describe('CircuitWeatherApp Pure Methods', () => {
     });
 
     // ---------------------------------------------------------------
+    // Weather Refresh Interval Logic
+    // ---------------------------------------------------------------
+    describe('Weather Refresh Interval Logic', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+            // Mock updateLiveWeatherForCircuit to track calls
+            app.updateLiveWeatherForCircuit = vi.fn();
+            app.currentCircuitCenter = [10, 20];
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+            if (app.weatherRefreshInterval) {
+                clearInterval(app.weatherRefreshInterval);
+            }
+        });
+
+        it('starts an interval that updates weather every 5 minutes', () => {
+            app.startWeatherRefreshInterval();
+
+            expect(app.updateLiveWeatherForCircuit).not.toHaveBeenCalled();
+
+            // Advance 5 minutes
+            vi.advanceTimersByTime(300000);
+            expect(app.updateLiveWeatherForCircuit).toHaveBeenCalledTimes(1);
+
+            // Advance another 5 minutes
+            vi.advanceTimersByTime(300000);
+            expect(app.updateLiveWeatherForCircuit).toHaveBeenCalledTimes(2);
+        });
+
+        it('clears existing interval before starting a new one', () => {
+            // Manually set a dummy interval ID
+            app.weatherRefreshInterval = 888;
+
+            // Spy on global.clearInterval
+            // Note: Since we use fake timers, we need to be careful.
+            // But here we just want to know if the function was called with the ID.
+            const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+
+            app.startWeatherRefreshInterval();
+
+            expect(clearIntervalSpy).toHaveBeenCalledWith(888);
+
+            expect(app.weatherRefreshInterval).not.toBe(888);
+            expect(app.weatherRefreshInterval).toBeTruthy();
+
+            clearIntervalSpy.mockRestore();
+        });
+
+        it('updateLiveWeatherForCircuit fetches forecast when circuit is selected', async () => {
+             // We need to restore the mock since we overwrote it in beforeEach
+             app.updateLiveWeatherForCircuit = CircuitWeatherApp.prototype.updateLiveWeatherForCircuit.bind(app);
+             app.currentCircuitCenter = [26.0, 50.0];
+
+             await app.updateLiveWeatherForCircuit();
+
+             expect(app.weatherClient.getForecast).toHaveBeenCalledWith(26.0, 50.0, expect.any(Date));
+             expect(app.mapWeatherWidget.update).toHaveBeenCalled();
+        });
+
+        it('updateLiveWeatherForCircuit returns early if no circuit is selected', async () => {
+            // We need to restore the mock since we overwrote it in beforeEach
+            app.updateLiveWeatherForCircuit = CircuitWeatherApp.prototype.updateLiveWeatherForCircuit.bind(app);
+            app.currentCircuitCenter = null;
+
+            await app.updateLiveWeatherForCircuit();
+
+            expect(app.weatherClient.getForecast).not.toHaveBeenCalled();
+            expect(app.mapWeatherWidget.update).not.toHaveBeenCalled();
+        });
+    });
+
+    // ---------------------------------------------------------------
     // Session Forecast Interval Logic
     // ---------------------------------------------------------------
     describe('Session Forecast Interval Logic', () => {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -16,10 +16,10 @@ export default defineConfig({
       ],
       // Coverage thresholds — CI will fail if coverage drops below these
       thresholds: {
-        lines: 91.37,
-        functions: 96.12,
-        branches: 92.10,
-        statements: 91.37,
+        lines: 91.64,
+        functions: 96.77,
+        branches: 92.26,
+        statements: 91.64,
       },
       // Report formats: text for CI logs, lcov for future GitHub integration
       reporter: ['text', 'text-summary'],


### PR DESCRIPTION
This PR adds robust unit tests for the weather refresh interval logic within `CircuitWeatherApp`. It ensures that the 5-minute polling mechanism works correctly, clears previous intervals to prevent leaks, and only fetches data when a circuit is selected. The coverage thresholds have been increased to reflect the new test coverage, adhering to the project's ratchet rule.

---
*PR created automatically by Jules for task [7196648558574205544](https://jules.google.com/task/7196648558574205544) started by @2fst4u*