### PR TITLE
🔭 Scout: Add missing Open Graph and Twitter Image metadata

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,11 @@
     <meta property="og:title" content="Circuit Weather — Live F1 Race Weather Radar &amp; Forecasts">
     <meta property="og:description" content="Real-time weather radar and forecasts for every Formula 1 circuit. Track rain and conditions live during every Grand Prix session.">
     <meta property="og:image" content="https://circuit-weather.racing/icon-512.png">
+    <!-- Scout: Added explicit image dimensions and alt text to ensure proper rendering in social feeds before image load, and improve accessibility. -->
+    <meta property="og:image:width" content="512">
+    <meta property="og:image:height" content="512">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:image:alt" content="Circuit Weather Logo">
     <meta property="og:site_name" content="Circuit Weather">
     <meta property="og:locale" content="en_NZ">
 
@@ -23,6 +28,8 @@
     <meta name="twitter:title" content="Circuit Weather — Live F1 Race Weather Radar &amp; Forecasts">
     <meta name="twitter:description" content="Real-time weather radar and forecasts for every Formula 1 circuit. Track rain and conditions live during every Grand Prix session.">
     <meta name="twitter:image" content="https://circuit-weather.racing/icon-512.png">
+    <!-- Scout: Added twitter:image:alt to provide alternative text for screen readers viewing Twitter cards. -->
+    <meta name="twitter:image:alt" content="Circuit Weather Logo">
 
     <link rel="canonical" href="https://circuit-weather.racing">
     <meta name="referrer" content="strict-origin-when-cross-origin">


### PR DESCRIPTION
💡 **What:** Added explicit metadata tags (`width`, `height`, `type`, `alt`) for the Open Graph image and an `alt` tag for the Twitter image in `public/index.html`. Included HTML comments explaining the SEO and accessibility value.
🎯 **Why:** To improve how social sharing platforms (like Facebook, LinkedIn, Twitter) render link previews, ensuring images display correctly before they fully load, and providing alternative text for screen readers viewing these cards.
📊 **Value:** Better social media discoverability and improved accessibility for link previews.
🔬 **Measurement:** Verify the DOM output contains `<meta property="og:image:width" content="512">`, `<meta property="og:image:height" content="512">`, `<meta property="og:image:type" content="image/png">`, `<meta property="og:image:alt" content="Circuit Weather Logo">`, and `<meta name="twitter:image:alt" content="Circuit Weather Logo">`.

---
*PR created automatically by Jules for task [18079276416748129265](https://jules.google.com/task/18079276416748129265) started by @2fst4u*