### PR TITLE
🧹 Sweep: Remove redundant keys from COUNTRY_CODES

### DIFF
--- a/public/src/config.js
+++ b/public/src/config.js
@@ -32,7 +32,7 @@ export const COUNTRY_CODES = {
     'Hungary': 'hu', 'Italy': 'it', 'Japan': 'jp', 'Mexico': 'mx',
     'Monaco': 'mc', 'Netherlands': 'nl', 'Qatar': 'qa', 'Saudi Arabia': 'sa',
     'Singapore': 'sg', 'Spain': 'es', 'UAE': 'ae', 'UK': 'gb',
-    'USA': 'us', 'United States': 'us', 'Las Vegas': 'us', 'Miami': 'us',
+    'USA': 'us', 'United States': 'us',
 };
 // SEC: Prevent runtime tampering with country codes
 Object.freeze(COUNTRY_CODES);


### PR DESCRIPTION
Removes unused/redundant city-level keys ('Las Vegas', 'Miami') from the `COUNTRY_CODES` configuration object. These keys were unnecessary because the F1 API provides standard country names ("USA") for these races, which are already covered by the configuration. This cleanup reduces configuration noise without altering application behavior.

---
*PR created automatically by Jules for task [9572879585947702529](https://jules.google.com/task/9572879585947702529) started by @2fst4u*