### PR TITLE
📚 Archivist: Clarify Cloudflare Workers hosting architecture

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -153,3 +153,7 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 
 **Learning:** GitHub Actions deprecated Node 20 runners, requiring an upgrade to Node 24 for the CI environment. Documentation must be kept in sync with the CI configuration to ensure developer environment consistency.
 **Action:** Updated `.github/workflows/ci.yml` to use Node 24.x and updated `AGENTS.md` to recommend Node 24+ for local development.
+
+## 2026-03-12 - Legacy Cloudflare Pages References
+**Learning:** The project migrated to Cloudflare Workers with Static Assets, but PRIVACY.md and AGENTS.md file tree still incorrectly referenced Cloudflare Pages.
+**Action:** Removed mentions of Cloudflare Pages to accurately reflect the single-worker architecture.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ circuit-weather/
 │   ├── robots.txt    # Search engine directives
 │   ├── sitemap.xml   # XML Sitemap for SEO
 │   ├── sw.js         # Service worker (app shell caching)
-│   ├── _headers      # Cloudflare Pages custom headers (CSP, security)
+│   ├── _headers      # Custom HTTP headers (CSP, security)
 │   └── PRIVACY.md
 ├── src/
 │   ├── worker.js       # Cloudflare Worker (API proxy + asset serving)

--- a/public/PRIVACY.md
+++ b/public/PRIVACY.md
@@ -19,7 +19,7 @@ However, the application relies on third-party services and infrastructure which
 ## Infrastructure & Caching
 
 ### Cloudflare
-This website is hosted on **Cloudflare Pages** and utilizes **Cloudflare Workers** to power its API. We leverage Cloudflare's global edge network to aggressively cache data close to you.
+This website is hosted on **Cloudflare Workers** (using Static Assets) which serves both the website and powers its API. We leverage Cloudflare's global edge network to aggressively cache data close to you.
 
 - **Privacy Proxy:** To enhance your privacy, requests for F1 schedules, Track Layouts, and **all RainViewer Radar Tiles** are proxied through our Cloudflare Worker. This hides your IP address from these third-party services.
 - **Advanced Caching:** We utilize advanced edge caching features to store API responses on Cloudflare's servers. This minimizes data usage and reduces load on the open-source community APIs we rely on.


### PR DESCRIPTION
💡 **Problem:** 
`PRIVACY.md` incorrectly claimed the website was hosted on **Cloudflare Pages**, and `AGENTS.md` incorrectly labeled the `_headers` file as `Cloudflare Pages custom headers`. This contradicts the actual architecture, which utilizes **Cloudflare Workers with Static Assets** (as defined in `wrangler.toml` and verified in code).

🎯 **Fix:** 
- Updated `PRIVACY.md` to accurately reflect the single-worker architecture, stating the site is hosted on Cloudflare Workers.
- Generalized the file tree comment for `_headers` in `AGENTS.md` to remove the Cloudflare Pages reference.
- Added a learning to `.jules/archivist.md` to prevent future drift.

🧪 **Verification:** 
- Inspected `wrangler.toml` (which configures `[assets]` binding).
- Verified changes with `cat` and `grep`.
- Ran `pnpm test` to ensure no regressions were introduced.

🔎 **Scope:** 
Confirmed this PR contains ONLY documentation changes and no code/functional modifications.

---
*PR created automatically by Jules for task [3734628151261137068](https://jules.google.com/task/3734628151261137068) started by @2fst4u*