### PR TITLE
📚 Archivist: Fix phantom npm commands and test scope in AGENTS.md

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -113,3 +113,7 @@ Issue: The actual test coverage thresholds in `vitest.config.js` were stricter (
 Cause: `vitest.config.js` was updated to enforce higher quality standards, but the documentation was not updated to reflect this change.
 Fix: Removed explicit thresholds from `AGENTS.md` in favor of referencing `vitest.config.js` as the single source of truth.
 Prevention: Avoid duplicating configuration values in documentation; reference the config file instead.
+
+## 2026-03-01 - Phantom Package Manager Instructions
+**Learning:** `AGENTS.md` contained multiple `npm` commands (`npm install`, `npm test`, etc.) despite the project memory indicating the use of `pnpm` (evidenced by `pnpm-lock.yaml`). Additionally, the documentation claimed `vitest` only tested "the Worker logic," whereas `vitest.config.js` explicitly includes `public/src/**/*.js` (frontend components).
+**Action:** Updated all `npm` references to `pnpm` in `AGENTS.md` and corrected the scope of `vitest` to include frontend components to match the test runner configuration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,7 +286,7 @@ mode = "smart"
 1. **No ad-hoc test files** - Scripts like `verify_*.py`, `test_*.js`, or similar should not be committed
 2. **No screenshots or artifacts** - Files like `verification.png`, `debug_output.txt`, etc. must be deleted after use
 3. **Clean up after yourself** - If you create temporary files for testing, remove them before completing your task
-4. **Use proper test locations** - Persistent unit tests should be placed in the `tests/` directory and must pass `npm test`.
+4. **Use proper test locations** - Persistent unit tests should be placed in the `tests/` directory and must pass `pnpm test`.
 
 ### If You Find Orphaned Test Files
 
@@ -306,12 +306,12 @@ This project uses [Cloudflare Workers](https://workers.cloudflare.com/) to proxy
 3.  **Install dependencies.**
     Run the following command in your terminal at the root of the project:
     ```bash
-    npm install
+    pnpm install
     ```
 4.  **Start the local development server.**
     Run the following command:
     ```bash
-    npm run dev
+    pnpm run dev
     # OR
     npx wrangler dev
     ```
@@ -322,10 +322,10 @@ This setup faithfully reproduces the production environment, running both the fr
 
 ### Running Tests
 
-This project uses `vitest` for unit testing the Worker logic.
+This project uses `vitest` for unit testing both the Worker logic and frontend components.
 
 ```bash
-npm test
+pnpm test
 ```
 
 #### Test Coverage
@@ -335,7 +335,7 @@ The CI pipeline enforces strict code coverage thresholds defined in `vitest.conf
 To verify coverage locally before pushing:
 
 ```bash
-npm run test:coverage
+pnpm run test:coverage
 ```
 
 ### Terminating Background Processes


### PR DESCRIPTION
💡 Problem: `AGENTS.md` incorrectly instructed developers to use `npm` (`npm install`, `npm run dev`, `npm test`) despite the project strictly using `pnpm` (as evidenced by `pnpm-lock.yaml`). It also inaccurately claimed that `vitest` was only configured for testing "the Worker logic," when the configuration explicitly includes the frontend components (`public/src/**/*.js`).
🎯 Fix: Replaced all phantom `npm` commands with `pnpm` equivalents in `AGENTS.md`. Updated the "Running Tests" section to accurately reflect that the suite covers both the Worker logic and frontend components. Appended a journal entry to `.jules/archivist.md` detailing the correction.
🧪 Verification: Confirmed `pnpm` usage via project files (`pnpm-lock.yaml`). Confirmed test scope via `vitest.config.js`. Ran `pnpm install` and `pnpm run test:coverage` successfully locally.
🔎 Scope: This PR contains ONLY documentation changes.

---
*PR created automatically by Jules for task [18061408229211234603](https://jules.google.com/task/18061408229211234603) started by @2fst4u*