### PR TITLE
📚 Archivist: Update CI pipeline to use pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 9
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
+        cache: 'pnpm'
     - name: Install dependencies
-      run: npm ci
+      run: pnpm install --frozen-lockfile
     - name: Run tests with coverage
-      run: npm run test:coverage
+      run: pnpm run test:coverage

--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -117,3 +117,7 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 ## 2026-03-01 - Phantom Package Manager Instructions
 **Learning:** `AGENTS.md` contained multiple `npm` commands (`npm install`, `npm test`, etc.) despite the project memory indicating the use of `pnpm` (evidenced by `pnpm-lock.yaml`). Additionally, the documentation claimed `vitest` only tested "the Worker logic," whereas `vitest.config.js` explicitly includes `public/src/**/*.js` (frontend components).
 **Action:** Updated all `npm` references to `pnpm` in `AGENTS.md` and corrected the scope of `vitest` to include frontend components to match the test runner configuration.
+
+## 2026-03-02 - CI Pipeline Package Manager Drift
+**Learning:** The project strictly uses `pnpm` (configured via `pnpm-lock.yaml` and documented in `AGENTS.md`), but the automated CI workflow (`.github/workflows/ci.yml`) was still using `npm ci` and `npm run test:coverage`. This caused a discrepancy between local test environments and the CI pipeline.
+**Action:** Updated `ci.yml` to use `pnpm/action-setup@v4` with `pnpm install --frozen-lockfile` to ensure exact matching behavior between local development and CI execution.


### PR DESCRIPTION
💡 Problem: The repository strictly uses `pnpm` for local dependency management, tests, and documentation, but the GitHub Actions CI workflow (`.github/workflows/ci.yml`) was using outdated `npm ci` and `npm run test:coverage` commands. This caused ambiguity and drift between local and CI test environments.
🎯 Fix: Updated `.github/workflows/ci.yml` to use `pnpm/action-setup@v4` with `pnpm install --frozen-lockfile` and `pnpm run test:coverage`. Added a journal entry to `.jules/archivist.md` to document this fix.
🧪 Verification: Confirmed changes locally using `pnpm install --frozen-lockfile && pnpm run test:coverage` passing all tests. Used `read_file` to ensure `ci.yml` syntax was correctly written.
🔎 Scope: Confirmation that this PR contains ONLY documentation and configuration changes.

---
*PR created automatically by Jules for task [8872282423900272886](https://jules.google.com/task/8872282423900272886) started by @2fst4u*