### PR TITLE
🧪 Spec: Add test for roundSelect events in CircuitWeatherApp

### DIFF
--- a/tests/circuit-weather-app.test.js
+++ b/tests/circuit-weather-app.test.js
@@ -936,9 +936,11 @@ describe('CircuitWeatherApp Pure Methods', () => {
     // ---------------------------------------------------------------
     describe('bindEvents', () => {
         beforeEach(() => {
+            app.ui.roundSelect = createMockElement('roundSelect');
             app.ui.sessionSelect = createMockElement('sessionSelect');
             app.selectedRace = {};
             app.selectSession = vi.fn();
+            app.selectRound = vi.fn();
         });
 
         it('binds sessionSelect change event to selectSession', () => {
@@ -956,6 +958,52 @@ describe('CircuitWeatherApp Pure Methods', () => {
 
             // Verify selectSession was called
             expect(app.selectSession).toHaveBeenCalledWith('race');
+        });
+
+        it('binds roundSelect change event to selectRound when value is present', () => {
+            app.bindEvents();
+
+            const addEventListenerCalls = app.ui.roundSelect.addEventListener.mock.calls;
+            const changeEventCall = addEventListenerCalls.find(call => call[0] === 'change');
+            expect(changeEventCall).toBeTruthy();
+
+            const changeHandler = changeEventCall[1];
+            changeHandler({ target: { value: 'round-1' } });
+
+            expect(app.selectRound).toHaveBeenCalledWith('round-1');
+        });
+
+        it('clears state when roundSelect change event has no value', () => {
+            app.stopSessionForecastInterval = vi.fn();
+            app.updatePageMetadata = vi.fn();
+            app.countdown.show = vi.fn();
+            app.trackLayer.clear = vi.fn();
+            app.rangeCircles.clear = vi.fn();
+            app.ui.forecastSection = createMockElement('forecastSection');
+            app.ui.raceInfoBanner = createMockElement('raceInfoBanner');
+            app.ui.sessionEmptyState = createMockElement('sessionEmptyState');
+
+            app.bindEvents();
+
+            const addEventListenerCalls = app.ui.roundSelect.addEventListener.mock.calls;
+            const changeEventCall = addEventListenerCalls.find(call => call[0] === 'change');
+
+            const changeHandler = changeEventCall[1];
+            changeHandler({ target: { value: '' } });
+
+            expect(app.selectedSession).toBeNull();
+            expect(app.selectedRace).toBeNull();
+            expect(app.ui.forecastSection.style.display).toBe('none');
+            expect(app.ui.raceInfoBanner.style.display).toBe('none');
+            expect(app.ui.sessionEmptyState.style.display).toBe('none');
+            expect(app.countdown.show).toHaveBeenCalledWith(false);
+            expect(app.trackLayer.clear).toHaveBeenCalled();
+            expect(app.rangeCircles.clear).toHaveBeenCalled();
+            expect(app.stopSessionForecastInterval).toHaveBeenCalled();
+            expect(app.updatePageMetadata).toHaveBeenCalled();
+            expect(app.ui.sessionSelect.disabled).toBe(true);
+            expect(app.ui.sessionSelect.title).toBe('Select a round first');
+            expect(app.ui.sessionSelect.innerHTML).toBe('<option value="">Select a round first</option>');
         });
     });
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -18,10 +18,10 @@ export default defineConfig({
       // Note: Branch coverage may vary slightly between local and CI environments
       // due to V8 engine differences. Thresholds are ratcheted to match CI results.
       thresholds: {
-        lines: 94.56,
+        lines: 95.06,
         functions: 98.11,
-        branches: 93.19,
-        statements: 94.56,
+        branches: 93.21,
+        statements: 95.06,
       },
       // Report formats: text for CI logs, lcov for future GitHub integration
       reporter: ['text', 'text-summary'],


### PR DESCRIPTION
💡 What: Added unit tests covering the `change` event listener for the `roundSelect` element in `CircuitWeatherApp.js`. Tested for the valid value present behavior and the empty value clear behavior.
🎯 Why: Lines 242-263 in `CircuitWeatherApp.js` describing the state-clearing logic and round selection on round select dropdown updates were previously uncovered.
📈 Ratchet: Increased statement and line coverage thresholds by 0.50% and branch coverage threshold by 0.02% to lock in the gain from this new test.

---
*PR created automatically by Jules for task [4928814926929123588](https://jules.google.com/task/4928814926929123588) started by @2fst4u*