### PR TITLE
🎨 Palette: Sync radar playback speed tooltip with state

### DIFF
--- a/public/src/map/WeatherRadar.js
+++ b/public/src/map/WeatherRadar.js
@@ -115,6 +115,7 @@ export class WeatherRadar {
             // Palette Accessibility: Update ARIA label with current state
             if (this.ui.speedBtn) {
                 this.ui.speedBtn.setAttribute('aria-label', `Playback speed: ${label}`);
+                this.ui.speedBtn.setAttribute('title', `Playback speed: ${label}`);
             }
         }
     }


### PR DESCRIPTION
💡 **What:** Added dynamic updating of the `title` attribute to the radar playback speed button in `WeatherRadar.js` to perfectly match its dynamically updated `aria-label`. 
🎯 **Why:** Previously, the `aria-label` updated (e.g. "Playback speed: 2x") but the `title` tooltip remained static ("Playback speed"), creating an informational disparity where screen reader users received more state context than mouse/hover users.
♿ **Accessibility:** This UX improvement ensures consistent state communication across all user interaction paradigms (hover vs. screen reader) for an icon-only button without needing additional visible text.

---
*PR created automatically by Jules for task [4039241491855191220](https://jules.google.com/task/4039241491855191220) started by @2fst4u*