### PR TITLE
📚 Archivist: Clarify Session Countdown timer behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,7 @@ mode = "smart"
 4. **Session Countdown**
    - Countdown timer to selected session start
    - Format: days/hours or HH:MM:SS
-   - Shows "NOW" when session is live
+   - Hidden if target time has passed or session is live
 
 5. **URL Routing**
    - Format: `/f1/{round}/{session}`


### PR DESCRIPTION
💡 Problem: `AGENTS.md` incorrectly claimed that the Session Countdown timer shows "NOW" when a session is live. This contradicted the actual codebase behavior, where the countdown is a map overlay that is only visible for future sessions, and is hidden entirely if the target time has passed or the session is live.

🎯 Fix: Updated the `Session Countdown` bullet point in `AGENTS.md` to state "Hidden if target time has passed or session is live" to accurately reflect reality.

🧪 Verification: Confirmed behavior by reading `tests/countdown-timer.test.js` where the `.ui.card.style.display` is verified to be set to `none` for past and current targets. Additionally, ran the `vitest` test suite via `pnpm run test` which passed successfully.

🔎 Scope: This PR contains ONLY documentation changes.

---
*PR created automatically by Jules for task [2948049551904441623](https://jules.google.com/task/2948049551904441623) started by @2fst4u*