### PR TITLE
📚 Archivist: Add verifiable links to the Credits section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ The map tiles are provided by Carto (based on OpenStreetMap data), ensuring a cl
 
 Huge thanks to the free APIs and data sources that make this possible:
 
-- **Jolpica F1** for the race data.
-- **RainViewer** for the weather radar.
-- **Open-Meteo** for the weather forecasts.
-- **Carto & OpenStreetMap** for the map tiles.
-- **bacinger/f1-circuits** for the circuit track data.
+- **[Jolpica F1](https://jolpi.ca/)** for the race data.
+- **[RainViewer](https://www.rainviewer.com/)** for the weather radar.
+- **[Open-Meteo](https://open-meteo.com/)** for the weather forecasts.
+- **[Carto](https://carto.com/)** & **[OpenStreetMap](https://www.openstreetmap.org/)** for the map tiles.
+- **[bacinger/f1-circuits](https://github.com/bacinger/f1-circuits)** for the circuit track data.
 
 ## License
 


### PR DESCRIPTION
💡 Problem: The README.md file listed data sources in the "Credits" section using ambiguous, unlinked text, making it harder for users to verify or discover the external APIs.

🎯 Fix: Updated `README.md` to add explicit, verifiable markdown links for "Jolpica F1", "RainViewer", "Open-Meteo", "Carto", "OpenStreetMap", and "bacinger/f1-circuits".

🧪 Verification: Verified formatting with `npx prettier --write README.md`. Ensured the test suite passed with `pnpm run test:coverage`. Checked the code reviewer's feedback.

🔎 Scope: This PR contains ONLY documentation changes in the README.

---
*PR created automatically by Jules for task [10656390646057583523](https://jules.google.com/task/10656390646057583523) started by @2fst4u*