### PR TITLE
🧪 Spec: Add keyboard a11y tests for Privacy Modal

### DIFF
--- a/tests/privacy-modal.test.js
+++ b/tests/privacy-modal.test.js
@@ -340,11 +340,48 @@ describe('PrivacyModal', () => {
         });
 
 
+
+
         it('triggers open when privacy link is clicked', () => {
             const openSpy = vi.spyOn(modal, 'open').mockImplementation(() => {});
             const clickHandler = modal.privacyLink.addEventListener.mock.calls.find(call => call[0] === 'click')[1];
             clickHandler({ preventDefault: vi.fn() });
             expect(openSpy).toHaveBeenCalled();
+        });
+
+
+
+        it('triggers open when privacy link is activated via keyboard (Space)', () => {
+            const openSpy = vi.spyOn(modal, 'open').mockImplementation(() => {});
+            const keydownHandler = modal.privacyLink.addEventListener.mock.calls.find(call => call[0] === 'keydown')[1];
+
+            const event = { key: ' ', preventDefault: vi.fn() };
+            keydownHandler(event);
+
+            expect(event.preventDefault).toHaveBeenCalled();
+            expect(openSpy).toHaveBeenCalled();
+        });
+
+        it('triggers open when privacy link is activated via keyboard (Spacebar)', () => {
+            const openSpy = vi.spyOn(modal, 'open').mockImplementation(() => {});
+            const keydownHandler = modal.privacyLink.addEventListener.mock.calls.find(call => call[0] === 'keydown')[1];
+
+            const event = { key: 'Spacebar', preventDefault: vi.fn() };
+            keydownHandler(event);
+
+            expect(event.preventDefault).toHaveBeenCalled();
+            expect(openSpy).toHaveBeenCalled();
+        });
+
+        it('does not trigger open for other keys on privacy link', () => {
+            const openSpy = vi.spyOn(modal, 'open').mockImplementation(() => {});
+            const keydownHandler = modal.privacyLink.addEventListener.mock.calls.find(call => call[0] === 'keydown')[1];
+
+            const event = { key: 'Enter', preventDefault: vi.fn() };
+            keydownHandler(event);
+
+            expect(event.preventDefault).not.toHaveBeenCalled();
+            expect(openSpy).not.toHaveBeenCalled();
         });
 
         it('closes when backdrop is clicked directly', () => {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -18,10 +18,10 @@ export default defineConfig({
       // Note: Branch coverage may vary slightly between local and CI environments
       // due to V8 engine differences. Thresholds are ratcheted to match CI results.
       thresholds: {
-        lines: 94.98,
+        lines: 95.07,
         functions: 98.11,
-        branches: 93.21,
-        statements: 94.98,
+        branches: 93.24,
+        statements: 95.07,
       },
       // Report formats: text for CI logs, lcov for future GitHub integration
       reporter: ['text', 'text-summary'],


### PR DESCRIPTION
💡 What: Added unit tests to `tests/privacy-modal.test.js` to ensure the Privacy Modal triggers correctly on `Space` and `Spacebar` keypresses, simulating keyboard accessibility interactions.
🎯 Why: The keyboard event listener logic for activating the privacy link functioning as a button was previously uncovered, leaving a gap in accessibility behavior verification.
📈 Ratchet: Increased coverage thresholds for lines (94.98 -> 95.07), branches (93.21 -> 93.24), and statements (94.98 -> 95.07) to lock in the gain from these new tests.

---
*PR created automatically by Jules for task [2490615507900432039](https://jules.google.com/task/2490615507900432039) started by @2fst4u*