### PR TITLE
Refactor: Extract magic numbers for refresh intervals into config

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -624,47 +624,21 @@ export class CircuitWeatherApp {
             clearInterval(this.weatherRefreshInterval);
         }
 
-        // TODO: This magic number requires further investigation and confirmation.
-        // The value 300000 represents the number of milliseconds in 5 minutes,
-        // which is the interval at which weather data is refreshed. While the
-        // comment indicates this is "every 5 minutes", having this as a literal
-        // number makes the code less readable and harder to maintain. If this
-        // refresh rate needs to be adjusted based on API rate limits, user
-        // preferences, or data freshness requirements, developers must manually
-        // calculate the milliseconds. This should be extracted to a named
-        // constant such as WEATHER_REFRESH_INTERVAL_MS or
-        // WEATHER_REFRESH_INTERVAL_MINUTES with appropriate documentation
-        // explaining why 5 minutes was chosen as the refresh interval and
-        // how it relates to API rate limits or data freshness requirements.
-        // Refresh weather every 5 minutes (300000ms)
         this.weatherRefreshInterval = setInterval(() => {
             this.updateLiveWeatherForCircuit();
-        }, 300000);
+        }, CONFIG.WEATHER_REFRESH_INTERVAL_MS);
     }
 
     startSessionForecastInterval() {
         this.stopSessionForecastInterval();
 
-        // TODO: This magic number requires further investigation and confirmation.
-        // The value 900000 represents the number of milliseconds in 15 minutes,
-        // which is the interval at which session forecast data is refreshed.
-        // Similar to the 5-minute weather refresh interval, this literal value
-        // makes the code less maintainable and harder to understand at a glance.
-        // The comment notes that this matches the WeatherClient cache TTL, but
-        // this relationship is implicit and could break if either value changes
-        // without updating the other. This should be extracted to a named
-        // constant such as SESSION_FORECAST_REFRESH_INTERVAL_MS or defined
-        // in a centralized constants file alongside the cache TTL to ensure
-        // they remain synchronized. Documentation should explain why 15 minutes
-        // was chosen and how it relates to the cache TTL for consistency.
-        // Refresh forecast every 15 minutes (900000ms) to match WeatherClient cache TTL
         this.sessionForecastInterval = setInterval(() => {
             if (this.selectedSession && this.selectedRace) {
                 const sessionTime = new Date(`${this.selectedSession.date}T${this.selectedSession.time}`);
                 // Background refresh, no loading spinner
                 this.updateSessionForecast(sessionTime, this.selectedSession.id);
             }
-        }, 900000);
+        }, CONFIG.SESSION_FORECAST_REFRESH_INTERVAL_MS);
     }
 
     stopSessionForecastInterval() {

--- a/public/src/api/WeatherClient.js
+++ b/public/src/api/WeatherClient.js
@@ -14,7 +14,7 @@ export class WeatherClient {
         // not account for different forecast times, which could lead to stale data being served
         // if the same location is queried for different session times.
         this.cache = new Map();
-        this.cacheTTL = 15 * 60 * 1000; // 15 minutes
+        this.cacheTTL = CONFIG.SESSION_FORECAST_REFRESH_INTERVAL_MS;
     }
 
     async getForecast(lat, lon, sessionTime) {

--- a/public/src/config.js
+++ b/public/src/config.js
@@ -25,6 +25,8 @@ export const CONFIG = {
     // Time Constants
     RACE_DURATION_BUFFER_HOURS: 4, // Assume race + podium + post-race takes ~4 hours
     RACE_DAY_END_HOUR: 23, // Fallback to end of day if session time is missing
+    WEATHER_REFRESH_INTERVAL_MS: 300000, // 5 minutes
+    SESSION_FORECAST_REFRESH_INTERVAL_MS: 900000, // 15 minutes
 };
 // SEC: Prevent runtime tampering with configuration
 Object.freeze(CONFIG);

--- a/tests/weather-client.test.js
+++ b/tests/weather-client.test.js
@@ -3,7 +3,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // Mock config before importing WeatherClient
 vi.mock('../public/src/config.js', () => ({
     CONFIG: {
-        weatherApi: 'https://api.open-meteo.com/v1/forecast'
+        weatherApi: 'https://api.open-meteo.com/v1/forecast',
+        SESSION_FORECAST_REFRESH_INTERVAL_MS: 900000
     }
 }));
 


### PR DESCRIPTION
This PR addresses two TODO comments related to magic numbers used for refresh intervals in `CircuitWeatherApp.js`. Specifically, it extracts the 5-minute (300000ms) and 15-minute (900000ms) intervals into named constants in `config.js` (`WEATHER_REFRESH_INTERVAL_MS` and `SESSION_FORECAST_REFRESH_INTERVAL_MS` respectively).

Crucially, it also updates the `WeatherClient.js` cache TTL to use the same `SESSION_FORECAST_REFRESH_INTERVAL_MS` constant, addressing the concern raised in the TODO comment that the caching and polling intervals were implicitly coupled and could break if one was updated without the other. Test mocks have been updated to reflect the new configuration structure.

---
*PR created automatically by Jules for task [4756670021933876336](https://jules.google.com/task/4756670021933876336) started by @2fst4u*