### PR TITLE
🧹 Sweep: Remove duplicate `border-radius` declaration in CSS

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -579,17 +579,6 @@ body {
     -webkit-backdrop-filter: var(--glass-blur);
     color: var(--color-text) !important;
     border: 1px solid var(--color-border) !important;
-    /* TODO: This CSS property requires further investigation and confirmation.
-       The border-radius property is declared twice in this rule block with the same value
-       and both declarations use !important. This is a redundant duplicate declaration
-       that serves no purpose and increases the CSS file size unnecessarily. The second
-       declaration will override the first (though they have the same value), which could
-       be confusing for developers reading the code. Additionally, the use of !important
-       in both declarations makes it difficult to override these styles if needed in
-       the future. One of these duplicate declarations should be removed to clean up the
-       CSS and avoid confusion.
-    */
-    border-radius: var(--radius-md) !important;
     border-radius: var(--radius-md) !important;
     width: 2.75rem !important;
     height: 2.75rem !important;


### PR DESCRIPTION
💡 **What**: Removed redundant duplicate `border-radius: var(--radius-md) !important;` CSS property declaration on `.leaflet-control-zoom-in, .leaflet-control-zoom-out` and its associated `/* TODO */` block.
🎯 **Why**: It was a redundant duplicate declaration serving no purpose and increasing the CSS file size unnecessarily.
🔬 **Verification**: Run `pnpm test` and ensured all tests passed successfully. Took a visual screenshot of the application via Playwright to ensure the zoom controls render correctly without visual regressions.

---
*PR created automatically by Jules for task [17373167114315935321](https://jules.google.com/task/17373167114315935321) started by @2fst4u*