### PR TITLE
fix: add abort signal timeout to open-meteo fetch call

### DIFF
--- a/public/src/api/WeatherClient.js
+++ b/public/src/api/WeatherClient.js
@@ -60,18 +60,9 @@ export class WeatherClient {
                 });
                 const url = `${this.baseUrl}?${params.toString()}`;
 
-                // TODO: This fetch operation requires further investigation and confirmation.
-                // Currently, this fetch call to the Open-Meteo API lacks an AbortSignal timeout,
-                // which means the request could potentially hang indefinitely if the upstream API
-                // becomes unresponsive or if there are network connectivity issues. Without a timeout,
-                // the application would wait forever for a response, blocking the user interface and
-                // preventing users from interacting with other parts of the application. This is
-                // particularly problematic for weather data that users expect to load quickly.
-                // Consider adding a timeout using AbortSignal.timeout() with an appropriate duration
-                // (for example, 5000 milliseconds) to ensure the request fails gracefully after a
-                // reasonable waiting period, allowing the error handling to execute and display
-                // appropriate feedback to the user.
-                const response = await fetch(url);
+                const response = await fetch(url, {
+                    signal: AbortSignal.timeout(5000)
+                });
                 if (!response.ok) throw new Error('Weather API error');
 
                 data = await response.json();


### PR DESCRIPTION
Resolved a TODO comment indicating the Open-Meteo `fetch` request was missing
a timeout. Replaced the `fetch` call with one that includes an
`AbortSignal.timeout(5000)` option so the application can gracefully fail if
the API hangs. The TODO comment block has been removed.

---
*PR created automatically by Jules for task [5643645132228862828](https://jules.google.com/task/5643645132228862828) started by @2fst4u*