### PR TITLE
Upgrade Node.js Runner to v24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -148,3 +148,8 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 
 **Learning:** `AGENTS.md` listed the `/api/health` endpoint but omitted its 60-second edge cache duration, which is crucial for understanding its DDOS protection strategy as implemented in `src/worker.js`.
 **Action:** Updated `AGENTS.md` to explicitly document the 60-second caching for the `/api/health` endpoint.
+
+## 2026-03-11 - Node.js Runner Upgrade
+
+**Learning:** GitHub Actions deprecated Node 20 runners, requiring an upgrade to Node 24 for the CI environment. Documentation must be kept in sync with the CI configuration to ensure developer environment consistency.
+**Action:** Updated `.github/workflows/ci.yml` to use Node 24.x and updated `AGENTS.md` to recommend Node 24+ for local development.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,7 +322,7 @@ This project uses [Cloudflare Workers](https://workers.cloudflare.com/) to proxy
 
 1.  **Clone the repository.**
 2.  **Install Node.js.**
-    If you don't have Node.js installed, download it from [nodejs.org](https://nodejs.org/). **v20+ is recommended** to match the CI environment.
+    If you don't have Node.js installed, download it from [nodejs.org](https://nodejs.org/). **v24+ is recommended** to match the CI environment.
 3.  **Install dependencies.**
     Run the following command in your terminal at the root of the project:
     ```bash


### PR DESCRIPTION
Upgraded the GitHub Actions runner to Node.js 24 to address the deprecation of Node 20. Documentation (AGENTS.md) and the Archivist Journal were also updated to maintain consistency across the project. Full test suite passed successfully.

Fixes #417

---
*PR created automatically by Jules for task [11179557685741252649](https://jules.google.com/task/11179557685741252649) started by @2fst4u*