### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS bypass on DOMParser failure in Markdown parser

### DIFF
--- a/public/src/ui/PrivacyModal.js
+++ b/public/src/ui/PrivacyModal.js
@@ -1,67 +1,67 @@
-import { escapeHtml } from '../utils/escapeHtml.js';
+import { escapeHtml } from "../utils/escapeHtml.js";
 
 export class PrivacyModal {
-    constructor() {
-        this.backdrop = document.getElementById('privacyModalBackdrop');
-        this.content = document.getElementById('privacyModalContent');
-        this.closeBtn = document.getElementById('privacyModalClose');
-        this.privacyLink = document.getElementById('privacyLink');
-        this.loaded = false;
-        this.triggerElement = null;
-        this._handleFocusTrap = this.handleFocusTrap.bind(this);
-        this.bindEvents();
+  constructor() {
+    this.backdrop = document.getElementById("privacyModalBackdrop");
+    this.content = document.getElementById("privacyModalContent");
+    this.closeBtn = document.getElementById("privacyModalClose");
+    this.privacyLink = document.getElementById("privacyLink");
+    this.loaded = false;
+    this.triggerElement = null;
+    this._handleFocusTrap = this.handleFocusTrap.bind(this);
+    this.bindEvents();
+  }
+
+  bindEvents() {
+    if (this.privacyLink) {
+      this.privacyLink.addEventListener("click", (e) => {
+        e.preventDefault();
+        this.open();
+      });
+      // Palette A11y: Ensure keyboard users can activate the link functioning as a button
+      this.privacyLink.addEventListener("keydown", (e) => {
+        if (e.key === " " || e.key === "Spacebar") {
+          e.preventDefault();
+          this.open();
+        }
+      });
     }
 
-    bindEvents() {
-        if (this.privacyLink) {
-            this.privacyLink.addEventListener('click', (e) => {
-                e.preventDefault();
-                this.open();
-            });
-            // Palette A11y: Ensure keyboard users can activate the link functioning as a button
-            this.privacyLink.addEventListener('keydown', (e) => {
-                if (e.key === ' ' || e.key === 'Spacebar') {
-                    e.preventDefault();
-                    this.open();
-                }
-            });
-        }
-
-        if (this.closeBtn) {
-            this.closeBtn.addEventListener('click', () => this.close());
-        }
-
-        if (this.backdrop) {
-            this.backdrop.addEventListener('click', (e) => {
-                if (e.target === this.backdrop) this.close();
-            });
-        }
-
-        // Close on Escape key
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'Escape' && this.backdrop?.classList.contains('visible')) {
-                this.close();
-            }
-        });
+    if (this.closeBtn) {
+      this.closeBtn.addEventListener("click", () => this.close());
     }
 
-    async open() {
-        this.triggerElement = document.activeElement;
+    if (this.backdrop) {
+      this.backdrop.addEventListener("click", (e) => {
+        if (e.target === this.backdrop) this.close();
+      });
+    }
 
-        // Palette UX: Show modal immediately to prevent perceived lag
-        if (this.backdrop) {
-            this.backdrop.classList.add('visible');
-            document.body.style.overflow = 'hidden';
-            // Move focus to close button for accessibility
-            if (this.closeBtn) this.closeBtn.focus();
-            // Enable focus trap
-            this.backdrop.addEventListener('keydown', this._handleFocusTrap);
-        }
+    // Close on Escape key
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && this.backdrop?.classList.contains("visible")) {
+        this.close();
+      }
+    });
+  }
 
