### PR TITLE
📚 Archivist: Update src/worker.js docstring

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -133,3 +133,8 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 
 **Learning:** `AGENTS.md` omitted "Weather Forecast" (Open-Meteo) from its "Core Features" section and "Testing Checklist", even though the feature was fully implemented, documented in `PRIVACY.md` and `README.md`, and is a primary value proposition of the app.
 **Action:** Added the "Weather Forecast" feature and its verification step to `AGENTS.md` to ensure a single source of truth for application capabilities and testing requirements.
+
+## 2026-03-05 - Incomplete Worker API Route Documentation
+
+**Learning:** The docstring at the top of `src/worker.js` only listed `/api/f1/*` as the handled route, despite the worker expanding to proxy multiple other services (e.g., `/api/health`, `/api/radar`, `/api/tiles/*`, `/api/track/*`, `/api/assets/*`) for caching and CSP compliance. This caused ambiguity for developers reading the entry point.
+**Action:** Updated the `src/worker.js` header docstring to list all actively handled API proxy routes to match the actual `fetch` handler implementation.

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,8 +1,13 @@
 /**
  * Cloudflare Worker with Asset Handling
  * 
- * Handles:
- * 1. API proxy requests to /api/f1/*
+ * Handles API proxy requests to:
+ * - /api/f1/*
+ * - /api/health
+ * - /api/radar
+ * - /api/tiles/*
+ * - /api/track/*
+ * - /api/assets/*
  * 
  * Static assets and SPA fallback are handled by Cloudflare's asset configuration
  * via wrangler.toml's run_worker_first and not_found_handling settings.


### PR DESCRIPTION
💡 **Problem:** The docstring at the top of `src/worker.js` only listed `/api/f1/*` as the handled API proxy route. However, the Cloudflare Worker was expanded to proxy multiple other services (e.g., `/api/health`, `/api/radar`, `/api/tiles/*`, `/api/track/*`, `/api/assets/*`) for caching and strict CSP compliance, creating out-of-date guidance for developers reading the entry point file.

🎯 **Fix:** Updated the `src/worker.js` header docstring to correctly list all actively handled API proxy routes to perfectly match the true behavior of the `fetch` handler. Also added a journal entry in `.jules/archivist.md` mapping the issue and resolution.

🧪 **Verification:**
- Verified that `src/worker.js` explicitly parses and handles the added routes in its `fetch` handler code.
- Successfully executed `pnpm run test:coverage` passing all 529 tests and satisfying the strict `vitest` thresholds.
- Verified that `npx prettier --write .jules/archivist.md` ran and formatted the journal file.

🔎 **Scope:** This PR strictly contains documentation changes (docstring update in the source code file and the agent journal). No application logic or product behavior was modified.

---
*PR created automatically by Jules for task [721986949154834101](https://jules.google.com/task/721986949154834101) started by @2fst4u*