### PR TITLE
📚 Archivist: Clarify /api/health cache duration in AGENTS.md

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -143,3 +143,8 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 
 **Learning:** Human developers are not the target audience for `README.md` local development instructions; this project is explicitly meant for AI agents to build and run.
 **Action:** Removed generic local setup steps from `README.md` and explicitly annotated `AGENTS.md` to reflect that the repository is agent-driven and does not target human contributors.
+
+## 2026-03-09 - Undocumented Health Check Cache Duration
+
+**Learning:** `AGENTS.md` listed the `/api/health` endpoint but omitted its 60-second edge cache duration, which is crucial for understanding its DDOS protection strategy as implemented in `src/worker.js`.
+**Action:** Updated `AGENTS.md` to explicitly document the 60-second caching for the `/api/health` endpoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,7 +263,7 @@ mode = "smart"
 | `/api/tiles/*`  | Proxies to RainViewer tile API with 2-hour edge caching (512px optimized)      |
 | `/api/track/*`  | Proxies to GitHub for GeoJSON track data with 24-hour caching                  |
 | `/api/assets/*` | Proxies to unpkg for Leaflet assets with 1-year immutable caching (strict CSP) |
-| `/api/health`   | System status check (connectivity to upstreams, version, env)                  |
+| `/api/health`   | System status check (connectivity to upstreams, version, env) with 60-second caching |
 
 ---
 


### PR DESCRIPTION
💡 Problem: The `AGENTS.md` API Endpoints table listed the `/api/health` endpoint but omitted its 60-second edge caching duration, leaving this aspect of the DDoS protection strategy undocumented compared to other cached endpoints.
🎯 Fix: Updated the `/api/health` row in `AGENTS.md` to explicitly state "with 60-second caching" to match the actual Worker logic. Also recorded the finding in `.jules/archivist.md`.
🧪 Verification: Confirmed via `grep` that `src/worker.js` enforces a 60-second `Cache-Control` header for this endpoint. Ran `pnpm test` to ensure no functionality was affected.
🔎 Scope: ONLY documentation changes were made (updating `AGENTS.md` and `.jules/archivist.md`).

---
*PR created automatically by Jules for task [14148924495051272728](https://jules.google.com/task/14148924495051272728) started by @2fst4u*