### PR TITLE
🧹 Sweep: Remove debug log from TrackLayer

### DIFF
--- a/public/src/map/TrackLayer.js
+++ b/public/src/map/TrackLayer.js
@@ -51,7 +51,6 @@ export class TrackLayer {
 
         const geoJsonId = CIRCUIT_MAP[circuitId];
         if (!geoJsonId) {
-            console.log(`No track map found for circuit: ${circuitId}`);
             return;
         }
 

--- a/tests/track-layer.test.js
+++ b/tests/track-layer.test.js
@@ -213,9 +213,7 @@ describe('TrackLayer', () => {
     });
 
     it('should handle unknown circuit ID', async () => {
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
         await trackLayer.loadTrack('non_existent_circuit');
-        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('No track map found'));
         expect(fetchMock).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
Removed a stray `console.log` from `public/src/map/TrackLayer.js` which was logging "No track map found for circuit: ..." when a circuit ID was not found in the map. This was identified as a leftover debug artifact.

Also updated the corresponding unit test in `tests/track-layer.test.js` to remove the expectation for the log call, ensuring the test suite remains green.

This cleanup aligns with the goal of keeping the codebase free of unnecessary clutter and debug artifacts.

---
*PR created automatically by Jules for task [6013433366445510882](https://jules.google.com/task/6013433366445510882) started by @2fst4u*