### PR TITLE
🎨 Palette: Improve error state retry button UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,6 @@
 ## 2024-05-25 - Async Modal Loading States
 **Learning:** When modals fetch content asynchronously (like privacy policies or terms) before opening, the UI appears frozen to the user after they click the trigger button.
 **Action:** Always open the modal immediately and display a skeleton loading state inside the modal body while the asynchronous content is being fetched, providing instant interaction feedback.
+## 2024-05-20 - Adding immediate feedback to synchronous page reloads
+**Learning:** When a UI action triggers a synchronous `window.location.reload()`, the browser can appear to freeze for a moment before the navigation occurs. Adding immediate visual feedback (disabling the button, changing text to "Retrying...", updating `aria-label`) right before the reload significantly improves perceived performance and reassures the user that their action was registered, especially on slower network connections.
+**Action:** Always add intermediate loading states to buttons that trigger full page navigations or reloads, rather than relying solely on the browser's native loading indicator.

--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -142,12 +142,17 @@ export class CircuitWeatherApp {
                     </div>
                     <h3>Connection Failed</h3>
                     <p>${escapeHtml(message)}</p>
-                    <button class="retry-btn" type="button">Retry</button>
+                    <button class="retry-btn" type="button" aria-label="Retry connection">Retry</button>
                 </div>
             `;
             const btn = sidebarContent.querySelector('.retry-btn');
             if (btn) {
-                btn.addEventListener('click', () => window.location.reload());
+                btn.addEventListener('click', () => {
+                    btn.disabled = true;
+                    btn.textContent = 'Retrying...';
+                    btn.setAttribute('aria-label', 'Retrying connection');
+                    window.location.reload();
+                });
             }
         }
     }


### PR DESCRIPTION
💡 What: Added an `aria-label` to the Retry button and introduced an immediate `disabled` state with "Retrying..." text upon click.
🎯 Why: `window.location.reload()` is synchronous and can cause the browser to freeze momentarily before navigation happens. Adding an immediate loading state reassures users that their click was registered, particularly on slower connections.
♿ Accessibility: The button now explicitly announces "Retry connection" and updates to "Retrying connection" when activated.

---
*PR created automatically by Jules for task [15247402006127770417](https://jules.google.com/task/15247402006127770417) started by @2fst4u*