### PR TITLE
🧪 Spec: Add worker.js CORS proxy test coverage

### DIFF
--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -136,12 +136,32 @@ describe('Worker Logic', () => {
       });
       cacheStore.set('https://api.jolpi.ca/ergast/f1/current', cacheResponse);
 
-      const req = createRequest('/api/f1/current');
+      const req = createRequest('/api/f1/current', {
+        headers: { 'Origin': 'https://circuit-weather.racing' }
+      });
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual(cachedData);
       expect(res.headers.get('X-Cache')).toBe('HIT');
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://circuit-weather.racing');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns cached response without CORS when origin is missing', async () => {
+      const cachedData = { cached: true };
+      const cacheResponse = new Response(JSON.stringify(cachedData), {
+        headers: { 'Content-Type': 'application/json' }
+      });
+      cacheStore.set('https://api.jolpi.ca/ergast/f1/current', cacheResponse);
+
+      const req = createRequest('/api/f1/current'); // No Origin header by default
+      const res = await worker.fetch(req, global.env, global.ctx);
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(cachedData);
+      expect(res.headers.get('X-Cache')).toBe('HIT');
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
@@ -257,6 +277,23 @@ describe('Worker Logic', () => {
         expect(await res.json()).toEqual(cachedData);
         expect(res.headers.get('X-Cache')).toBe('HIT');
         expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://circuit-weather.racing');
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+    it('returns cached response for radar without CORS when origin is missing', async () => {
+        const cachedData = { version: '2.0', host: 'https://x.com', radar: {} };
+        const cacheResponse = new Response(JSON.stringify(cachedData), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+        cacheStore.set('https://api.rainviewer.com/public/weather-maps.json', cacheResponse);
+
+        const req = createRequest('/api/radar');
+        const res = await worker.fetch(req, global.env, global.ctx);
+
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual(cachedData);
+        expect(res.headers.get('X-Cache')).toBe('HIT');
+        expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
         expect(mockFetch).not.toHaveBeenCalled();
       });
 
@@ -462,6 +499,15 @@ describe('Worker Logic', () => {
 
       expect(res.status).toBe(500);
       expect(res.headers.get('X-Upstream-Status')).toBe('500');
+    });
+
+    it('handles fetch exceptions gracefully', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const req = createRequest('/api/tiles/v2/radar/error.png');
+      const res = await worker.fetch(req, global.env, global.ctx);
+
+      expect(res.status).toBe(502);
     });
   });
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -16,10 +16,10 @@ export default defineConfig({
       ],
       // Coverage thresholds — CI will fail if coverage drops below these
       thresholds: {
-        lines: 94.47,
+        lines: 94.56,
         functions: 98.11,
-        branches: 92.84,
-        statements: 94.47,
+        branches: 93.06,
+        statements: 94.56,
       },
       // Report formats: text for CI logs, lcov for future GitHub integration
       reporter: ['text', 'text-summary'],


### PR DESCRIPTION
💡 What: Added unit tests for F1 API proxy caching, Radar API proxy caching without origins, and fetch exceptions gracefully returning 502 for the tile proxy.
🎯 Why: Covered edge cases with Cloudflare Worker routing regarding missing origin headers and fetch failures.
📈 Ratchet: Increased statement coverage threshold by 0.09% (from 94.47 to 94.56), lines by 0.09% (from 94.47 to 94.56), and branches by 0.22% (from 92.84 to 93.06) to lock in the gain from these new tests.

---
*PR created automatically by Jules for task [4874649707200813837](https://jules.google.com/task/4874649707200813837) started by @2fst4u*