### PR TITLE
🔭 Scout: Upgrade countdown sections with semantic h2 headings

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -5,3 +5,7 @@
 ## 2025-02-27 - Mobile H1 Restoration
 **Learning:** Previous optimization (removing secondary H1) inadvertently removed the ONLY visible H1 on mobile, as the sidebar is hidden.
 **Action:** Restored H1 on mobile header to ensure heading hierarchy is maintained across all viewports.
+
+## 2025-02-28 - ARIA Landmark Linkage
+**Learning:** When upgrading structural elements (like `<section>`) that contain a heading (e.g., `<h2>`) into semantic landmarks, replacing a hardcoded `aria-label` with `aria-labelledby` creates a more robust linkage. However, modifying existing well-understood labels (e.g., changing "Session Countdown" to point to an inner heading saying "Starts in") can degrade clarity for screen reader users.
+**Action:** Always verify that the targeted heading's text provides equivalent or superior descriptive context compared to the original `aria-label` before converting to `aria-labelledby`.

--- a/public/index.html
+++ b/public/index.html
@@ -169,7 +169,8 @@
 
                 <!-- Session Countdown -->
                 <section class="countdown-card" id="countdownCard" aria-label="Session Countdown" style="display: none;">
-                    <div class="countdown-label">Session starts in</div>
+                    <!-- Scout: Upgraded generic div to semantic h2 to provide a proper heading for the section landmark, improving document outline and discoverability. -->
+                    <h2 class="countdown-label" id="countdownLabel">Session starts in</h2>
                     <div class="countdown-timer" id="countdownTimer" role="timer">--:--:--</div>
                     <div class="countdown-session" id="countdownSession"></div>
                 </section>
@@ -325,7 +326,8 @@
             <!-- Mobile Countdown Overlay (visible only on mobile) -->
             <!-- Scout: Upgraded generic div to semantic section for consistent landmarks -->
             <section class="mobile-countdown" id="mobileCountdown" aria-label="Mobile Session Countdown" style="display: none;">
-                <div class="mobile-countdown-label">Starts in</div>
+                <!-- Scout: Upgraded generic div to semantic h2 to provide a proper heading for the section landmark, improving document outline and discoverability. -->
+                <h2 class="mobile-countdown-label" id="mobileCountdownLabel">Starts in</h2>
                 <div class="mobile-countdown-timer" id="mobileCountdownTimer" role="timer">--:--:--</div>
                 <div class="mobile-countdown-session" id="mobileCountdownSession"></div>
             </section>


### PR DESCRIPTION
💡 What: Upgraded the generic `<div>` labels inside the `countdown-card` and `mobile-countdown` sections to semantic `<h2>` headings.
🎯 Why: Fixes the document outline and heading hierarchy. `<section>` elements act as landmarks and should contain a heading to properly structure the page for search engine crawlers and screen readers.
📊 Value: Improves discoverability by ensuring a sequential heading structure (H1 -> H2).
🔬 Measurement: Verify by checking the DOM structure within `#countdownCard` and `#mobileCountdown` ensuring `<h2 class="countdown-label">` exists and is linked via `aria-labelledby` or `aria-label`.

---
*PR created automatically by Jules for task [11982275778965263106](https://jules.google.com/task/11982275778965263106) started by @2fst4u*