### PR TITLE
📚 Archivist: Clarify complete list of proxied services in README

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -115,9 +115,16 @@ Fix: Removed explicit thresholds from `AGENTS.md` in favor of referencing `vites
 Prevention: Avoid duplicating configuration values in documentation; reference the config file instead.
 
 ## 2026-03-01 - Phantom Package Manager Instructions
+
 **Learning:** `AGENTS.md` contained multiple `npm` commands (`npm install`, `npm test`, etc.) despite the project memory indicating the use of `pnpm` (evidenced by `pnpm-lock.yaml`). Additionally, the documentation claimed `vitest` only tested "the Worker logic," whereas `vitest.config.js` explicitly includes `public/src/**/*.js` (frontend components).
 **Action:** Updated all `npm` references to `pnpm` in `AGENTS.md` and corrected the scope of `vitest` to include frontend components to match the test runner configuration.
 
 ## 2026-03-02 - CI Pipeline Package Manager Drift
+
 **Learning:** The project strictly uses `pnpm` (configured via `pnpm-lock.yaml` and documented in `AGENTS.md`), but the automated CI workflow (`.github/workflows/ci.yml`) was still using `npm ci` and `npm run test:coverage`. This caused a discrepancy between local test environments and the CI pipeline.
 **Action:** Updated `ci.yml` to use `pnpm/action-setup@v4` with `pnpm install --frozen-lockfile` to ensure exact matching behavior between local development and CI execution.
+
+## 2026-03-03 - Incomplete Proxied Services in README
+
+**Learning:** `README.md` claimed "All API requests (Jolpica F1, RainViewer) are proxied" but omitted GitHub (track data) and Unpkg (Leaflet assets), which were later proxied for CSP compliance and privacy.
+**Action:** Always cross-reference `README.md` architecture claims with `worker.js` and `PRIVACY.md` when asset or data fetching strategies evolve.

--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ This web app is completely and unashamedly vibe coded primarily with the use of 
 The site provides a live weather radar overlay on top of the circuit map. You can see past weather movement and a short-term forecast to predict if rain is incoming. It automatically loads the schedule for the current F1 season, allowing you to jump between different rounds and sessions (like Qualifying or the Race).
 
 Key features include:
-*   **Live Radar:** Visualise rain moving across the track with a 2-hour history.
-*   **Race Schedule:** Browse all circuits from the current F1 season with session start times.
-*   **Distance Markers:** Toggle range circles to gauge how far the rain is from the track (in km or miles).
-*   **Theme Support:** Automatically adapts to your system's dark or light mode, or you can toggle it manually.
-*   **Deep Linking:** Navigate directly to a specific race or session via the URL.
-*   **Responsive Design:** Works great on your phone, tablet, or desktop.
-*   **Installable PWA:** Add to your home screen on mobile for a native app-like experience — no app store required.
+
+- **Live Radar:** Visualise rain moving across the track with a 2-hour history.
+- **Race Schedule:** Browse all circuits from the current F1 season with session start times.
+- **Distance Markers:** Toggle range circles to gauge how far the rain is from the track (in km or miles).
+- **Theme Support:** Automatically adapts to your system's dark or light mode, or you can toggle it manually.
+- **Deep Linking:** Navigate directly to a specific race or session via the URL.
+- **Responsive Design:** Works great on your phone, tablet, or desktop.
+- **Installable PWA:** Add to your home screen on mobile for a native app-like experience — no app store required.
 
 ## How it works
 
@@ -30,19 +31,19 @@ The application is built with vanilla HTML, CSS, and native ES modules, keeping 
 
 The frontend is organised into small, maintainable modules located in `public/src/`. It uses native browser support for ES modules (`import`/`export`), which means there is **no build step** required. The files are served directly as-is, making the development workflow extremely simple.
 
-All API requests (Jolpica F1, RainViewer) are proxied through a **Cloudflare Worker** to cache data at the edge and protect user privacy. Weather forecasts are fetched directly from Open-Meteo by the client to ensure reliability. Optimised **512px tile caching** is used to reduce request volume by 75% compared to standard implementations.
+External API and asset requests (Jolpica F1, RainViewer, GitHub for track layouts, and Unpkg for Leaflet assets) are proxied through a **Cloudflare Worker** to cache data at the edge, enforce strict Content Security Policy (CSP), and protect user privacy. Weather forecasts are fetched directly from Open-Meteo by the client to ensure reliability. Optimised **512px tile caching** is used to reduce request volume by 75% compared to standard implementations.
 
 The map tiles are provided by Carto (based on OpenStreetMap data), ensuring a clean look that works well with the weather overlays.
-
 
 ## Credits
 
 Huge thanks to the free APIs and data sources that make this possible:
-*   **Jolpica F1** for the race data.
-*   **RainViewer** for the weather radar.
-*   **Open-Meteo** for the weather forecasts.
-*   **Carto & OpenStreetMap** for the map tiles.
-*   **bacinger/f1-circuits** for the circuit track data.
+
+- **Jolpica F1** for the race data.
+- **RainViewer** for the weather radar.
+- **Open-Meteo** for the weather forecasts.
+- **Carto & OpenStreetMap** for the map tiles.
+- **bacinger/f1-circuits** for the circuit track data.
 
 ## License
 


### PR DESCRIPTION
📚 Archivist: Clarify complete list of proxied services in README

💡 Problem: The `README.md` claimed "All API requests (Jolpica F1, RainViewer) are proxied", which was incomplete. It omitted GitHub (track data) and Unpkg (Leaflet assets) that were later added to the worker proxy for strict CSP compliance and privacy.
🎯 Fix: Updated `README.md` to accurately reflect that external API and asset requests (including GitHub and Unpkg) are proxied through the Cloudflare Worker.
🧪 Verification: Cross-referenced `worker.js` and `PRIVACY.md` to confirm all proxied services. Ran `pnpm test` and `npx prettier`.
🔎 Scope: Documentation change only. Added learning to `.jules/archivist.md`.

---
*PR created automatically by Jules for task [13865018848422452521](https://jules.google.com/task/13865018848422452521) started by @2fst4u*