### PR TITLE
🎨 Palette: Improve accessibility of semantic landmarks

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -47,3 +47,6 @@
 ## 2024-05-20 - Adding immediate feedback to synchronous page reloads
 **Learning:** When a UI action triggers a synchronous `window.location.reload()`, the browser can appear to freeze for a moment before the navigation occurs. Adding immediate visual feedback (disabling the button, changing text to "Retrying...", updating `aria-label`) right before the reload significantly improves perceived performance and reassures the user that their action was registered, especially on slower network connections.
 **Action:** Always add intermediate loading states to buttons that trigger full page navigations or reloads, rather than relying solely on the browser's native loading indicator.
+## 2024-05-24 - Semantic Landmark Headings
+**Learning:** When a `<section>` semantic landmark has an internal heading (like an `<h2>`), applying a static `aria-label` creates redundancy and often less descriptive context for screen reader users than the dynamic heading itself.
+**Action:** Always use `aria-labelledby="[heading-id]"` to tie the structural landmark directly to its internal heading, especially when the heading text updates dynamically (e.g., changing to the name of a newly selected race).

--- a/public/index.html
+++ b/public/index.html
@@ -157,7 +157,7 @@
                 </section>
 
                 <!-- Race Info Banner -->
-                <section class="race-info-banner" id="raceInfoBanner" aria-label="Circuit Information" style="display: none;">
+                <section class="race-info-banner" id="raceInfoBanner" aria-labelledby="raceInfoName" style="display: none;">
                     <img id="countryFlag" class="race-info-flag" alt="">
                     <div class="race-info-details">
                         <div class="race-info-country" id="raceInfoCountry"></div>
@@ -168,7 +168,7 @@
                 </section>
 
                 <!-- Session Countdown -->
-                <section class="countdown-card" id="countdownCard" aria-label="Session Countdown" style="display: none;">
+                <section class="countdown-card" id="countdownCard" aria-labelledby="countdownLabel" style="display: none;">
                     <!-- Scout: Upgraded generic div to semantic h2 to provide a proper heading for the section landmark, improving document outline and discoverability. -->
                     <h2 class="countdown-label" id="countdownLabel">Session starts in</h2>
                     <div class="countdown-timer" id="countdownTimer" role="timer">--:--:--</div>
@@ -325,7 +325,7 @@
 
             <!-- Mobile Countdown Overlay (visible only on mobile) -->
             <!-- Scout: Upgraded generic div to semantic section for consistent landmarks -->
-            <section class="mobile-countdown" id="mobileCountdown" aria-label="Mobile Session Countdown" style="display: none;">
+            <section class="mobile-countdown" id="mobileCountdown" aria-labelledby="mobileCountdownLabel" style="display: none;">
                 <!-- Scout: Upgraded generic div to semantic h2 to provide a proper heading for the section landmark, improving document outline and discoverability. -->
                 <h2 class="mobile-countdown-label" id="mobileCountdownLabel">Starts in</h2>
                 <div class="mobile-countdown-timer" id="mobileCountdownTimer" role="timer">--:--:--</div>
@@ -336,7 +336,7 @@
             <div class="mobile-ui-layout">
                 <!-- Mobile Race Info Overlay (visible only on mobile) -->
                 <!-- Scout: Upgraded generic div to semantic section for consistent landmarks -->
-                <section class="mobile-race-info" id="mobileRaceInfo" aria-label="Mobile Circuit Information" style="display: none;">
+                <section class="mobile-race-info" id="mobileRaceInfo" aria-labelledby="mobileRaceInfoName" style="display: none;">
                     <img id="mobileCountryFlag" class="mobile-race-info-flag" alt="">
                     <div class="mobile-race-info-text">
                 <!-- Scout: Upgraded generic span to semantic h2 for consistent heading hierarchy across viewports -->


### PR DESCRIPTION
🎨 Palette: Improve accessibility of semantic landmarks

💡 What: Replaced hardcoded `aria-label` attributes with `aria-labelledby` on `<section>` elements that contain dynamic internal headings (`<h2>`).
🎯 Why: Screen readers now announce the dynamic heading text (e.g., "Australian Grand Prix, region") instead of generic text like "Circuit Information, region", providing significantly more context to non-visual users.
♿ Accessibility: Improved semantic HTML compliance and screen reader context for F1 race selection flow.

---
*PR created automatically by Jules for task [9957006820076794745](https://jules.google.com/task/9957006820076794745) started by @2fst4u*