### PR TITLE
🧪 Spec: Add Tile Proxy CORS headers coverage

### DIFF
--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -1,6 +1,5 @@
-
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import worker from '../src/worker.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import worker from "../src/worker.js";
 
 // --- Mocks ---
 
@@ -19,26 +18,26 @@ const mockCache = {
 };
 
 // Mock Global Caches
-vi.stubGlobal('caches', {
+vi.stubGlobal("caches", {
   default: mockCache,
 });
 
 // Mock Crypto for SRI checks
 // Use vi.stubGlobal or defineProperty since global.crypto is read-only in some envs
-Object.defineProperty(global, 'crypto', {
+Object.defineProperty(global, "crypto", {
   value: {
     subtle: {
       digest: vi.fn(async (algo, buffer) => {
         return new ArrayBuffer(32);
-      })
-    }
+      }),
+    },
   },
-  writable: true
+  writable: true,
 });
 
 // --- Tests ---
 
-describe('Worker Logic', () => {
+describe("Worker Logic", () => {
   let mockFetch;
 
   beforeEach(() => {
@@ -46,10 +45,10 @@ describe('Worker Logic', () => {
     vi.clearAllMocks();
 
     mockFetch = vi.fn();
-    vi.stubGlobal('fetch', mockFetch);
+    vi.stubGlobal("fetch", mockFetch);
 
-    vi.stubGlobal('env', { ENVIRONMENT: 'test' });
-    vi.stubGlobal('ctx', {
+    vi.stubGlobal("env", { ENVIRONMENT: "test" });
+    vi.stubGlobal("ctx", {
       waitUntil: vi.fn(),
     });
   });
@@ -61,128 +60,138 @@ describe('Worker Logic', () => {
   const createRequest = (path, options = {}) => {
     const url = `https://circuit-weather.racing${path}`;
     const headers = new Headers(options.headers || {});
-    if (!headers.has('Sec-Fetch-Site')) {
-      headers.set('Sec-Fetch-Site', 'same-origin');
+    if (!headers.has("Sec-Fetch-Site")) {
+      headers.set("Sec-Fetch-Site", "same-origin");
     }
     return new Request(url, {
-      method: options.method || 'GET',
+      method: options.method || "GET",
       headers: headers,
     });
   };
 
-  describe('Router & Security', () => {
-    it('returns 405 for non-GET/HEAD methods', async () => {
-      const req = createRequest('/api/health', { method: 'POST' });
+  describe("Router & Security", () => {
+    it("returns 405 for non-GET/HEAD methods", async () => {
+      const req = createRequest("/api/health", { method: "POST" });
       const res = await worker.fetch(req, global.env, global.ctx);
       expect(res.status).toBe(405);
     });
 
-    it('returns 404 for unknown routes', async () => {
-      const req = createRequest('/api/unknown');
+    it("returns 404 for unknown routes", async () => {
+      const req = createRequest("/api/unknown");
       const res = await worker.fetch(req, global.env, global.ctx);
       expect(res.status).toBe(404);
     });
 
-    it('blocks hotlinking (invalid Origin/Referer)', async () => {
-      const req = new Request('https://circuit-weather.racing/api/health', {
-        headers: {}
+    it("blocks hotlinking (invalid Origin/Referer)", async () => {
+      const req = new Request("https://circuit-weather.racing/api/health", {
+        headers: {},
       });
       const res = await worker.fetch(req, global.env, global.ctx);
       expect(res.status).toBe(403);
     });
   });
 
-  describe('Health Check (/api/health)', () => {
-    it('returns 200 and status ok', async () => {
+  describe("Health Check (/api/health)", () => {
+    it("returns 200 and status ok", async () => {
       mockFetch.mockResolvedValue({
         status: 200,
         ok: true,
-        text: async () => 'ok'
+        text: async () => "ok",
       });
 
-      const req = createRequest('/api/health');
+      const req = createRequest("/api/health");
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(200);
       const data = await res.json();
-      expect(data.status).toBe('ok');
+      expect(data.status).toBe("ok");
     });
   });
 
-  describe('F1 API Proxy (/api/f1/*)', () => {
-    it('proxies request to Jolpica and caches result', async () => {
+  describe("F1 API Proxy (/api/f1/*)", () => {
+    it("proxies request to Jolpica and caches result", async () => {
       const upstreamData = { MRData: { raceTable: {} } };
-      mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(upstreamData), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' }
-      }));
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify(upstreamData), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
 
-      const req = createRequest('/api/f1/current');
+      const req = createRequest("/api/f1/current");
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual(upstreamData);
       expect(mockCache.put).toHaveBeenCalled();
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('api.jolpi.ca/ergast/f1/current'),
-        expect.any(Object)
+        expect.stringContaining("api.jolpi.ca/ergast/f1/current"),
+        expect.any(Object),
       );
     });
 
-    it('returns cached response if available', async () => {
+    it("returns cached response if available", async () => {
       const cachedData = { cached: true };
       const cacheResponse = new Response(JSON.stringify(cachedData), {
-        headers: { 'Content-Type': 'application/json' }
+        headers: { "Content-Type": "application/json" },
       });
-      cacheStore.set('https://api.jolpi.ca/ergast/f1/current', cacheResponse);
+      cacheStore.set("https://api.jolpi.ca/ergast/f1/current", cacheResponse);
 
-      const req = createRequest('/api/f1/current', {
-        headers: { 'Origin': 'https://circuit-weather.racing' }
+      const req = createRequest("/api/f1/current", {
+        headers: { Origin: "https://circuit-weather.racing" },
       });
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual(cachedData);
-      expect(res.headers.get('X-Cache')).toBe('HIT');
-      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://circuit-weather.racing');
+      expect(res.headers.get("X-Cache")).toBe("HIT");
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://circuit-weather.racing",
+      );
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it('returns cached response without CORS when origin is missing', async () => {
+    it("returns cached response without CORS when origin is missing", async () => {
       const cachedData = { cached: true };
       const cacheResponse = new Response(JSON.stringify(cachedData), {
-        headers: { 'Content-Type': 'application/json' }
+        headers: { "Content-Type": "application/json" },
       });
-      cacheStore.set('https://api.jolpi.ca/ergast/f1/current', cacheResponse);
+      cacheStore.set("https://api.jolpi.ca/ergast/f1/current", cacheResponse);
 
-      const req = createRequest('/api/f1/current'); // No Origin header by default
+      const req = createRequest("/api/f1/current"); // No Origin header by default
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual(cachedData);
-      expect(res.headers.get('X-Cache')).toBe('HIT');
-      expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
+      expect(res.headers.get("X-Cache")).toBe("HIT");
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it('validates API path (blocks injection/traversal)', async () => {
+    it("validates API path (blocks injection/traversal)", async () => {
       // Note: URL parsing normalizes path segments like /../ automatically.
       // We test a non-segment ".." to ensure the explicit check works.
-      const req = createRequest('/api/f1/drivers/vet..tel');
+      const req = createRequest("/api/f1/drivers/vet..tel");
       const res = await worker.fetch(req, global.env, global.ctx);
       expect(res.status).toBe(400);
     });
   });
 
-  describe('Radar API (/api/radar)', () => {
-    it('fetches rainviewer data and caches it', async () => {
-      const mockRadarData = { version: '2.0', host: 'https://x.com', radar: {} };
-      mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(mockRadarData), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' }
-      }));
+  describe("Radar API (/api/radar)", () => {
+    it("fetches rainviewer data and caches it", async () => {
+      const mockRadarData = {
+        version: "2.0",
+        host: "https://x.com",
+        radar: {},
+      };
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify(mockRadarData), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
 
-      const req = createRequest('/api/radar');
+      const req = createRequest("/api/radar");
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(200);
@@ -190,11 +199,11 @@ describe('Worker Logic', () => {
       expect(mockCache.put).toHaveBeenCalled();
     });
 
-    it('handles upstream errors gracefully (empty response)', async () => {
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      mockFetch.mockResolvedValueOnce(new Response('Error', { status: 500 }));
+    it("handles upstream errors gracefully (empty response)", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      mockFetch.mockResolvedValueOnce(new Response("Error", { status: 500 }));
 
-      const req = createRequest('/api/radar');
+      const req = createRequest("/api/radar");
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(200);
@@ -202,33 +211,35 @@ describe('Worker Logic', () => {
       // Ensure we get the empty radar structure defined in getEmptyRadarResponse
       expect(data.radar).toBeDefined();
       expect(data.radar.past).toEqual([]);
-      expect(res.headers.get('X-Upstream-Status')).toBe('500');
+      expect(res.headers.get("X-Upstream-Status")).toBe("500");
       expect(errorSpy).toHaveBeenCalled();
       errorSpy.mockRestore();
     });
 
-    it('handles fetch exceptions gracefully', async () => {
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+    it("handles fetch exceptions gracefully", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
 
-      const req = createRequest('/api/radar');
+      const req = createRequest("/api/radar");
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(502);
       const data = await res.json();
-      expect(data.error).toBe('Failed to fetch radar data');
+      expect(data.error).toBe("Failed to fetch radar data");
       expect(errorSpy).toHaveBeenCalled();
       errorSpy.mockRestore();
     });
 
-    it('blocks invalid content-type from upstream radar', async () => {
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({}), {
-        status: 200,
-        headers: { 'Content-Type': 'text/html' }
-      }));
+    it("blocks invalid content-type from upstream radar", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "Content-Type": "text/html" },
+        }),
+      );
 
-      const req = createRequest('/api/radar');
+      const req = createRequest("/api/radar");
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(200);
@@ -239,231 +250,285 @@ describe('Worker Logic', () => {
       errorSpy.mockRestore();
     });
 
-    it('sets CORS headers when valid Origin is provided', async () => {
-      mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({ radar: { past: [] } }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' }
-      }));
+    it("sets CORS headers when valid Origin is provided", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ radar: { past: [] } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
 
-      const req = createRequest('/api/radar', {
-        headers: { 'Origin': 'https://circuit-weather.racing' }
+      const req = createRequest("/api/radar", {
+        headers: { Origin: "https://circuit-weather.racing" },
       });
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(200);
-      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://circuit-weather.racing');
-      expect(res.headers.get('Vary')).toBe('Origin');
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://circuit-weather.racing",
+      );
+      expect(res.headers.get("Vary")).toBe("Origin");
     });
 
-    it('handles upstream rate limit (429) for radar', async () => {
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({ error: 'Rate Limit' }), {
-        status: 429,
-        headers: { 'Content-Type': 'application/json', 'Retry-After': '60' }
-      }));
+    it("handles upstream rate limit (429) for radar", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "Rate Limit" }), {
+          status: 429,
+          headers: { "Content-Type": "application/json", "Retry-After": "60" },
+        }),
+      );
 
-      const req = createRequest('/api/radar');
+      const req = createRequest("/api/radar");
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(429);
       const data = await res.json();
-      expect(data.error).toBe('Upstream Rate Limit');
-      expect(res.headers.get('Retry-After')).toBe('60');
+      expect(data.error).toBe("Upstream Rate Limit");
+      expect(res.headers.get("Retry-After")).toBe("60");
       expect(errorSpy).toHaveBeenCalled();
       errorSpy.mockRestore();
     });
 
-    it('returns cached response for radar with valid origin', async () => {
-        const cachedData = { version: '2.0', host: 'https://x.com', radar: {} };
-        const cacheResponse = new Response(JSON.stringify(cachedData), {
-          headers: { 'Content-Type': 'application/json' }
-        });
-        cacheStore.set('https://api.rainviewer.com/public/weather-maps.json', cacheResponse);
-
-        const req = createRequest('/api/radar', {
-          headers: { 'Origin': 'https://circuit-weather.racing' }
-        });
-        const res = await worker.fetch(req, global.env, global.ctx);
-
-        expect(res.status).toBe(200);
-        expect(await res.json()).toEqual(cachedData);
-        expect(res.headers.get('X-Cache')).toBe('HIT');
-        expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://circuit-weather.racing');
-        expect(mockFetch).not.toHaveBeenCalled();
+    it("returns cached response for radar with valid origin", async () => {
+      const cachedData = { version: "2.0", host: "https://x.com", radar: {} };
+      const cacheResponse = new Response(JSON.stringify(cachedData), {
+        headers: { "Content-Type": "application/json" },
       });
+      cacheStore.set(
+        "https://api.rainviewer.com/public/weather-maps.json",
+        cacheResponse,
+      );
 
-    it('returns cached response for radar without CORS when origin is missing', async () => {
-        const cachedData = { version: '2.0', host: 'https://x.com', radar: {} };
-        const cacheResponse = new Response(JSON.stringify(cachedData), {
-          headers: { 'Content-Type': 'application/json' }
-        });
-        cacheStore.set('https://api.rainviewer.com/public/weather-maps.json', cacheResponse);
-
-        const req = createRequest('/api/radar');
-        const res = await worker.fetch(req, global.env, global.ctx);
-
-        expect(res.status).toBe(200);
-        expect(await res.json()).toEqual(cachedData);
-        expect(res.headers.get('X-Cache')).toBe('HIT');
-        expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
-        expect(mockFetch).not.toHaveBeenCalled();
+      const req = createRequest("/api/radar", {
+        headers: { Origin: "https://circuit-weather.racing" },
       });
+      const res = await worker.fetch(req, global.env, global.ctx);
 
-    it('blocks radar request with invalid fetch destination', async () => {
-      const req = new Request('https://circuit-weather.racing/api/radar', {
-        headers: { 'Sec-Fetch-Dest': 'script', 'Sec-Fetch-Site': 'same-origin' }
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(cachedData);
+      expect(res.headers.get("X-Cache")).toBe("HIT");
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://circuit-weather.racing",
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns cached response for radar without CORS when origin is missing", async () => {
+      const cachedData = { version: "2.0", host: "https://x.com", radar: {} };
+      const cacheResponse = new Response(JSON.stringify(cachedData), {
+        headers: { "Content-Type": "application/json" },
+      });
+      cacheStore.set(
+        "https://api.rainviewer.com/public/weather-maps.json",
+        cacheResponse,
+      );
+
+      const req = createRequest("/api/radar");
+      const res = await worker.fetch(req, global.env, global.ctx);
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(cachedData);
+      expect(res.headers.get("X-Cache")).toBe("HIT");
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("blocks radar request with invalid fetch destination", async () => {
+      const req = new Request("https://circuit-weather.racing/api/radar", {
+        headers: {
+          "Sec-Fetch-Dest": "script",
+          "Sec-Fetch-Site": "same-origin",
+        },
       });
       const res = await worker.fetch(req, global.env, global.ctx);
       expect(res.status).toBe(403);
     });
 
-    it('returns radar response without CORS when origin is missing', async () => {
-        mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({ radar: { past: [] } }), {
+    it("returns radar response without CORS when origin is missing", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ radar: { past: [] } }), {
           status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        }));
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
 
-        const req = createRequest('/api/radar'); // No Origin header by default
-        const res = await worker.fetch(req, global.env, global.ctx);
+      const req = createRequest("/api/radar"); // No Origin header by default
+      const res = await worker.fetch(req, global.env, global.ctx);
 
-        expect(res.status).toBe(200);
-        expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
-      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+    });
   });
 
-  describe('Track Proxy (/api/track/*)', () => {
-    it('fetches geojson from github', async () => {
-      const mockGeoJson = { type: 'FeatureCollection', features: [] };
-      mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(mockGeoJson), {
-        status: 200,
-      }));
+  describe("Track Proxy (/api/track/*)", () => {
+    it("fetches geojson from github", async () => {
+      const mockGeoJson = { type: "FeatureCollection", features: [] };
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify(mockGeoJson), {
+          status: 200,
+        }),
+      );
 
-      const req = createRequest('/api/track/monaco');
+      const req = createRequest("/api/track/monaco");
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual(mockGeoJson);
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('bacinger/f1-circuits/master/circuits/monaco.geojson'),
-        expect.any(Object)
+        expect.stringContaining(
+          "bacinger/f1-circuits/master/circuits/monaco.geojson",
+        ),
+        expect.any(Object),
       );
     });
 
-    it('validates track ID', async () => {
-      const req = createRequest('/api/track/invalid<script>');
+    it("validates track ID", async () => {
+      const req = createRequest("/api/track/invalid<script>");
       const res = await worker.fetch(req, global.env, global.ctx);
       expect(res.status).toBe(400);
     });
   });
 
-  describe('Leaflet Assets Proxy (/api/assets/*)', () => {
+  describe("Leaflet Assets Proxy (/api/assets/*)", () => {
     // Valid hash for leaflet.js from worker.js
-    const VALID_HASH_B64 = '20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=';
+    const VALID_HASH_B64 = "20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=";
 
     // Helper to setup crypto mock to return matching or mismatching hash
     const setupCryptoMock = (shouldMatch) => {
       const buffer = shouldMatch
-        ? Uint8Array.from(atob(VALID_HASH_B64), c => c.charCodeAt(0)).buffer
+        ? Uint8Array.from(atob(VALID_HASH_B64), (c) => c.charCodeAt(0)).buffer
         : new ArrayBuffer(32); // Random empty buffer (mismatch)
 
-      Object.defineProperty(global, 'crypto', {
+      Object.defineProperty(global, "crypto", {
         value: {
           subtle: {
-            digest: vi.fn(async () => buffer)
-          }
+            digest: vi.fn(async () => buffer),
+          },
         },
-        writable: true
+        writable: true,
       });
     };
 
-    it('proxies valid asset with correct SRI', async () => {
+    it("proxies valid asset with correct SRI", async () => {
       setupCryptoMock(true);
 
       const mockScript = 'console.log("leaflet")';
-      mockFetch.mockResolvedValueOnce(new Response(mockScript, {
-        status: 200,
-        headers: { 'Content-Type': 'application/javascript' }
-      }));
+      mockFetch.mockResolvedValueOnce(
+        new Response(mockScript, {
+          status: 200,
+          headers: { "Content-Type": "application/javascript" },
+        }),
+      );
 
-      const req = createRequest('/api/assets/leaflet.js');
+      const req = createRequest("/api/assets/leaflet.js");
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(200);
-      expect(res.headers.get('Content-Type')).toBe('application/javascript');
+      expect(res.headers.get("Content-Type")).toBe("application/javascript");
       expect(mockCache.put).toHaveBeenCalled();
     });
 
-    it('blocks asset with SRI mismatch', async () => {
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    it("blocks asset with SRI mismatch", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       setupCryptoMock(false); // Returns random hash
 
       const mockScript = 'console.log("hacked")';
-      mockFetch.mockResolvedValueOnce(new Response(mockScript, {
-        status: 200,
-        headers: { 'Content-Type': 'application/javascript' }
-      }));
+      mockFetch.mockResolvedValueOnce(
+        new Response(mockScript, {
+          status: 200,
+          headers: { "Content-Type": "application/javascript" },
+        }),
+      );
 
-      const req = createRequest('/api/assets/leaflet.js');
+      const req = createRequest("/api/assets/leaflet.js");
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(502); // Bad Gateway (SRI failed)
-      expect(await res.text()).toContain('SRI Integrity Check Failed');
+      expect(await res.text()).toContain("SRI Integrity Check Failed");
       expect(errorSpy).toHaveBeenCalled();
       errorSpy.mockRestore();
     });
 
-    it('returns 404 for unknown asset', async () => {
-      const req = createRequest('/api/assets/unknown.js');
+    it("returns 404 for unknown asset", async () => {
+      const req = createRequest("/api/assets/unknown.js");
       const res = await worker.fetch(req, global.env, global.ctx);
       expect(res.status).toBe(404);
     });
   });
 
-  describe('Tile Proxy (/api/tiles/*)', () => {
-    it('proxies valid png requests', async () => {
+  describe("Tile Proxy (/api/tiles/*)", () => {
+    it("proxies valid png requests", async () => {
       const mockImage = new ArrayBuffer(10);
-      mockFetch.mockResolvedValueOnce(new Response(mockImage, {
-        status: 200,
-        headers: { 'Content-Type': 'image/png' }
-      }));
+      mockFetch.mockResolvedValueOnce(
+        new Response(mockImage, {
+          status: 200,
+          headers: { "Content-Type": "image/png" },
+        }),
+      );
 
-      const req = createRequest('/api/tiles/v2/radar/1/2/3/512/1/1_1.png');
+      const req = createRequest("/api/tiles/v2/radar/1/2/3/512/1/1_1.png");
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(200);
-      expect(res.headers.get('Content-Type')).toBe('image/png');
+      expect(res.headers.get("Content-Type")).toBe("image/png");
       expect(mockCache.put).toHaveBeenCalled();
     });
 
-    it('returns tile response without CORS when origin is missing', async () => {
+    it("sets CORS headers for tile response when valid Origin is provided", async () => {
       const mockImage = new ArrayBuffer(10);
-      mockFetch.mockResolvedValueOnce(new Response(mockImage, {
-        status: 200,
-        headers: { 'Content-Type': 'image/png' }
-      }));
+      mockFetch.mockResolvedValueOnce(
+        new Response(mockImage, {
+          status: 200,
+          headers: { "Content-Type": "image/png" },
+        }),
+      );
 
-      const req = createRequest('/api/tiles/v2/radar/1/2/3/512/1/1_1.png');
+      const req = createRequest("/api/tiles/v2/radar/1/2/3/512/1/1_1.png", {
+        headers: { Origin: "https://circuit-weather.racing" },
+      });
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(200);
-      expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://circuit-weather.racing",
+      );
+      expect(res.headers.get("Vary")).toBe("Origin");
     });
 
-    it('blocks non-png requests', async () => {
-      const req = createRequest('/api/tiles/hack.exe');
+    it("returns tile response without CORS when origin is missing", async () => {
+      const mockImage = new ArrayBuffer(10);
+      mockFetch.mockResolvedValueOnce(
+        new Response(mockImage, {
+          status: 200,
+          headers: { "Content-Type": "image/png" },
+        }),
+      );
+
+      const req = createRequest("/api/tiles/v2/radar/1/2/3/512/1/1_1.png");
+      const res = await worker.fetch(req, global.env, global.ctx);
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+    });
+
+    it("blocks non-png requests", async () => {
+      const req = createRequest("/api/tiles/hack.exe");
       const res = await worker.fetch(req, global.env, global.ctx);
       expect(res.status).toBe(400);
     });
 
-    it('enforces strict upstream content-type (anti-sniffing)', async () => {
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      mockFetch.mockResolvedValueOnce(new Response('<html>Error</html>', {
-        status: 200,
-        headers: { 'Content-Type': 'text/html' }
-      }));
+    it("enforces strict upstream content-type (anti-sniffing)", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      mockFetch.mockResolvedValueOnce(
+        new Response("<html>Error</html>", {
+          status: 200,
+          headers: { "Content-Type": "text/html" },
+        }),
+      );
 
       // The URL implies a png, but upstream returns html
-      const req = createRequest('/api/tiles/v2/radar/1.png');
+      const req = createRequest("/api/tiles/v2/radar/1.png");
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(502); // Bad Gateway
@@ -471,59 +536,85 @@ describe('Worker Logic', () => {
       errorSpy.mockRestore();
     });
 
-    it('returns safe JSON error for upstream 404 (non-image) and caches it', async () => {
+    it("returns safe JSON error for upstream 404 (non-image) and caches it", async () => {
       // Simulate upstream returning HTML error page (e.g. standard 404)
-      mockFetch.mockResolvedValueOnce(new Response('<html>Not Found</html>', {
-        status: 404,
-        headers: { 'Content-Type': 'text/html' }
-      }));
+      mockFetch.mockResolvedValueOnce(
+        new Response("<html>Not Found</html>", {
+          status: 404,
+          headers: { "Content-Type": "text/html" },
+        }),
+      );
 
-      const req = createRequest('/api/tiles/v2/radar/missing.png');
+      const req = createRequest("/api/tiles/v2/radar/missing.png");
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(404);
-      expect(res.headers.get('Content-Type')).toBe('application/json');
+      expect(res.headers.get("Content-Type")).toBe("application/json");
       const body = await res.json();
-      expect(body.error).toBe('Tile not found');
+      expect(body.error).toBe("Tile not found");
 
       // Verify caching behavior
       expect(mockCache.put).toHaveBeenCalled();
     });
 
-    it('handles upstream rate limit (429) correctly', async () => {
-      mockFetch.mockResolvedValueOnce(new Response('Rate Limit', {
-        status: 429,
-        headers: {
-          'Retry-After': '120',
-          'Content-Type': 'text/plain'
-        }
-      }));
+    it("sets CORS headers for safe 404 tile response when valid Origin is provided", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response("<html>Not Found</html>", {
+          status: 404,
+          headers: { "Content-Type": "text/html" },
+        }),
+      );
 
-      const req = createRequest('/api/tiles/v2/radar/limit.png');
+      const req = createRequest("/api/tiles/v2/radar/missing.png", {
+        headers: { Origin: "https://circuit-weather.racing" },
+      });
+      const res = await worker.fetch(req, global.env, global.ctx);
+
+      expect(res.status).toBe(404);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://circuit-weather.racing",
+      );
+      expect(res.headers.get("Vary")).toBe("Origin");
+    });
+
+    it("handles upstream rate limit (429) correctly", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response("Rate Limit", {
+          status: 429,
+          headers: {
+            "Retry-After": "120",
+            "Content-Type": "text/plain",
+          },
+        }),
+      );
+
+      const req = createRequest("/api/tiles/v2/radar/limit.png");
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(429);
-      expect(res.headers.get('Retry-After')).toBe('120');
-      expect(res.headers.get('X-Upstream-Status')).toBe('429');
+      expect(res.headers.get("Retry-After")).toBe("120");
+      expect(res.headers.get("X-Upstream-Status")).toBe("429");
     });
 
-    it('handles upstream server error (500) correctly', async () => {
-      mockFetch.mockResolvedValueOnce(new Response('Server Error', {
-        status: 500
-      }));
+    it("handles upstream server error (500) correctly", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response("Server Error", {
+          status: 500,
+        }),
+      );
 
-      const req = createRequest('/api/tiles/v2/radar/error.png');
+      const req = createRequest("/api/tiles/v2/radar/error.png");
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(500);
-      expect(res.headers.get('X-Upstream-Status')).toBe('500');
+      expect(res.headers.get("X-Upstream-Status")).toBe("500");
     });
 
-    it('handles fetch exceptions gracefully', async () => {
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+    it("handles fetch exceptions gracefully", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
 
-      const req = createRequest('/api/tiles/v2/radar/error.png');
+      const req = createRequest("/api/tiles/v2/radar/error.png");
       const res = await worker.fetch(req, global.env, global.ctx);
 
       expect(res.status).toBe(502);
@@ -531,5 +622,4 @@ describe('Worker Logic', () => {
       errorSpy.mockRestore();
     });
   });
-
 });


### PR DESCRIPTION
💡 What: Added two robust tests for the Tile Proxy (`/api/tiles/*`) endpoint in `tests/worker.test.js` to assert that correct CORS headers (`Access-Control-Allow-Origin` and `Vary`) are appropriately set when a valid `Origin` is provided. This covers both successful 200 responses and 404 handled safe responses.
🎯 Why: Fortifying the test suite's boundary checks on integrations ensures future UI clients handle external resources securely without unintentional proxy mismatches.
📈 Maturity Impact: N/A, currently sitting comfortably at standard.

---
*PR created automatically by Jules for task [15078413619918574761](https://jules.google.com/task/15078413619918574761) started by @2fst4u*