### PR TITLE
🧪 Spec: Fix noisy console error in weather-radar-frames.test.js

### DIFF
--- a/tests/weather-radar-frames.test.js
+++ b/tests/weather-radar-frames.test.js
@@ -276,13 +276,18 @@ describe('WeatherRadar Frame & Speed Logic', () => {
 
         it('calls updateErrorUI on network error', async () => {
             const uiSpy = vi.spyOn(radar, 'updateErrorUI').mockImplementation(() => { });
+            const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
             global.fetch.mockRejectedValueOnce(new Error('offline'));
 
             radar.handleTileError({ tile: {} });
 
-            await vi.waitFor(() => {
-                expect(uiSpy).toHaveBeenCalled();
-            });
+            try {
+                await vi.waitFor(() => {
+                    expect(uiSpy).toHaveBeenCalled();
+                });
+            } finally {
+                errorSpy.mockRestore();
+            }
         });
     });
 });


### PR DESCRIPTION
💡 What: Mocked `console.error` inside the `calls updateErrorUI on network error` test in `tests/weather-radar-frames.test.js` to suppress an expected error message, and wrapped `vi.waitFor` in a `try...finally` block to ensure the mock is restored safely.
🎯 Why: To fix CI feedback / noisy test suite logs by preventing an expected simulated network error from polluting `stderr` during local and automated test runs.

---
*PR created automatically by Jules for task [10955496275174742150](https://jules.google.com/task/10955496275174742150) started by @2fst4u*