### PR TITLE
📚 Archivist: Clarify Cache Durations for Proxied Services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,12 +35,12 @@ Circuit Weather is a real-time F1 race circuit weather radar application. It dis
 
 | Service         | Purpose                                                          | Connection           |
 | --------------- | ---------------------------------------------------------------- | -------------------- |
-| Jolpica F1 API  | Race schedule data                                               | Proxied (Cached)     |
+| Jolpica F1 API  | Race schedule data (1-hour cache)                                | Proxied (Cached)     |
 | RainViewer      | Weather radar tiles (2-hour cache) and metadata (1-minute cache) | Proxied (Cached)     |
 | Open-Meteo      | Weather forecasts                                                | Direct (Client-side) |
 | Carto           | Map basemap tiles                                                | Direct (Client-side) |
-| GitHub          | Track GeoJSON data                                               | Proxied (Cached)     |
-| Unpkg (Leaflet) | Map library assets                                               | Proxied (Cached)     |
+| GitHub          | Track GeoJSON data (24-hour cache)                               | Proxied (Cached)     |
+| Unpkg (Leaflet) | Map library assets (1-year cache)                                | Proxied (Cached)     |
 | Google Fonts    | Typography                                                       | Direct (Client-side) |
 | FlagCDN         | Country flags                                                    | Direct (Client-side) |
 | Buy Me a Coffee | Support widget                                                   | Direct (Client-side) |


### PR DESCRIPTION
* 💡 **Problem**: The `Third-Party Services` table in `AGENTS.md` inconsistently documented cache durations. It specified the durations for RainViewer but omitted them for Jolpica F1 API, GitHub Track Data, and Unpkg (Leaflet), despite these being actively cached by the Worker proxy. This creates ambiguity for developers regarding the expected data freshness and system architecture.
* 🎯 **Fix**: Updated the `Purpose` column in the `Third-Party Services` table within `AGENTS.md` to explicitly state the caching durations for:
    * Jolpica F1 API (1-hour cache)
    * GitHub Track GeoJSON data (24-hour cache)
    * Unpkg Map library assets (1-year cache)
* 🧪 **Verification**: Ran `grep` to verify the table changes and `pnpm test` to ensure no documentation parsing or system tests were broken. Checked `git diff` to confirm only `AGENTS.md` was modified.
* 🔎 **Scope**: Documentation updates to `AGENTS.md` only. No application code or configuration changes.

---
*PR created automatically by Jules for task [495025609084888415](https://jules.google.com/task/495025609084888415) started by @2fst4u*