### PR TITLE
Prioritize LIVE sessions in auto-selection logic

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -192,15 +192,15 @@ export class CircuitWeatherApp {
             this.selectRound(nextRace.round);
 
             // Find next upcoming session within this round
-            const nextSession = nextRace.sessions.find(session => {
-                if (!session.date || !session.time) return false;
-                const sessionTime = new Date(`${session.date}T${session.time}`);
-                return sessionTime > now;
-            });
+            // Priority: LIVE > FUTURE
+            let targetSession = nextRace.sessions.find(session => getSessionStatus(session, now) === 'LIVE');
+            if (!targetSession) {
+                targetSession = nextRace.sessions.find(session => getSessionStatus(session, now) === 'FUTURE');
+            }
 
-            if (nextSession) {
-                if (this.ui.sessionSelect) this.ui.sessionSelect.value = nextSession.id;
-                this.selectSession(nextSession.id);
+            if (targetSession) {
+                if (this.ui.sessionSelect) this.ui.sessionSelect.value = targetSession.id;
+                this.selectSession(targetSession.id);
             }
         }
     }


### PR DESCRIPTION
The session auto-selection logic was too aggressive, choosing the next upcoming session even if a session was currently live. I updated the logic in `CircuitWeatherApp.js` to first check for any 'LIVE' sessions before falling back to the first 'FUTURE' session. This ensures that users are always presented with the most relevant active session when opening the application during a race weekend.

Fixes #394

---
*PR created automatically by Jules for task [11794354832186873795](https://jules.google.com/task/11794354832186873795) started by @2fst4u*