### PR TITLE
🧹 Sweep: Remove leftover patch script

### DIFF
--- a/patch_file_3.py
+++ b/patch_file_3.py
@@ -1,9 +1,0 @@
-import re
-
-with open('tests/privacy-modal.test.js', 'r') as f:
-    content = f.read()
-
-content = content.replace("clickHandler();", "clickHandler({ preventDefault: vi.fn() });")
-
-with open('tests/privacy-modal.test.js', 'w') as f:
-    f.write(content)


### PR DESCRIPTION
💡 **What:** Deleted the leftover script `patch_file_3.py` from the root directory.
🎯 **Why:** This file was clearly a temporary artifact used to patch the `tests/privacy-modal.test.js` file (by adding `preventDefault: vi.fn()` to a click handler). It serves no active purpose in the application's runtime or build process and is simply repository clutter.
🔬 **Verification:** 
- Inspected the contents of `patch_file_3.py` which confirmed it was a one-off Python script for string replacement.
- Ran `git grep "patch_file_3.py"` and confirmed the script is not referenced or imported anywhere else in the codebase.
- Ran the full test suite (`pnpm test`), which passed successfully, proving the deletion is safe and causes no regressions.

---
*PR created automatically by Jules for task [5736353204206121800](https://jules.google.com/task/5736353204206121800) started by @2fst4u*