### PR TITLE
Refine "Live" Indicator for Race Rounds

### DIFF
--- a/public/src/utils/status.js
+++ b/public/src/utils/status.js
@@ -37,6 +37,7 @@ export function getRoundStatus(race, now) {
     // Find earliest start and latest end
     let minStart = null;
     let maxEnd = null;
+    let anySessionLive = false;
 
     race.sessions.forEach(session => {
         if (!session.date || !session.time) return;
@@ -49,12 +50,18 @@ export function getRoundStatus(race, now) {
 
         if (!minStart || start < minStart) minStart = start;
         if (!maxEnd || end > maxEnd) maxEnd = end;
+
+        if (now >= start && now <= end) {
+            anySessionLive = true;
+        }
     });
 
     if (!minStart || !maxEnd) return 'UNKNOWN';
 
-    if (now >= minStart && now <= maxEnd) {
+    if (anySessionLive) {
         return 'LIVE';
+    } else if (now >= minStart && now <= maxEnd) {
+        return 'CURRENT';
     } else if (now < minStart) {
         return 'FUTURE';
     } else {
@@ -65,13 +72,16 @@ export function getRoundStatus(race, now) {
 /**
  * Formats a label with status indicators.
  * @param {string} label - The original label.
- * @param {string} status - The status ('LIVE', 'FUTURE', 'PAST').
+ * @param {string} status - The status ('LIVE', 'FUTURE', 'PAST', 'CURRENT').
  * @param {boolean} isNext - Whether this item is the next upcoming one.
  * @returns {string} - The formatted label.
  */
 export function formatStatusLabel(label, status, isNext) {
     if (status === 'LIVE') {
         return `🔴 LIVE ${label}`;
+    }
+    if (status === 'CURRENT') {
+        return `(Current) ${label}`;
     }
     if (isNext) {
         return `(Next) ${label}`;

--- a/tests/status.test.js
+++ b/tests/status.test.js
@@ -53,9 +53,9 @@ describe('status utils', () => {
             expect(getRoundStatus(race, now)).toBe('LIVE');
         });
 
-        it('identifies LIVE round between sessions', () => {
+        it('identifies CURRENT round between sessions', () => {
             const now = new Date('2023-03-04T12:00:00Z'); // Between FP1 and Race
-            expect(getRoundStatus(race, now)).toBe('LIVE');
+            expect(getRoundStatus(race, now)).toBe('CURRENT');
         });
 
         it('identifies FUTURE round', () => {
@@ -91,6 +91,10 @@ describe('status utils', () => {
         it('formats LIVE correctly', () => {
             expect(formatStatusLabel('Round 1', 'LIVE', false)).toBe('🔴 LIVE Round 1');
             expect(formatStatusLabel('Round 1', 'LIVE', true)).toBe('🔴 LIVE Round 1');
+        });
+
+        it('formats CURRENT correctly', () => {
+            expect(formatStatusLabel('Round 1', 'CURRENT', false)).toBe('(Current) Round 1');
         });
 
         it('formats NEXT correctly', () => {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -18,10 +18,10 @@ export default defineConfig({
       // Note: Branch coverage may vary slightly between local and CI environments
       // due to V8 engine differences. Thresholds are ratcheted to match CI results.
       thresholds: {
-        lines: 94.54,
+        lines: 94.56,
         functions: 98.11,
-        branches: 93.05,
-        statements: 94.54,
+        branches: 93.1,
+        statements: 94.56,
       },
       // Report formats: text for CI logs, lcov for future GitHub integration
       reporter: ['text', 'text-summary'],


### PR DESCRIPTION
The "live" indicator for race rounds was previously active for the entire duration of a race weekend, which could be confusing for users when no session was actually in progress.

This change refines the logic in `public/src/utils/status.js` so that:
1. `getRoundStatus` now specifically checks if any session within the round is currently live.
2. If at least one session is live, it returns `'LIVE'`.
3. If no session is live, but the current time is within the overall window of the race weekend (from the first session's start to the last session's end), it returns `'CURRENT'`.
4. `formatStatusLabel` has been updated to prefix labels with `(Current) ` when the status is `'CURRENT'`, while retaining the `🔴 LIVE` prefix for truly active sessions.

Unit tests in `tests/status.test.js` have been updated to verify these changes, including a new test case for the `'CURRENT'` status and an updated test for the 'between sessions' scenario. Test coverage thresholds in `vitest.config.js` were also ratcheted to reflect the updated coverage.

Visual verification was performed using a Playwright script that mocked the F1 API and current time, confirming that the UI correctly displays "(Current)" when appropriate and "🔴 LIVE" during active sessions.

Fixes #389

---
*PR created automatically by Jules for task [9378913876571696301](https://jules.google.com/task/9378913876571696301) started by @2fst4u*