-        if (!this.loaded) {
-            // Palette UX: Show skeleton loading state while fetching
-            if (this.content) {
-                this.content.innerHTML = `
+  async open() {
+    this.triggerElement = document.activeElement;
+
+    // Palette UX: Show modal immediately to prevent perceived lag
+    if (this.backdrop) {
+      this.backdrop.classList.add("visible");
+      document.body.style.overflow = "hidden";
+      // Move focus to close button for accessibility
+      if (this.closeBtn) this.closeBtn.focus();
+      // Enable focus trap
+      this.backdrop.addEventListener("keydown", this._handleFocusTrap);
+    }
+
+    if (!this.loaded) {
+      // Palette UX: Show skeleton loading state while fetching
+      if (this.content) {
+        this.content.innerHTML = `
                     <div class="skeleton" style="height: 1.5rem; width: 30%; margin-bottom: 1rem; border-radius: var(--radius-sm);"></div>
                     <div class="skeleton" style="height: 1rem; width: 100%; margin-bottom: 0.5rem; border-radius: var(--radius-sm);"></div>
                     <div class="skeleton" style="height: 1rem; width: 95%; margin-bottom: 0.5rem; border-radius: var(--radius-sm);"></div>
@@ -71,148 +71,156 @@ export class PrivacyModal {
                     <div class="skeleton" style="height: 1rem; width: 100%; margin-bottom: 0.5rem; border-radius: var(--radius-sm);"></div>
                     <div class="skeleton" style="height: 1rem; width: 85%; margin-bottom: 0.5rem; border-radius: var(--radius-sm);"></div>
                 `;
-            }
-            await this.loadContent();
-        }
+      }
+      await this.loadContent();
     }
+  }
 
-    close() {
-        if (this.backdrop) {
-            this.backdrop.classList.remove('visible');
-            document.body.style.overflow = '';
-            // Remove focus trap
-            this.backdrop.removeEventListener('keydown', this._handleFocusTrap);
-            // Restore focus to trigger element
-            if (this.triggerElement) {
-                this.triggerElement.focus();
-                this.triggerElement = null;
-            }
-        }
+  close() {
+    if (this.backdrop) {
+      this.backdrop.classList.remove("visible");
+      document.body.style.overflow = "";
+      // Remove focus trap
+      this.backdrop.removeEventListener("keydown", this._handleFocusTrap);
+      // Restore focus to trigger element
+      if (this.triggerElement) {
+        this.triggerElement.focus();
+        this.triggerElement = null;
+      }
     }
+  }
 
-    handleFocusTrap(e) {
-        if (e.key !== 'Tab') return;
+  handleFocusTrap(e) {
+    if (e.key !== "Tab") return;
 
-        const focusableSelectors = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
-        // Palette A11y: Filter out hidden elements to prevent focus trap from getting stuck
-        const focusableElements = Array.from(this.backdrop.querySelectorAll(focusableSelectors))
-            .filter(el => el.offsetParent !== null);
+    const focusableSelectors =
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+    // Palette A11y: Filter out hidden elements to prevent focus trap from getting stuck
+    const focusableElements = Array.from(
+      this.backdrop.querySelectorAll(focusableSelectors),
+    ).filter((el) => el.offsetParent !== null);
 
-        if (focusableElements.length === 0) return;
+    if (focusableElements.length === 0) return;
 
-        const firstElement = focusableElements[0];
-        const lastElement = focusableElements[focusableElements.length - 1];
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
 
-        if (e.shiftKey) {
-            if (document.activeElement === firstElement) {
-                e.preventDefault();
-                lastElement.focus();
-            }
+    if (e.shiftKey) {
+      if (document.activeElement === firstElement) {
+        e.preventDefault();
+        lastElement.focus();
+      }
+    } else {
+      if (document.activeElement === lastElement) {
+        e.preventDefault();
+        firstElement.focus();
+      }
+    }
+  }
+
+  async loadContent() {
+    try {
+      const response = await fetch("/PRIVACY.md");
+      const markdown = await response.text();
+      if (this.content) {
+        this.content.innerHTML = this.parseMarkdown(markdown);
+      }
+      this.loaded = true;
+    } catch (error) {
+      console.error("Failed to load privacy policy:", error);
+      if (this.content) {
+        this.content.innerHTML =
+          "<p>Failed to load privacy policy. Please try again later.</p>";
+      }
+    }
+  }
+
+  parseMarkdown(md) {
+    // Simple markdown parser for privacy policy content
+
+    // SEC: Sanitize URLs to prevent XSS (e.g. javascript: links)
+    const sanitizeUrl = (url) => {
+      // SEC: Remove all whitespace/control chars to prevent scheme bypass (e.g. java\nscript:)
+      let clean = String(url).replace(/[\s\x00-\x1F\x7F-\x9F]/g, "");
+
+      // SEC: Decode ALL HTML entities that could bypass the scheme check (e.g. j&#x61;vascript:alert(1))
+      // The browser decodes entities in the href attribute before parsing the URL scheme,
+      // so we must check the fully decoded value.
+      try {
+        const doc = new DOMParser().parseFromString(clean, "text/html");
+        if (doc && doc.documentElement) {
+          clean = doc.documentElement.textContent || clean;
         } else {
-            if (document.activeElement === lastElement) {
-                e.preventDefault();
-                firstElement.focus();
-            }
+          return "#unsafe-url";
         }
-    }
+      } catch (e) {
+        // Fallback if DOMParser fails
+        return "#unsafe-url";
+      }
 
-    async loadContent() {
-        try {
-            const response = await fetch('/PRIVACY.md');
-            const markdown = await response.text();
-            if (this.content) {
-                this.content.innerHTML = this.parseMarkdown(markdown);
-            }
-            this.loaded = true;
-        } catch (error) {
-            console.error('Failed to load privacy policy:', error);
-            if (this.content) {
-                this.content.innerHTML = '<p>Failed to load privacy policy. Please try again later.</p>';
-            }
+      // Remove control characters and whitespace AGAIN after decoding, as entities might decode to them
+      clean = clean.replace(/[\s\x00-\x1F\x7F-\x9F]/g, "");
+
+      // Allowlist approach: Check for protocol scheme
+      // Regex: Start with letter, followed by valid scheme chars, then colon
+      if (/^[a-z][a-z0-9+.-]*:/i.test(clean)) {
+        // If scheme exists, it MUST be in our allowlist
+        if (/^(?:https?|mailto):/i.test(clean)) {
+          // SEC: Return the original (encoded) string if it's safe, or the decoded one?
+          // Safe to return the decoded one since it's verified.
+          return escapeHtml(clean);
         }
-    }
+        // Block file:, javascript:, vbscript:, data:, blob:, etc.
+        return "#unsafe-url";
+      }
+      // No scheme (relative URL), allow
+      return escapeHtml(clean);
+    };
 
-    parseMarkdown(md) {
-        // Simple markdown parser for privacy policy content
-
-        // SEC: Sanitize URLs to prevent XSS (e.g. javascript: links)
-        const sanitizeUrl = (url) => {
-            // SEC: Remove all whitespace/control chars to prevent scheme bypass (e.g. java\nscript:)
-            let clean = String(url).replace(/[\s\x00-\x1F\x7F-\x9F]/g, '');
-
-            // SEC: Decode ALL HTML entities that could bypass the scheme check (e.g. j&#x61;vascript:alert(1))
-            // The browser decodes entities in the href attribute before parsing the URL scheme,
-            // so we must check the fully decoded value.
-            try {
-                const doc = new DOMParser().parseFromString(clean, 'text/html');
-                if (doc && doc.documentElement) {
-                    clean = doc.documentElement.textContent || clean;
-                }
-            } catch (e) {
-                // Fallback if DOMParser fails
-            }
-
-            // Remove control characters and whitespace AGAIN after decoding, as entities might decode to them
-            clean = clean.replace(/[\s\x00-\x1F\x7F-\x9F]/g, '');
-
-            // Allowlist approach: Check for protocol scheme
-            // Regex: Start with letter, followed by valid scheme chars, then colon
-            if (/^[a-z][a-z0-9+.-]*:/i.test(clean)) {
-                // If scheme exists, it MUST be in our allowlist
-                if (/^(?:https?|mailto):/i.test(clean)) {
-                    // SEC: Return the original (encoded) string if it's safe, or the decoded one?
-                    // Safe to return the decoded one since it's verified.
-                    return escapeHtml(clean);
-                }
-                // Block file:, javascript:, vbscript:, data:, blob:, etc.
-                return '#unsafe-url';
-            }
-            // No scheme (relative URL), allow
-            return escapeHtml(clean);
-        };
-
-        return escapeHtml(md)
-            // Remove the main title (we have it in the header)
-            .replace(/^# Privacy Policy\s*\n*/m, '')
-            // Headers (Escaped chars mean we look for escaped # if they were escaped, but # is safe)
-            // Note: Since we escaped first, we must match safe content.
-            // Standard markdown # is safe from escapeHtml unless it was &#... but # is not escaped.
-            .replace(/^### (.+)$/gm, '<h3>$1</h3>')
-            .replace(/^## (.+)$/gm, '<h2>$1</h2>')
-            // Bold
-            .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-            // Links
-            .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, text, url) => {
-                // Palette A11y: Add external link indicator and SR text
-                const icon = `<svg class="icon-external" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>`;
-                return `<a href="${sanitizeUrl(url)}" target="_blank" rel="noopener noreferrer" class="external-link">${text} ${icon}<span class="sr-only">(opens in a new tab)</span></a>`;
-            })
-            // List items
-            .replace(/^- (.+)$/gm, '<li>$1</li>')
-            // Wrap consecutive list items in ul
-            .replace(/(<li>.*<\/li>\n?)+/g, '<ul>$&</ul>')
-            // Paragraphs (lines that aren't headers, lists, or empty)
-            .split('\n\n')
-            .map(block => {
-                block = block.trim();
-                if (!block) return '';
-                // Since we generate safe HTML tags above (h3, h2, strong, a, li, ul)
-                // we can trust lines starting with these tags.
-                // The inputs $1, $2 are already escaped.
-                if (block.startsWith('<h') || block.startsWith('<ul')) return block;
-                // If it doesn't start with a generated tag, wrap it in p
-                // Note: The original check `block.startsWith('<')` would fail for escaped content like &lt;
-                // so we just check against our known safe tags.
-                if (!block.startsWith('<')) return `<p>${block}</p>`;
-                // If it starts with < but isn't one of ours (shouldn't happen due to escape), treat as text?
-                // But wait, if I have `&lt;img...` it starts with `&`.
-                // So the `startsWith('<')` check is actually tricky now.
-                // Let's refine:
-                // If I escaped everything, the ONLY things starting with < are the ones I just replaced.
-                // So if it starts with <, it's safe.
-                // If it starts with &lt;, it's text.
-                return block;
-            })
-            .join('\n');
-    }
+    return (
+      escapeHtml(md)
+        // Remove the main title (we have it in the header)
+        .replace(/^# Privacy Policy\s*\n*/m, "")
+        // Headers (Escaped chars mean we look for escaped # if they were escaped, but # is safe)
+        // Note: Since we escaped first, we must match safe content.
+        // Standard markdown # is safe from escapeHtml unless it was &#... but # is not escaped.
+        .replace(/^### (.+)$/gm, "<h3>$1</h3>")
+        .replace(/^## (.+)$/gm, "<h2>$1</h2>")
+        // Bold
+        .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+        // Links
+        .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, text, url) => {
+          // Palette A11y: Add external link indicator and SR text
+          const icon = `<svg class="icon-external" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>`;
+          return `<a href="${sanitizeUrl(url)}" target="_blank" rel="noopener noreferrer" class="external-link">${text} ${icon}<span class="sr-only">(opens in a new tab)</span></a>`;
+        })
+        // List items
+        .replace(/^- (.+)$/gm, "<li>$1</li>")
+        // Wrap consecutive list items in ul
+        .replace(/(<li>.*<\/li>\n?)+/g, "<ul>$&</ul>")
+        // Paragraphs (lines that aren't headers, lists, or empty)
+        .split("\n\n")
+        .map((block) => {
+          block = block.trim();
+          if (!block) return "";
+          // Since we generate safe HTML tags above (h3, h2, strong, a, li, ul)
+          // we can trust lines starting with these tags.
+          // The inputs $1, $2 are already escaped.
+          if (block.startsWith("<h") || block.startsWith("<ul")) return block;
+          // If it doesn't start with a generated tag, wrap it in p
+          // Note: The original check `block.startsWith('<')` would fail for escaped content like &lt;
+          // so we just check against our known safe tags.
+          if (!block.startsWith("<")) return `<p>${block}</p>`;
+          // If it starts with < but isn't one of ours (shouldn't happen due to escape), treat as text?
+          // But wait, if I have `&lt;img...` it starts with `&`.
+          // So the `startsWith('<')` check is actually tricky now.
+          // Let's refine:
+          // If I escaped everything, the ONLY things starting with < are the ones I just replaced.
+          // So if it starts with <, it's safe.
+          // If it starts with &lt;, it's text.
+          return block;
+        })
+        .join("\n")
+    );
+  }
 }

--- a/tests/privacy-modal.test.js
+++ b/tests/privacy-modal.test.js
@@ -1,575 +1,604 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // --- Global Mocks ---
 const createMockElement = (id) => {
-    const el = {
-        id,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        classList: {
-            add: vi.fn(),
-            remove: vi.fn(),
-            contains: vi.fn().mockReturnValue(false),
-        },
-        style: {},
-        setAttribute: vi.fn(),
-        removeAttribute: vi.fn(),
-        textContent: '',
-        innerHTML: '',
-        focus: vi.fn(function() {
-             // Correctly update activeElement when focus is called
-            mockActiveElement = this;
-        }),
-        querySelectorAll: vi.fn(() => []),
-        offsetParent: {},
-    };
-    return el;
+  const el = {
+    id,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    classList: {
+      add: vi.fn(),
+      remove: vi.fn(),
+      contains: vi.fn().mockReturnValue(false),
+    },
+    style: {},
+    setAttribute: vi.fn(),
+    removeAttribute: vi.fn(),
+    textContent: "",
+    innerHTML: "",
+    focus: vi.fn(function () {
+      // Correctly update activeElement when focus is called
+      mockActiveElement = this;
+    }),
+    querySelectorAll: vi.fn(() => []),
+    offsetParent: {},
+  };
+  return el;
 };
 
 // We need a way to control activeElement for tests
-let mockActiveElement = { tagName: 'BODY' };
+let mockActiveElement = { tagName: "BODY" };
 
-vi.stubGlobal('document', {
-    getElementById: vi.fn((id) => createMockElement(id)),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    get activeElement() { return mockActiveElement; },
-    set activeElement(el) { mockActiveElement = el; },
-    body: { style: {} },
+vi.stubGlobal("document", {
+  getElementById: vi.fn((id) => createMockElement(id)),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  get activeElement() {
+    return mockActiveElement;
+  },
+  set activeElement(el) {
+    mockActiveElement = el;
+  },
+  body: { style: {} },
 });
 
-vi.stubGlobal('fetch', vi.fn());
+vi.stubGlobal("fetch", vi.fn());
 
 // Mock DOMParser for tests since it's not natively available in the Node.js test environment
 class MockDOMParser {
-    parseFromString(str, type) {
-        // Simple mock implementation to handle entity decoding for our specific test cases
-        let decoded = str;
-        // Run a few times to handle nested encoded strings like `&amp;colon;` becoming `&colon;` then `:`
-        for (let i = 0; i < 3; i++) {
-            decoded = decoded
-                .replace(/&amp;/gi, '&')
-                .replace(/&colon;/gi, ':')
-                .replace(/&#58;/gi, ':')
-                .replace(/&#x3a;/gi, ':')
-                .replace(/&quot;/gi, '"');
-        }
-
-        return {
-            documentElement: {
-                textContent: decoded
-            }
-        };
+  parseFromString(str, type) {
+    // Simple mock implementation to handle entity decoding for our specific test cases
+    let decoded = str;
+    // Run a few times to handle nested encoded strings like `&amp;colon;` becoming `&colon;` then `:`
+    for (let i = 0; i < 3; i++) {
+      decoded = decoded
+        .replace(/&amp;/gi, "&")
+        .replace(/&colon;/gi, ":")
+        .replace(/&#58;/gi, ":")
+        .replace(/&#x3a;/gi, ":")
+        .replace(/&quot;/gi, '"');
     }
+
+    return {
+      documentElement: {
+        textContent: decoded,
+      },
+    };
+  }
 }
-vi.stubGlobal('DOMParser', MockDOMParser);
+vi.stubGlobal("DOMParser", MockDOMParser);
 
-const { PrivacyModal } = await import('../public/src/ui/PrivacyModal.js');
+const { PrivacyModal } = await import("../public/src/ui/PrivacyModal.js");
 
-describe('PrivacyModal', () => {
-    let modal;
+describe("PrivacyModal", () => {
+  let modal;
 
-    beforeEach(() => {
-        vi.clearAllMocks();
-        mockActiveElement = { tagName: 'BODY', focus: vi.fn() };
-        // Reset fetch to a default success
-        global.fetch.mockResolvedValue({
-            ok: true,
-            text: async () => 'Privacy Policy Content',
-        });
-        modal = new PrivacyModal();
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveElement = { tagName: "BODY", focus: vi.fn() };
+    // Reset fetch to a default success
+    global.fetch.mockResolvedValue({
+      ok: true,
+      text: async () => "Privacy Policy Content",
+    });
+    modal = new PrivacyModal();
+  });
+
+  // ---------------------------------------------------------------
+  // sanitizeUrl is a closure inside parseMarkdown, so we test it
+  // indirectly by passing markdown containing links and inspecting
+  // the href attribute in the rendered HTML.
+  // ---------------------------------------------------------------
+  describe("sanitizeUrl (via parseMarkdown)", () => {
+    const extractHref = (html) => {
+      const match = html.match(/href="([^"]*)"/);
+      return match ? match[1] : null;
+    };
+
+    it("allows https URLs", () => {
+      const md = "[link](https://example.com)";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("https://example.com");
     });
 
-    // ---------------------------------------------------------------
-    // sanitizeUrl is a closure inside parseMarkdown, so we test it
-    // indirectly by passing markdown containing links and inspecting
-    // the href attribute in the rendered HTML.
-    // ---------------------------------------------------------------
-    describe('sanitizeUrl (via parseMarkdown)', () => {
-        const extractHref = (html) => {
-            const match = html.match(/href="([^"]*)"/);
-            return match ? match[1] : null;
-        };
-
-        it('allows https URLs', () => {
-            const md = '[link](https://example.com)';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('https://example.com');
-        });
-
-        it('allows http URLs', () => {
-            const md = '[link](http://example.com)';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('http://example.com');
-        });
-
-        it('allows mailto URLs', () => {
-            const md = '[email](mailto:user@example.com)';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('mailto:user@example.com');
-        });
-
-        it('allows relative URLs (no scheme)', () => {
-            const md = '[page](/about)';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('/about');
-        });
-
-        it('blocks javascript: URLs', () => {
-            const md = '[click](javascript:alert(1))';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('#unsafe-url');
-        });
-
-        it('blocks vbscript: URLs', () => {
-            const md = '[click](vbscript:MsgBox)';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('#unsafe-url');
-        });
-
-        it('blocks data: URLs', () => {
-            const md = '[click](data:text/html,<h1>XSS</h1>)';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('#unsafe-url');
-        });
-
-        it('blocks file: URLs', () => {
-            const md = '[click](file:///etc/passwd)';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('#unsafe-url');
-        });
-
-        it('blocks blob: URLs', () => {
-            const md = '[click](blob:http://example.com/uuid)';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('#unsafe-url');
-        });
-
-        it('blocks whitespace bypass (java\\nscript:)', () => {
-            const md = '[click](java\nscript:alert(1))';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('#unsafe-url');
-        });
-
-        it('blocks control character bypass (java\\x00script:)', () => {
-            const md = '[click](java\x00script:alert(1))';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('#unsafe-url');
-        });
-
-        it('handles case-insensitive scheme detection', () => {
-            const md = '[click](JAVASCRIPT:alert(1))';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('#unsafe-url');
-        });
-
-        it('blocks HTML entity encoded scheme bypasses (&colon;)', () => {
-            const md = '[click](javascript&colon;alert(1))';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('#unsafe-url');
-        });
-
-        it('blocks HTML entity encoded scheme bypasses (&#58;)', () => {
-            const md = '[click](javascript&#58;alert(1))';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('#unsafe-url');
-        });
-
-        it('blocks HTML entity encoded scheme bypasses (&#x3a;)', () => {
-            const md = '[click](javascript&#x3a;alert(1))';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('#unsafe-url');
-        });
-
-        it('allows HTTPS in uppercase', () => {
-            const md = '[link](HTTPS://EXAMPLE.COM)';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('HTTPS://EXAMPLE.COM');
-        });
-
-        it('re-escapes entities that decode to quotes to prevent attribute breakout', () => {
-            const md = '[link](https://example.com/&quot;onmouseover=&quot;alert=1)';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('https://example.com/&quot;onmouseover=&quot;alert=1');
-        });
-
-        it('falls back to original string if DOMParser fails', () => {
-            // Temporarily mock DOMParser to throw an error
-            const originalDOMParser = global.DOMParser;
-            class ErrorDOMParser {
-                parseFromString() {
-                    throw new Error('Simulated DOMParser error');
-                }
-            }
-            global.DOMParser = ErrorDOMParser;
-
-            const md = '[link](https://example.com/safe)';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('https://example.com/safe');
-
-            // Restore original mock
-            global.DOMParser = originalDOMParser;
-        });
-
-        it('handles DOMParser returning null doc', () => {
-            const originalDOMParser = global.DOMParser;
-            class NullDocDOMParser {
-                parseFromString() {
-                    return null;
-                }
-            }
-            global.DOMParser = NullDocDOMParser;
-
-            const md = '[link](https://example.com/safe)';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('https://example.com/safe');
-
-            // Restore original mock
-            global.DOMParser = originalDOMParser;
-        });
-
-        it('handles DOMParser returning doc without documentElement', () => {
-            const originalDOMParser = global.DOMParser;
-            class NullDocDOMParser {
-                parseFromString() {
-                    return {};
-                }
-            }
-            global.DOMParser = NullDocDOMParser;
-
-            const md = '[link](https://example.com/safe)';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('https://example.com/safe');
-
-            // Restore original mock
-            global.DOMParser = originalDOMParser;
-        });
-
-        it('handles DOMParser missing documentElement textContent', () => {
-            const originalDOMParser = global.DOMParser;
-            class NoTextContentDOMParser {
-                parseFromString() {
-                    return { documentElement: {} };
-                }
-            }
-            global.DOMParser = NoTextContentDOMParser;
-
-            const md = '[link](https://example.com/safe)';
-            const html = modal.parseMarkdown(md);
-            expect(extractHref(html)).toBe('https://example.com/safe');
-
-            // Restore original mock
-            global.DOMParser = originalDOMParser;
-        });
+    it("allows http URLs", () => {
+      const md = "[link](http://example.com)";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("http://example.com");
     });
 
-    // ---------------------------------------------------------------
-    // parseMarkdown rendering tests
-    // ---------------------------------------------------------------
-    describe('parseMarkdown', () => {
-        it('removes the main "# Privacy Policy" heading', () => {
-            const md = '# Privacy Policy\n\nSome content.';
-            const html = modal.parseMarkdown(md);
-            expect(html).not.toContain('Privacy Policy');
-            expect(html).toContain('Some content.');
-        });
-
-        it('converts ## headings to <h2>', () => {
-            const md = '## Section Title';
-            const html = modal.parseMarkdown(md);
-            expect(html).toContain('<h2>Section Title</h2>');
-        });
-
-        it('converts ### headings to <h3>', () => {
-            const md = '### Sub-Section';
-            const html = modal.parseMarkdown(md);
-            expect(html).toContain('<h3>Sub-Section</h3>');
-        });
-
-        it('converts **bold** to <strong>', () => {
-            const md = 'This is **bold** text.';
-            const html = modal.parseMarkdown(md);
-            expect(html).toContain('<strong>bold</strong>');
-        });
-
-        it('converts list items to <li> wrapped in <ul>', () => {
-            const md = '- Item 1\n- Item 2';
-            const html = modal.parseMarkdown(md);
-            expect(html).toContain('<li>Item 1</li>');
-            expect(html).toContain('<li>Item 2</li>');
-            expect(html).toContain('<ul>');
-            expect(html).toContain('</ul>');
-        });
-
-        it('escapes HTML to prevent XSS', () => {
-            const md = '<script>alert("xss")</script>';
-            const html = modal.parseMarkdown(md);
-            expect(html).not.toContain('<script>');
-            expect(html).toContain('&lt;script&gt;');
-        });
-
-        it('wraps plain text blocks in <p> tags', () => {
-            const md = 'Just a paragraph.';
-            const html = modal.parseMarkdown(md);
-            expect(html).toContain('<p>');
-            expect(html).toContain('Just a paragraph.');
-        });
-
-        it('renders links with target="_blank" and rel="noopener noreferrer"', () => {
-            const md = '[Example](https://example.com)';
-            const html = modal.parseMarkdown(md);
-            expect(html).toContain('target="_blank"');
-            expect(html).toContain('rel="noopener noreferrer"');
-        });
-
-
-        it('returns block unchanged if it starts with < but not h or ul', () => {
-            const md = '**bold**';
-            const html = modal.parseMarkdown(md);
-            expect(html).toBe('<strong>bold</strong>');
-        });
-
-        it('returns empty string for empty input', () => {
-            const html = modal.parseMarkdown('');
-            expect(html).toBe('');
-        });
+    it("allows mailto URLs", () => {
+      const md = "[email](mailto:user@example.com)";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("mailto:user@example.com");
     });
 
-    // ---------------------------------------------------------------
-    // Interaction & Logic Tests
-    // ---------------------------------------------------------------
-    describe('Interaction Logic', () => {
-        it('binds events on initialization', () => {
-            // Check that event listeners were attached to key elements
-            expect(modal.privacyLink.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
-            expect(modal.closeBtn.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
-            expect(modal.backdrop.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
-            expect(document.addEventListener).toHaveBeenCalledWith('keydown', expect.any(Function));
-        });
-
-
-
-
-        it('triggers open when privacy link is clicked', () => {
-            const openSpy = vi.spyOn(modal, 'open').mockImplementation(() => {});
-            const clickHandler = modal.privacyLink.addEventListener.mock.calls.find(call => call[0] === 'click')[1];
-            clickHandler({ preventDefault: vi.fn() });
-            expect(openSpy).toHaveBeenCalled();
-        });
-
-
-
-        it('triggers open when privacy link is activated via keyboard (Space)', () => {
-            const openSpy = vi.spyOn(modal, 'open').mockImplementation(() => {});
-            const keydownHandler = modal.privacyLink.addEventListener.mock.calls.find(call => call[0] === 'keydown')[1];
-
-            const event = { key: ' ', preventDefault: vi.fn() };
-            keydownHandler(event);
-
-            expect(event.preventDefault).toHaveBeenCalled();
-            expect(openSpy).toHaveBeenCalled();
-        });
-
-        it('triggers open when privacy link is activated via keyboard (Spacebar)', () => {
-            const openSpy = vi.spyOn(modal, 'open').mockImplementation(() => {});
-            const keydownHandler = modal.privacyLink.addEventListener.mock.calls.find(call => call[0] === 'keydown')[1];
-
-            const event = { key: 'Spacebar', preventDefault: vi.fn() };
-            keydownHandler(event);
-
-            expect(event.preventDefault).toHaveBeenCalled();
-            expect(openSpy).toHaveBeenCalled();
-        });
-
-        it('does not trigger open for other keys on privacy link', () => {
-            const openSpy = vi.spyOn(modal, 'open').mockImplementation(() => {});
-            const keydownHandler = modal.privacyLink.addEventListener.mock.calls.find(call => call[0] === 'keydown')[1];
-
-            const event = { key: 'Enter', preventDefault: vi.fn() };
-            keydownHandler(event);
-
-            expect(event.preventDefault).not.toHaveBeenCalled();
-            expect(openSpy).not.toHaveBeenCalled();
-        });
-
-        it('closes when backdrop is clicked directly', () => {
-            const closeSpy = vi.spyOn(modal, 'close').mockImplementation(() => {});
-            const clickHandler = modal.backdrop.addEventListener.mock.calls.find(call => call[0] === 'click')[1];
-            clickHandler({ target: modal.backdrop });
-            expect(closeSpy).toHaveBeenCalled();
-        });
-
-        it('does not close when inner content of backdrop is clicked', () => {
-            const closeSpy = vi.spyOn(modal, 'close').mockImplementation(() => {});
-            const clickHandler = modal.backdrop.addEventListener.mock.calls.find(call => call[0] === 'click')[1];
-            clickHandler({ target: {} });
-            expect(closeSpy).not.toHaveBeenCalled();
-        });
-
-        it('opens, fetches content, and locks focus', async () => {
-            // Setup a trigger element
-            const trigger = { tagName: 'BUTTON', focus: vi.fn(), id: 'trigger-btn' };
-            document.activeElement = trigger;
-
-            await modal.open();
-
-            // Verify content fetch
-            expect(global.fetch).toHaveBeenCalledWith('/PRIVACY.md');
-            expect(modal.loaded).toBe(true);
-
-            // Verify visibility
-            expect(modal.backdrop.classList.add).toHaveBeenCalledWith('visible');
-            expect(document.body.style.overflow).toBe('hidden');
-
-            // Verify focus management
-            expect(modal.closeBtn.focus).toHaveBeenCalled();
-            expect(modal.triggerElement).toBe(trigger); // Should store the trigger
-        });
-
-        it('does not re-fetch content if already loaded', async () => {
-            modal.loaded = true;
-            await modal.open();
-            expect(global.fetch).not.toHaveBeenCalled();
-        });
-
-        it('closes, restores focus, and unlocks body', async () => {
-            // Setup open state
-            const trigger = { tagName: 'BUTTON', focus: vi.fn(), id: 'trigger-btn' };
-            modal.triggerElement = trigger;
-            modal.backdrop.classList.contains.mockReturnValue(true);
-
-            modal.close();
-
-            expect(modal.backdrop.classList.remove).toHaveBeenCalledWith('visible');
-            expect(document.body.style.overflow).toBe('');
-            expect(trigger.focus).toHaveBeenCalled();
-            expect(modal.triggerElement).toBeNull();
-        });
-
-        it('closes on Escape key press when visible', () => {
-            // Spy on close
-            const closeSpy = vi.spyOn(modal, 'close');
-            // Setup visible state
-            modal.backdrop.classList.contains.mockReturnValue(true);
-
-            // Simulate Escape key
-            // Note: We need to find the listener bound in constructor
-            const calls = document.addEventListener.mock.calls;
-            const keydownHandler = calls.find(call => call[0] === 'keydown')[1];
-
-            keydownHandler({ key: 'Escape' });
-
-            expect(closeSpy).toHaveBeenCalled();
-        });
-
-        it('ignores Escape key press when not visible', () => {
-            const closeSpy = vi.spyOn(modal, 'close');
-            modal.backdrop.classList.contains.mockReturnValue(false);
-
-            const calls = document.addEventListener.mock.calls;
-            const keydownHandler = calls.find(call => call[0] === 'keydown')[1];
-
-            keydownHandler({ key: 'Escape' });
-
-            expect(closeSpy).not.toHaveBeenCalled();
-        });
-
-        it('handles fetch errors gracefully', async () => {
-            const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-            global.fetch.mockRejectedValue(new Error('Network error'));
-
-            await modal.open();
-
-            expect(modal.content.innerHTML).toContain('Failed to load privacy policy');
-            // Even if failed, it might set loaded to false or just show error.
-            // Implementation sets loaded=true only on success? No, let's check code.
-            // Code sets loaded=true ONLY in try block. So it remains false.
-            expect(modal.loaded).toBe(false);
-            expect(errorSpy).toHaveBeenCalled();
-            errorSpy.mockRestore();
-        });
+    it("allows relative URLs (no scheme)", () => {
+      const md = "[page](/about)";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("/about");
     });
 
-    describe('Focus Trap', () => {
-        let firstElement, lastElement;
-
-        beforeEach(async () => {
-            // Open modal to attach focus trap listener
-            await modal.open();
-
-            // Setup mock focusable elements
-            firstElement = { id: 'first', focus: vi.fn(), offsetParent: {} };
-            lastElement = { id: 'last', focus: vi.fn(), offsetParent: {} };
-
-            // Mock querySelectorAll to return our elements
-            modal.backdrop.querySelectorAll.mockReturnValue([firstElement, lastElement]);
-        });
-
-        it('loops focus to first element when tabbing from last element', () => {
-            document.activeElement = lastElement;
-
-            // Trigger handler directly (it's bound to backdrop keydown)
-            // Find the listener added to backdrop in open()
-            const calls = modal.backdrop.addEventListener.mock.calls;
-            const trapHandler = calls.find(call => call[0] === 'keydown')[1];
-
-            const event = {
-                key: 'Tab',
-                shiftKey: false,
-                preventDefault: vi.fn(),
-            };
-
-            trapHandler(event);
-
-            expect(event.preventDefault).toHaveBeenCalled();
-            expect(firstElement.focus).toHaveBeenCalled();
-        });
-
-        it('loops focus to last element when shift-tabbing from first element', () => {
-            document.activeElement = firstElement;
-
-            const calls = modal.backdrop.addEventListener.mock.calls;
-            const trapHandler = calls.find(call => call[0] === 'keydown')[1];
-
-            const event = {
-                key: 'Tab',
-                shiftKey: true,
-                preventDefault: vi.fn(),
-            };
-
-            trapHandler(event);
-
-            expect(event.preventDefault).toHaveBeenCalled();
-            expect(lastElement.focus).toHaveBeenCalled();
-        });
-
-        it('does nothing for non-Tab keys', () => {
-            const calls = modal.backdrop.addEventListener.mock.calls;
-            const trapHandler = calls.find(call => call[0] === 'keydown')[1];
-
-            const event = {
-                key: 'Enter',
-                preventDefault: vi.fn(),
-            };
-
-            trapHandler(event);
-
-            expect(event.preventDefault).not.toHaveBeenCalled();
-        });
-
-        it('does nothing if no focusable elements found', () => {
-            modal.backdrop.querySelectorAll.mockReturnValue([]);
-
-            const calls = modal.backdrop.addEventListener.mock.calls;
-            const trapHandler = calls.find(call => call[0] === 'keydown')[1];
-
-            const event = {
-                key: 'Tab',
-                preventDefault: vi.fn(),
-            };
-
-            trapHandler(event);
-            expect(event.preventDefault).not.toHaveBeenCalled();
-        });
+    it("blocks javascript: URLs", () => {
+      const md = "[click](javascript:alert(1))";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("#unsafe-url");
     });
+
+    it("blocks vbscript: URLs", () => {
+      const md = "[click](vbscript:MsgBox)";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("#unsafe-url");
+    });
+
+    it("blocks data: URLs", () => {
+      const md = "[click](data:text/html,<h1>XSS</h1>)";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("#unsafe-url");
+    });
+
+    it("blocks file: URLs", () => {
+      const md = "[click](file:///etc/passwd)";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("#unsafe-url");
+    });
+
+    it("blocks blob: URLs", () => {
+      const md = "[click](blob:http://example.com/uuid)";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("#unsafe-url");
+    });
+
+    it("blocks whitespace bypass (java\\nscript:)", () => {
+      const md = "[click](java\nscript:alert(1))";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("#unsafe-url");
+    });
+
+    it("blocks control character bypass (java\\x00script:)", () => {
+      const md = "[click](java\x00script:alert(1))";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("#unsafe-url");
+    });
+
+    it("handles case-insensitive scheme detection", () => {
+      const md = "[click](JAVASCRIPT:alert(1))";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("#unsafe-url");
+    });
+
+    it("blocks HTML entity encoded scheme bypasses (&colon;)", () => {
+      const md = "[click](javascript&colon;alert(1))";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("#unsafe-url");
+    });
+
+    it("blocks HTML entity encoded scheme bypasses (&#58;)", () => {
+      const md = "[click](javascript&#58;alert(1))";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("#unsafe-url");
+    });
+
+    it("blocks HTML entity encoded scheme bypasses (&#x3a;)", () => {
+      const md = "[click](javascript&#x3a;alert(1))";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("#unsafe-url");
+    });
+
+    it("allows HTTPS in uppercase", () => {
+      const md = "[link](HTTPS://EXAMPLE.COM)";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("HTTPS://EXAMPLE.COM");
+    });
+
+    it("re-escapes entities that decode to quotes to prevent attribute breakout", () => {
+      const md = "[link](https://example.com/&quot;onmouseover=&quot;alert=1)";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe(
+        "https://example.com/&quot;onmouseover=&quot;alert=1",
+      );
+    });
+
+    it("fails securely and blocks URL if DOMParser fails", () => {
+      // Temporarily mock DOMParser to throw an error
+      const originalDOMParser = global.DOMParser;
+      class ErrorDOMParser {
+        parseFromString() {
+          throw new Error("Simulated DOMParser error");
+        }
+      }
+      global.DOMParser = ErrorDOMParser;
+
+      const md = "[link](https://example.com/safe)";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("#unsafe-url");
+
+      // Restore original mock
+      global.DOMParser = originalDOMParser;
+    });
+
+    it("fails securely and blocks URL if DOMParser returns null doc", () => {
+      const originalDOMParser = global.DOMParser;
+      class NullDocDOMParser {
+        parseFromString() {
+          return null;
+        }
+      }
+      global.DOMParser = NullDocDOMParser;
+
+      const md = "[link](https://example.com/safe)";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("#unsafe-url");
+
+      // Restore original mock
+      global.DOMParser = originalDOMParser;
+    });
+
+    it("fails securely and blocks URL if DOMParser returns doc without documentElement", () => {
+      const originalDOMParser = global.DOMParser;
+      class NullDocDOMParser {
+        parseFromString() {
+          return {};
+        }
+      }
+      global.DOMParser = NullDocDOMParser;
+
+      const md = "[link](https://example.com/safe)";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("#unsafe-url");
+
+      // Restore original mock
+      global.DOMParser = originalDOMParser;
+    });
+
+    it("handles DOMParser missing documentElement textContent", () => {
+      const originalDOMParser = global.DOMParser;
+      class NoTextContentDOMParser {
+        parseFromString() {
+          return { documentElement: {} };
+        }
+      }
+      global.DOMParser = NoTextContentDOMParser;
+
+      const md = "[link](https://example.com/safe)";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("https://example.com/safe");
+
+      // Restore original mock
+      global.DOMParser = originalDOMParser;
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // parseMarkdown rendering tests
+  // ---------------------------------------------------------------
+  describe("parseMarkdown", () => {
+    it('removes the main "# Privacy Policy" heading', () => {
+      const md = "# Privacy Policy\n\nSome content.";
+      const html = modal.parseMarkdown(md);
+      expect(html).not.toContain("Privacy Policy");
+      expect(html).toContain("Some content.");
+    });
+
+    it("converts ## headings to <h2>", () => {
+      const md = "## Section Title";
+      const html = modal.parseMarkdown(md);
+      expect(html).toContain("<h2>Section Title</h2>");
+    });
+
+    it("converts ### headings to <h3>", () => {
+      const md = "### Sub-Section";
+      const html = modal.parseMarkdown(md);
+      expect(html).toContain("<h3>Sub-Section</h3>");
+    });
+
+    it("converts **bold** to <strong>", () => {
+      const md = "This is **bold** text.";
+      const html = modal.parseMarkdown(md);
+      expect(html).toContain("<strong>bold</strong>");
+    });
+
+    it("converts list items to <li> wrapped in <ul>", () => {
+      const md = "- Item 1\n- Item 2";
+      const html = modal.parseMarkdown(md);
+      expect(html).toContain("<li>Item 1</li>");
+      expect(html).toContain("<li>Item 2</li>");
+      expect(html).toContain("<ul>");
+      expect(html).toContain("</ul>");
+    });
+
+    it("escapes HTML to prevent XSS", () => {
+      const md = '<script>alert("xss")</script>';
+      const html = modal.parseMarkdown(md);
+      expect(html).not.toContain("<script>");
+      expect(html).toContain("&lt;script&gt;");
+    });
+
+    it("wraps plain text blocks in <p> tags", () => {
+      const md = "Just a paragraph.";
+      const html = modal.parseMarkdown(md);
+      expect(html).toContain("<p>");
+      expect(html).toContain("Just a paragraph.");
+    });
+
+    it('renders links with target="_blank" and rel="noopener noreferrer"', () => {
+      const md = "[Example](https://example.com)";
+      const html = modal.parseMarkdown(md);
+      expect(html).toContain('target="_blank"');
+      expect(html).toContain('rel="noopener noreferrer"');
+    });
+
+    it("returns block unchanged if it starts with < but not h or ul", () => {
+      const md = "**bold**";
+      const html = modal.parseMarkdown(md);
+      expect(html).toBe("<strong>bold</strong>");
+    });
+
+    it("returns empty string for empty input", () => {
+      const html = modal.parseMarkdown("");
+      expect(html).toBe("");
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Interaction & Logic Tests
+  // ---------------------------------------------------------------
+  describe("Interaction Logic", () => {
+    it("binds events on initialization", () => {
+      // Check that event listeners were attached to key elements
+      expect(modal.privacyLink.addEventListener).toHaveBeenCalledWith(
+        "click",
+        expect.any(Function),
+      );
+      expect(modal.closeBtn.addEventListener).toHaveBeenCalledWith(
+        "click",
+        expect.any(Function),
+      );
+      expect(modal.backdrop.addEventListener).toHaveBeenCalledWith(
+        "click",
+        expect.any(Function),
+      );
+      expect(document.addEventListener).toHaveBeenCalledWith(
+        "keydown",
+        expect.any(Function),
+      );
+    });
+
+    it("triggers open when privacy link is clicked", () => {
+      const openSpy = vi.spyOn(modal, "open").mockImplementation(() => {});
+      const clickHandler = modal.privacyLink.addEventListener.mock.calls.find(
+        (call) => call[0] === "click",
+      )[1];
+      clickHandler({ preventDefault: vi.fn() });
+      expect(openSpy).toHaveBeenCalled();
+    });
+
+    it("triggers open when privacy link is activated via keyboard (Space)", () => {
+      const openSpy = vi.spyOn(modal, "open").mockImplementation(() => {});
+      const keydownHandler = modal.privacyLink.addEventListener.mock.calls.find(
+        (call) => call[0] === "keydown",
+      )[1];
+
+      const event = { key: " ", preventDefault: vi.fn() };
+      keydownHandler(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(openSpy).toHaveBeenCalled();
+    });
+
+    it("triggers open when privacy link is activated via keyboard (Spacebar)", () => {
+      const openSpy = vi.spyOn(modal, "open").mockImplementation(() => {});
+      const keydownHandler = modal.privacyLink.addEventListener.mock.calls.find(
+        (call) => call[0] === "keydown",
+      )[1];
+
+      const event = { key: "Spacebar", preventDefault: vi.fn() };
+      keydownHandler(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(openSpy).toHaveBeenCalled();
+    });
+
+    it("does not trigger open for other keys on privacy link", () => {
+      const openSpy = vi.spyOn(modal, "open").mockImplementation(() => {});
+      const keydownHandler = modal.privacyLink.addEventListener.mock.calls.find(
+        (call) => call[0] === "keydown",
+      )[1];
+
+      const event = { key: "Enter", preventDefault: vi.fn() };
+      keydownHandler(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(openSpy).not.toHaveBeenCalled();
+    });
+
+    it("closes when backdrop is clicked directly", () => {
+      const closeSpy = vi.spyOn(modal, "close").mockImplementation(() => {});
+      const clickHandler = modal.backdrop.addEventListener.mock.calls.find(
+        (call) => call[0] === "click",
+      )[1];
+      clickHandler({ target: modal.backdrop });
+      expect(closeSpy).toHaveBeenCalled();
+    });
+
+    it("does not close when inner content of backdrop is clicked", () => {
+      const closeSpy = vi.spyOn(modal, "close").mockImplementation(() => {});
+      const clickHandler = modal.backdrop.addEventListener.mock.calls.find(
+        (call) => call[0] === "click",
+      )[1];
+      clickHandler({ target: {} });
+      expect(closeSpy).not.toHaveBeenCalled();
+    });
+
+    it("opens, fetches content, and locks focus", async () => {
+      // Setup a trigger element
+      const trigger = { tagName: "BUTTON", focus: vi.fn(), id: "trigger-btn" };
+      document.activeElement = trigger;
+
+      await modal.open();
+
+      // Verify content fetch
+      expect(global.fetch).toHaveBeenCalledWith("/PRIVACY.md");
+      expect(modal.loaded).toBe(true);
+
+      // Verify visibility
+      expect(modal.backdrop.classList.add).toHaveBeenCalledWith("visible");
+      expect(document.body.style.overflow).toBe("hidden");
+
+      // Verify focus management
+      expect(modal.closeBtn.focus).toHaveBeenCalled();
+      expect(modal.triggerElement).toBe(trigger); // Should store the trigger
+    });
+
+    it("does not re-fetch content if already loaded", async () => {
+      modal.loaded = true;
+      await modal.open();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("closes, restores focus, and unlocks body", async () => {
+      // Setup open state
+      const trigger = { tagName: "BUTTON", focus: vi.fn(), id: "trigger-btn" };
+      modal.triggerElement = trigger;
+      modal.backdrop.classList.contains.mockReturnValue(true);
+
+      modal.close();
+
+      expect(modal.backdrop.classList.remove).toHaveBeenCalledWith("visible");
+      expect(document.body.style.overflow).toBe("");
+      expect(trigger.focus).toHaveBeenCalled();
+      expect(modal.triggerElement).toBeNull();
+    });
+
+    it("closes on Escape key press when visible", () => {
+      // Spy on close
+      const closeSpy = vi.spyOn(modal, "close");
+      // Setup visible state
+      modal.backdrop.classList.contains.mockReturnValue(true);
+
+      // Simulate Escape key
+      // Note: We need to find the listener bound in constructor
+      const calls = document.addEventListener.mock.calls;
+      const keydownHandler = calls.find((call) => call[0] === "keydown")[1];
+
+      keydownHandler({ key: "Escape" });
+
+      expect(closeSpy).toHaveBeenCalled();
+    });
+
+    it("ignores Escape key press when not visible", () => {
+      const closeSpy = vi.spyOn(modal, "close");
+      modal.backdrop.classList.contains.mockReturnValue(false);
+
+      const calls = document.addEventListener.mock.calls;
+      const keydownHandler = calls.find((call) => call[0] === "keydown")[1];
+
+      keydownHandler({ key: "Escape" });
+
+      expect(closeSpy).not.toHaveBeenCalled();
+    });
+
+    it("handles fetch errors gracefully", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      global.fetch.mockRejectedValue(new Error("Network error"));
+
+      await modal.open();
+
+      expect(modal.content.innerHTML).toContain(
+        "Failed to load privacy policy",
+      );
+      // Even if failed, it might set loaded to false or just show error.
+      // Implementation sets loaded=true only on success? No, let's check code.
+      // Code sets loaded=true ONLY in try block. So it remains false.
+      expect(modal.loaded).toBe(false);
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe("Focus Trap", () => {
+    let firstElement, lastElement;
+
+    beforeEach(async () => {
+      // Open modal to attach focus trap listener
+      await modal.open();
+
+      // Setup mock focusable elements
+      firstElement = { id: "first", focus: vi.fn(), offsetParent: {} };
+      lastElement = { id: "last", focus: vi.fn(), offsetParent: {} };
+
+      // Mock querySelectorAll to return our elements
+      modal.backdrop.querySelectorAll.mockReturnValue([
+        firstElement,
+        lastElement,
+      ]);
+    });
+
+    it("loops focus to first element when tabbing from last element", () => {
+      document.activeElement = lastElement;
+
+      // Trigger handler directly (it's bound to backdrop keydown)
+      // Find the listener added to backdrop in open()
+      const calls = modal.backdrop.addEventListener.mock.calls;
+      const trapHandler = calls.find((call) => call[0] === "keydown")[1];
+
+      const event = {
+        key: "Tab",
+        shiftKey: false,
+        preventDefault: vi.fn(),
+      };
+
+      trapHandler(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(firstElement.focus).toHaveBeenCalled();
+    });
+
+    it("loops focus to last element when shift-tabbing from first element", () => {
+      document.activeElement = firstElement;
+
+      const calls = modal.backdrop.addEventListener.mock.calls;
+      const trapHandler = calls.find((call) => call[0] === "keydown")[1];
+
+      const event = {
+        key: "Tab",
+        shiftKey: true,
+        preventDefault: vi.fn(),
+      };
+
+      trapHandler(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(lastElement.focus).toHaveBeenCalled();
+    });
+
+    it("does nothing for non-Tab keys", () => {
+      const calls = modal.backdrop.addEventListener.mock.calls;
+      const trapHandler = calls.find((call) => call[0] === "keydown")[1];
+
+      const event = {
+        key: "Enter",
+        preventDefault: vi.fn(),
+      };
+
+      trapHandler(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("does nothing if no focusable elements found", () => {
+      modal.backdrop.querySelectorAll.mockReturnValue([]);
+
+      const calls = modal.backdrop.addEventListener.mock.calls;
+      const trapHandler = calls.find((call) => call[0] === "keydown")[1];
+
+      const event = {
+        key: "Tab",
+        preventDefault: vi.fn(),
+      };
+
+      trapHandler(event);
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `sanitizeUrl` function in `public/src/ui/PrivacyModal.js` relies on `DOMParser` to decode HTML entities in URLs to prevent XSS scheme bypasses (e.g., `j&#x61;vascript:alert(1)`). However, if `DOMParser` is not available, fails to initialize, or returns a document without `documentElement`, the code silently fell back to the original un-decoded string `clean`. An attacker could exploit this by providing a payload like `javascript&#58;alert(1)`. Because `&#58;` hides the colon from the scheme-checking regex (`/^[a-z][a-z0-9+.-]*:/i`), the script would assume it's a relative URL, bypass the allowlist, and return the payload. The browser would later decode `&#58;` in the `href` attribute and execute the XSS.
🎯 Impact: This could lead to Cross-Site Scripting (XSS) if malicious links are injected, executing arbitrary JavaScript in the victim's browser within the context of the application.
🔧 Fix: Updated the `try...catch` block in `sanitizeUrl` to return `#unsafe-url` if `doc && doc.documentElement` is falsy, and to explicitly return `#unsafe-url` inside the `catch` block. This ensures that the application "fails securely" by blocking the URL if it cannot be properly decoded for inspection.
✅ Verification: Ran the test suite (`pnpm test`), which includes new test cases expecting `#unsafe-url` instead of the original string when `DOMParser` throws or returns a falsy document, verifying the fix works as expected.

---
*PR created automatically by Jules for task [6181561186962974689](https://jules.google.com/task/6181561186962974689) started by @2fst4u*