### PR TITLE
fix: Improve health check error handling in worker proxy

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -673,17 +673,6 @@ async function handleHealthRequest(request, env, ctx) {
   };
 
   const results = {};
-  // TODO: This error handling in the health check requires further investigation and confirmation.
-  // The catch block silently swallows the actual error by discarding the exception object and
-  // only recording the string 'unreachable' in the results. This means that if an upstream
-  // becomes unavailable, there is no way to distinguish between a DNS resolution failure,
-  // a connection timeout, a TLS handshake error, or any other network-level problem when
-  // reviewing the health check output. The actual error information is lost entirely.
-  // For debugging and monitoring purposes, it would be valuable to at least log the error
-  // type or message (e.g., in development mode) so that infrastructure issues can be
-  // diagnosed from logs. Consider recording the error name or type alongside the
-  // 'unreachable' status, or logging the error in non-production environments where
-  // the information would be useful without risking information disclosure.
   const checks = Object.entries(upstreams).map(async ([name, url]) => {
     try {
       const res = await fetch(url, {
@@ -693,7 +682,7 @@ async function handleHealthRequest(request, env, ctx) {
       });
       results[name] = res.status;
     } catch (e) {
-      results[name] = 'unreachable';
+      results[name] = env.ENVIRONMENT !== 'production' ? `unreachable: ${e.name || e.message || 'Error'}` : 'unreachable';
     }
   });
 

--- a/tests/worker-edge-cases.test.js
+++ b/tests/worker-edge-cases.test.js
@@ -151,8 +151,8 @@ describe('Worker Edge Cases', () => {
             const response = await workerModule.fetch(request, env, ctx);
 
             const body = await response.json();
-            expect(body.upstreams.jolpica).toBe('unreachable');
-            expect(body.upstreams.rainviewer).toBe('unreachable');
+            expect(body.upstreams.jolpica).toContain('unreachable');
+            expect(body.upstreams.rainviewer).toContain('unreachable');
 
             globalThis.fetch = originalFetch;
         });

--- a/tests/worker-health-cache.test.js
+++ b/tests/worker-health-cache.test.js
@@ -87,9 +87,9 @@ describe("Worker Health Check Caching", () => {
     expect(body.status).toBe("ok");
 
     // Check that all 3 upstreams are marked unreachable
-    expect(body.upstreams.jolpica).toBe("unreachable");
-    expect(body.upstreams.rainviewer).toBe("unreachable");
-    expect(body.upstreams.github).toBe("unreachable");
+    expect(body.upstreams.jolpica).toContain("unreachable");
+    expect(body.upstreams.rainviewer).toContain("unreachable");
+    expect(body.upstreams.github).toContain("unreachable");
 
     expect(mockFetch).toHaveBeenCalledTimes(3);
     expect(mockCache.put).toHaveBeenCalled();


### PR DESCRIPTION
Resolves a TODO comment in `src/worker.js` by improving the error handling of upstream health checks. Previously, network errors silently resulted in a blanket `'unreachable'` string. In non-production environments, the proxy now appends the error name/message (`unreachable: ErrorName`) for easier debugging. Production environments remain unchanged to prevent internal information leakage. The relevant test assertions in Vitest were updated from strict equality (`.toBe`) to partial matches (`.toContain`) to prevent brittle test failures across varying environments.

---
*PR created automatically by Jules for task [16095931000809020528](https://jules.google.com/task/16095931000809020528) started by @2fst4u*