### PR TITLE
🔭 Scout: Add fallback alt text to country flag images

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -194,7 +194,8 @@
                          maintaining the visual design. The empty alt should only be used if the
                          flag truly provides no meaningful information beyond decoration.
                     -->
-                    <img id="countryFlag" class="race-info-flag" alt="">
+                    <!-- Scout: Added a generic fallback alt text for SEO and accessibility before JS populates the country name -->
+                    <img id="countryFlag" class="race-info-flag" alt="Country flag">
                     <div class="race-info-details">
                         <div class="race-info-country" id="raceInfoCountry"></div>
                 <!-- Scout: Upgraded generic div to semantic h2 for better heading hierarchy and discoverability -->
@@ -379,7 +380,8 @@
                          to provide meaningful context. Consider implementing this in the JavaScript
                          that updates the mobileCountryFlag.src property.
                     -->
-                    <img id="mobileCountryFlag" class="mobile-race-info-flag" alt="">
+                    <!-- Scout: Added a generic fallback alt text for SEO and accessibility before JS populates the country name -->
+                    <img id="mobileCountryFlag" class="mobile-race-info-flag" alt="Country flag">
                     <div class="mobile-race-info-text">
                 <!-- Scout: Upgraded generic span to semantic h2 for consistent heading hierarchy across viewports -->
                 <h2 id="mobileRaceInfoName"></h2>


### PR DESCRIPTION
💡 What: Added `alt="Country flag"` to `#countryFlag` and `#mobileCountryFlag` image elements in `public/index.html`.
🎯 Why: Purely informational country flag images were previously rendered with an empty `alt=""` attribute before JavaScript executed. This caused them to be flagged as decorative or completely invisible to crawlers that don't execute JS.
📊 Value: Improves indexing and accessibility by ensuring search engines and screen readers always have context for the image, even before hydration.
🔬 Measurement: Verify the initial HTML payload (e.g., using `curl`) or inspect the DOM before JS execution to confirm the `alt="Country flag"` attribute is present on both `.race-info-flag` and `.mobile-race-info-flag` images.

---
*PR created automatically by Jules for task [18070308471316649543](https://jules.google.com/task/18070308471316649543) started by @2fst4u*