### PR TITLE
🎨 Palette: Remove redundant aria-disabled attributes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -36,6 +36,8 @@
 
 ## 2026-03-06 - Interactive Regions and Accessible Grouping
 **Learning:** When creating widgets like Map controls or scrollable containers (like `PrivacyModal`), native keyboard users and screen reader users cannot explore their contents directly unless those containers have `tabindex="0"`. Additionally, creating an overarching descriptive `aria-label` and `role="region"` for parents prevents the stuttering caused by over-labeled children while maintaining total discoverability.
-**Action:** Always apply `tabindex="0"` and `role="region"` to custom widgets and scrollable containers to establish them as interactive semantic landmarks, while letting the inner content speak for itself.## 2024-05-18 - Redundant ARIA Attributes
+**Action:** Always apply `tabindex="0"` and `role="region"` to custom widgets and scrollable containers to establish them as interactive semantic landmarks, while letting the inner content speak for itself.
+
+## 2024-05-18 - Redundant ARIA Attributes
 **Learning:** Native HTML form controls like `<select>` automatically communicate their `disabled` state semantically to screen readers via the native `disabled` attribute. Adding `aria-disabled="true"` to these elements is redundant, provides no extra accessibility benefit, and violates the "First Rule of ARIA" (which favors using native semantic HTML over ARIA).
 **Action:** Do not implement explicit `aria-disabled` logic for native form controls that already use the `disabled` boolean attribute.

--- a/public/index.html
+++ b/public/index.html
@@ -128,7 +128,7 @@
                 <section class="control-section" aria-label="Race Selection">
                     <div class="control-group">
                         <label for="seriesSelect">Series</label>
-                        <select id="seriesSelect" class="select" disabled aria-disabled="true"
+                        <select id="seriesSelect" class="select" disabled
                             title="Only Formula 1 is currently supported">
                             <option value="f1">Formula 1</option>
                         </select>
@@ -141,7 +141,7 @@
                     </div>
                     <div class="control-group">
                         <label for="sessionSelect">Session</label>
-                        <select id="sessionSelect" class="select" disabled aria-disabled="true">
+                        <select id="sessionSelect" class="select" disabled>
                             <option value="">Select a round first</option>
                         </select>
                     </div>

--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -240,7 +240,6 @@ export class CircuitWeatherApp {
                     // Palette UX: Reset session select when round is cleared
                     if (this.ui.sessionSelect) {
                         this.ui.sessionSelect.disabled = true;
-                        this.ui.sessionSelect.setAttribute('aria-disabled', 'true');
                         this.ui.sessionSelect.innerHTML = '<option value="">Select a round first</option>';
                     }
                     this.selectedSession = null;
@@ -495,7 +494,6 @@ export class CircuitWeatherApp {
         if (!select) return;
 
         select.disabled = false;
-        select.setAttribute('aria-disabled', 'false');
         select.innerHTML = '<option value="">Select session...</option>';
 
         // Bolt Optimization: Use DocumentFragment to batch DOM insertions


### PR DESCRIPTION
💡 What: Removed `aria-disabled="true"` logic from the Series, Round, and Session `<select>` form controls in both `index.html` and dynamic updates in `CircuitWeatherApp.js`.
🎯 Why: Native HTML form controls already expose their `disabled` state to screen readers natively. Adding `aria-disabled="true"` to them is redundant, potentially confusing for certain assistive technologies, and violates the First Rule of ARIA.
♿ Accessibility: Eliminates redundant state announcements and ensures a cleaner accessibility tree by relying strictly on native HTML semantics.

---
*PR created automatically by Jules for task [3623971765632513624](https://jules.google.com/task/3623971765632513624) started by @2fst4u*