### PR TITLE
🧹 Sweep: Remove unused `centerLat` variable

### DIFF
--- a/public/src/map/RangeCircles.js
+++ b/public/src/map/RangeCircles.js
@@ -187,7 +187,6 @@ export class RangeCircles {
         // Calculate dynamic steps based on current view bounds
         const bounds = this.map.getBounds();
         const north = bounds.getNorth();
-        const centerLat = center[0];
 
         // Approximate visible radius in meters (center to top edge)
         // This is a rough heuristic to ensure rings fit on screen


### PR DESCRIPTION
### 💡 What:
Removed the unused `const centerLat = center[0];` declaration from the `calculateSteps` method in `public/src/map/RangeCircles.js`.

### 🎯 Why:
This variable was declared and assigned, but never used anywhere inside the function or the rest of the file. It is dead code and adds unnecessary cognitive load. The assignment (`center[0]`) had no side effects, so its removal is 100% safe.

### 🔬 Verification:
Ran `grep -rn "centerLat" public/src/map/RangeCircles.js` which confirmed its only existence was the declaration.
Ran `npm run test` and `npm run test:coverage` to confirm the application functions exactly as before and no tests/regressions were triggered. No coverage was lost.

---
*PR created automatically by Jules for task [15345537777189761972](https://jules.google.com/task/15345537777189761972) started by @2fst4u*