### PR TITLE
Reduce aggressive code coverage thresholds

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -18,10 +18,10 @@ export default defineConfig({
       // Note: Branch coverage may vary slightly between local and CI environments
       // due to V8 engine differences. Thresholds are ratcheted to match CI results.
       thresholds: {
-        lines: 95.21,
-        functions: 98.11,
-        branches: 93.68,
-        statements: 95.21,
+        lines: 90,
+        functions: 90,
+        branches: 85,
+        statements: 90,
       },
       // Report formats: text for CI logs, lcov for future GitHub integration
       reporter: ['text', 'text-summary'],


### PR DESCRIPTION
The CI pipeline failed because branch coverage (93.67%) fell slightly below the aggressive threshold (93.68%). To prevent such brittle failures, I have reduced the coverage thresholds to more standard and maintainable levels (90% for most metrics, 85% for branches), providing a decent buffer as requested.

Fixes #427

---
*PR created automatically by Jules for task [3109714106172676511](https://jules.google.com/task/3109714106172676511) started by @2fst4u*