### PR TITLE
🧪 Spec: Add cache hit CORS verification to worker proxy tests

### DIFF
--- a/tests/worker-api-cors.test.js
+++ b/tests/worker-api-cors.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import worker from "../src/worker.js";
+
+// --- Mocks ---
+
+// Mock Cache API
+const cacheStore = new Map();
+const mockCache = {
+  match: vi.fn(async (request) => {
+    const key = request.url;
+    return cacheStore.get(key) || undefined;
+  }),
+  put: vi.fn(async (request, response) => {
+    const key = request.url;
+    cacheStore.set(key, response.clone());
+    return Promise.resolve();
+  }),
+};
+
+// Mock Global Caches
+vi.stubGlobal("caches", {
+  default: mockCache,
+});
+
+describe("Worker API Proxy CORS and Error Cases", () => {
+  let mockFetch;
+
+  beforeEach(() => {
+    cacheStore.clear();
+    vi.clearAllMocks();
+
+    mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    vi.stubGlobal("env", { ENVIRONMENT: "test" });
+    vi.stubGlobal("ctx", {
+      waitUntil: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createRequest = (path, headersInit = {}) => {
+    const url = `https://circuit-weather.racing${path}`;
+    const headers = new Headers(headersInit);
+    if (!headers.has("Sec-Fetch-Site")) {
+      headers.set("Sec-Fetch-Site", "same-origin");
+    }
+    return new Request(url, {
+      method: "GET",
+      headers: headers,
+    });
+  };
+
+  it("applies strict CORS headers for api cache hit when valid Origin is provided", async () => {
+    mockCache.match.mockResolvedValueOnce(new Response('{"data":"ok"}', {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    }));
+
+    const req = createRequest("/api/f1/current", {
+      Origin: "https://circuit-weather.racing"
+    });
+    const res = await worker.fetch(req, global.env, global.ctx);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Cache")).toBe("HIT");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://circuit-weather.racing");
+    expect(res.headers.get("Vary")).toBe("Origin");
+  });
+
+  it("deletes CORS headers for api cache hit when invalid Origin is provided", async () => {
+    mockCache.match.mockResolvedValueOnce(new Response('{"data":"ok"}', {
+      status: 200,
+      headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "https://old.com" }
+    }));
+
+    const req = createRequest("/api/f1/current", {
+      Origin: "https://evil.com"
+    });
+    const res = await worker.fetch(req, global.env, global.ctx);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Cache")).toBe("HIT");
+    expect(res.headers.has("Access-Control-Allow-Origin")).toBe(false);
+  });
+
+  it("handles upstream catch block error correctly in non-production", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockRejectedValueOnce(new Error("Network Error"));
+
+    const req = createRequest("/api/f1/current");
+    const res = await worker.fetch(req, global.env, global.ctx);
+
+    expect(res.status).toBe(502);
+    const data = await res.json();
+    expect(data.error).toBe("Failed to fetch from upstream");
+    expect(errorSpy).toHaveBeenCalledWith("API Fetch Error:", expect.any(Error));
+    errorSpy.mockRestore();
+  });
+});

--- a/tests/worker-assets-cache-cors.test.js
+++ b/tests/worker-assets-cache-cors.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import worker from "../src/worker.js";
+
+// --- Mocks ---
+
+// Mock Cache API
+const cacheStore = new Map();
+const mockCache = {
+  match: vi.fn(async (request) => {
+    const key = request.url;
+    return cacheStore.get(key) || undefined;
+  }),
+  put: vi.fn(async (request, response) => {
+    const key = request.url;
+    cacheStore.set(key, response.clone());
+    return Promise.resolve();
+  }),
+};
+
+// Mock Global Caches
+vi.stubGlobal("caches", {
+  default: mockCache,
+});
+
+describe("Worker Assets Proxy Caching CORS", () => {
+  let mockFetch;
+
+  beforeEach(() => {
+    cacheStore.clear();
+    vi.clearAllMocks();
+
+    mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    vi.stubGlobal("env", { ENVIRONMENT: "test" });
+    vi.stubGlobal("ctx", {
+      waitUntil: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createRequest = (path, headersInit = {}) => {
+    const url = `https://circuit-weather.racing${path}`;
+    const headers = new Headers(headersInit);
+    if (!headers.has("Sec-Fetch-Site")) {
+      headers.set("Sec-Fetch-Site", "same-origin");
+    }
+    return new Request(url, {
+      method: "GET",
+      headers: headers,
+    });
+  };
+
+  it("applies strict CORS headers for asset cache hit when valid Origin is provided", async () => {
+    // We mock the cache hit directly for asset proxy since it avoids setting up SRI hash mocks
+    mockCache.match.mockResolvedValueOnce(new Response("asset-data", {
+        status: 200,
+        headers: { "Content-Type": "application/javascript" }
+    }));
+
+    const req = createRequest("/api/assets/leaflet.js", {
+      Origin: "https://circuit-weather.racing"
+    });
+    const res = await worker.fetch(req, global.env, global.ctx);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Cache")).toBe("HIT");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://circuit-weather.racing");
+    expect(res.headers.get("Vary")).toBe("Origin");
+  });
+
+  it("deletes CORS headers for asset cache hit when invalid Origin is provided", async () => {
+    mockCache.match.mockResolvedValueOnce(new Response("asset-data", {
+        status: 200,
+        headers: { "Content-Type": "application/javascript", "Access-Control-Allow-Origin": "https://old.com" }
+    }));
+
+    const req = createRequest("/api/assets/leaflet.js", {
+      Origin: "https://evil.com"
+    });
+    const res = await worker.fetch(req, global.env, global.ctx);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Cache")).toBe("HIT");
+    expect(res.headers.has("Access-Control-Allow-Origin")).toBe(false);
+  });
+});

--- a/tests/worker-assets-cors.test.js
+++ b/tests/worker-assets-cors.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import worker from "../src/worker.js";
+
+// --- Mocks ---
+
+// Mock Cache API
+const cacheStore = new Map();
+const mockCache = {
+  match: vi.fn(async (request) => {
+    const key = request.url;
+    return cacheStore.get(key) || undefined;
+  }),
+  put: vi.fn(async (request, response) => {
+    const key = request.url;
+    cacheStore.set(key, response.clone());
+    return Promise.resolve();
+  }),
+};
+
+// Mock Global Caches
+vi.stubGlobal("caches", {
+  default: mockCache,
+});
+
+describe("Worker Assets Proxy Initial Fetch CORS", () => {
+  let mockFetch;
+
+  // Valid hash for leaflet.js from worker.js
+  const VALID_HASH_B64 = "20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=";
+
+  const setupCryptoMock = (shouldMatch) => {
+    const buffer = shouldMatch
+      ? Uint8Array.from(atob(VALID_HASH_B64), (c) => c.charCodeAt(0)).buffer
+      : new ArrayBuffer(32);
+
+    Object.defineProperty(global, "crypto", {
+      value: {
+        subtle: {
+          digest: vi.fn(async () => buffer),
+        },
+      },
+      writable: true,
+    });
+  };
+
+  beforeEach(() => {
+    cacheStore.clear();
+    vi.clearAllMocks();
+
+    mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    vi.stubGlobal("env", { ENVIRONMENT: "test" });
+    vi.stubGlobal("ctx", {
+      waitUntil: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createRequest = (path, headersInit = {}) => {
+    const url = `https://circuit-weather.racing${path}`;
+    const headers = new Headers(headersInit);
+    if (!headers.has("Sec-Fetch-Site")) {
+      headers.set("Sec-Fetch-Site", "same-origin");
+    }
+    return new Request(url, {
+      method: "GET",
+      headers: headers,
+    });
+  };
+
+  it("applies strict CORS headers for initial asset fetch when valid Origin is provided", async () => {
+    setupCryptoMock(true);
+
+    const mockScript = 'console.log("leaflet")';
+    mockFetch.mockResolvedValueOnce(
+      new Response(mockScript, {
+        status: 200,
+        headers: { "Content-Type": "application/javascript" },
+      }),
+    );
+
+    const req = createRequest("/api/assets/leaflet.js", {
+      Origin: "https://circuit-weather.racing"
+    });
+    const res = await worker.fetch(req, global.env, global.ctx);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://circuit-weather.racing");
+    expect(res.headers.get("Vary")).toBe("Origin");
+  });
+
+  it("handles catch block error logging correctly in non-production", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    setupCryptoMock(true);
+
+    mockFetch.mockRejectedValueOnce(new Error("Network failure"));
+
+    const req = createRequest("/api/assets/leaflet.js");
+    const res = await worker.fetch(req, global.env, global.ctx);
+
+    expect(res.status).toBe(502);
+    expect(await res.text()).toBe("Leaflet fetch failed");
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/tests/worker-assets-upstream-error.test.js
+++ b/tests/worker-assets-upstream-error.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import worker from "../src/worker.js";
+
+// --- Mocks ---
+const mockCache = {
+  match: vi.fn(async () => undefined),
+  put: vi.fn(async () => Promise.resolve()),
+};
+
+vi.stubGlobal("caches", {
+  default: mockCache,
+});
+
+describe("Worker Assets Proxy Upstream Error", () => {
+  let mockFetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    vi.stubGlobal("env", { ENVIRONMENT: "test" });
+    vi.stubGlobal("ctx", {
+      waitUntil: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createRequest = (path) => {
+    const url = `https://circuit-weather.racing${path}`;
+    const headers = new Headers();
+    headers.set("Sec-Fetch-Site", "same-origin");
+    return new Request(url, {
+      method: "GET",
+      headers: headers,
+    });
+  };
+
+  it("handles upstream non-ok response correctly in non-production", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Valid hash mocking not strictly needed as it errors before checking SRI
+
+    mockFetch.mockResolvedValueOnce(new Response("Not Found on Upstream", {
+        status: 404,
+        statusText: "Not Found"
+    }));
+
+    const req = createRequest("/api/assets/leaflet.js");
+    const res = await worker.fetch(req, global.env, global.ctx);
+
+    expect(res.status).toBe(502);
+    expect(res.headers.get("X-Upstream-Status")).toBe("404");
+    expect(await res.text()).toBe("Failed to load Leaflet asset");
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Leaflet Fetch Error"));
+    errorSpy.mockRestore();
+  });
+});

--- a/tests/worker-health-cache-cors.test.js
+++ b/tests/worker-health-cache-cors.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import worker from "../src/worker.js";
+
+// --- Mocks ---
+
+// Mock Cache API
+const cacheStore = new Map();
+const mockCache = {
+  match: vi.fn(async (request) => {
+    const key = request.url;
+    return cacheStore.get(key) || undefined;
+  }),
+  put: vi.fn(async (request, response) => {
+    const key = request.url;
+    cacheStore.set(key, response.clone());
+    return Promise.resolve();
+  }),
+};
+
+// Mock Global Caches
+vi.stubGlobal("caches", {
+  default: mockCache,
+});
+
+// Mock Crypto
+Object.defineProperty(global, "crypto", {
+  value: {
+    subtle: {
+      digest: vi.fn(async () => new ArrayBuffer(32)),
+    },
+  },
+  writable: true,
+});
+
+describe("Worker Health Check Caching CORS", () => {
+  let mockFetch;
+
+  beforeEach(() => {
+    cacheStore.clear();
+    vi.clearAllMocks();
+
+    mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    vi.stubGlobal("env", { ENVIRONMENT: "test" });
+    vi.stubGlobal("ctx", {
+      waitUntil: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createRequest = (path, headersInit = {}) => {
+    const url = `https://circuit-weather.racing${path}`;
+    const headers = new Headers(headersInit);
+    if (!headers.has("Sec-Fetch-Site")) {
+      headers.set("Sec-Fetch-Site", "same-origin");
+    }
+    return new Request(url, {
+      method: "GET",
+      headers: headers,
+    });
+  };
+
+  it("applies strict CORS headers for health check cache hit when valid Origin is provided", async () => {
+    mockFetch.mockResolvedValue({
+      status: 200,
+      ok: true,
+      text: async () => "ok",
+    });
+
+    const req1 = createRequest("/api/health");
+    const res1 = await worker.fetch(req1, global.env, global.ctx);
+    expect(res1.status).toBe(200);
+
+    const req2 = createRequest("/api/health", {
+      Origin: "https://circuit-weather.racing"
+    });
+    const res2 = await worker.fetch(req2, global.env, global.ctx);
+    expect(res2.status).toBe(200);
+    expect(res2.headers.get("X-Cache")).toBe("HIT");
+    expect(res2.headers.get("Access-Control-Allow-Origin")).toBe("https://circuit-weather.racing");
+    expect(res2.headers.get("Vary")).toBe("Origin");
+  });
+
+  it("deletes CORS headers for health check cache hit when invalid Origin is provided", async () => {
+    mockFetch.mockResolvedValue({
+      status: 200,
+      ok: true,
+      text: async () => "ok",
+    });
+
+    const req1 = createRequest("/api/health");
+    const res1 = await worker.fetch(req1, global.env, global.ctx);
+    expect(res1.status).toBe(200);
+
+    const req2 = createRequest("/api/health", {
+      Origin: "https://evil.com"
+    });
+    const res2 = await worker.fetch(req2, global.env, global.ctx);
+    expect(res2.status).toBe(200);
+    expect(res2.headers.get("X-Cache")).toBe("HIT");
+    expect(res2.headers.has("Access-Control-Allow-Origin")).toBe(false);
+  });
+});

--- a/tests/worker-tiles-cache-cors.test.js
+++ b/tests/worker-tiles-cache-cors.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import worker from "../src/worker.js";
+
+// --- Mocks ---
+
+// Mock Cache API
+const cacheStore = new Map();
+const mockCache = {
+  match: vi.fn(async (request) => {
+    const key = request.url;
+    return cacheStore.get(key) || undefined;
+  }),
+  put: vi.fn(async (request, response) => {
+    const key = request.url;
+    cacheStore.set(key, response.clone());
+    return Promise.resolve();
+  }),
+};
+
+// Mock Global Caches
+vi.stubGlobal("caches", {
+  default: mockCache,
+});
+
+describe("Worker Tile Proxy Caching CORS", () => {
+  let mockFetch;
+
+  beforeEach(() => {
+    cacheStore.clear();
+    vi.clearAllMocks();
+
+    mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    vi.stubGlobal("env", { ENVIRONMENT: "test" });
+    vi.stubGlobal("ctx", {
+      waitUntil: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createRequest = (path, headersInit = {}) => {
+    const url = `https://circuit-weather.racing${path}`;
+    const headers = new Headers(headersInit);
+    if (!headers.has("Sec-Fetch-Site")) {
+      headers.set("Sec-Fetch-Site", "same-origin");
+    }
+    return new Request(url, {
+      method: "GET",
+      headers: headers,
+    });
+  };
+
+  it("applies strict CORS headers for tile cache hit when valid Origin is provided", async () => {
+    mockFetch.mockResolvedValue(new Response("image-data", {
+      status: 200,
+      headers: { "Content-Type": "image/png" }
+    }));
+
+    const req1 = createRequest("/api/tiles/v2/radar/1.png");
+    const res1 = await worker.fetch(req1, global.env, global.ctx);
+    expect(res1.status).toBe(200);
+
+    const req2 = createRequest("/api/tiles/v2/radar/1.png", {
+      Origin: "https://circuit-weather.racing"
+    });
+    const res2 = await worker.fetch(req2, global.env, global.ctx);
+    expect(res2.status).toBe(200);
+    expect(res2.headers.get("X-Cache")).toBe("HIT");
+    expect(res2.headers.get("Access-Control-Allow-Origin")).toBe("https://circuit-weather.racing");
+    expect(res2.headers.get("Vary")).toBe("Origin");
+  });
+
+  it("deletes CORS headers for tile cache hit when invalid Origin is provided", async () => {
+    mockFetch.mockResolvedValue(new Response("image-data", {
+      status: 200,
+      headers: { "Content-Type": "image/png" }
+    }));
+
+    const req1 = createRequest("/api/tiles/v2/radar/1.png");
+    const res1 = await worker.fetch(req1, global.env, global.ctx);
+    expect(res1.status).toBe(200);
+
+    const req2 = createRequest("/api/tiles/v2/radar/1.png", {
+      Origin: "https://evil.com"
+    });
+    const res2 = await worker.fetch(req2, global.env, global.ctx);
+    expect(res2.status).toBe(200);
+    expect(res2.headers.get("X-Cache")).toBe("HIT");
+    expect(res2.headers.has("Access-Control-Allow-Origin")).toBe(false);
+  });
+});

--- a/tests/worker-tracks-cors.test.js
+++ b/tests/worker-tracks-cors.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import worker from "../src/worker.js";
+
+// --- Mocks ---
+
+// Mock Cache API
+const cacheStore = new Map();
+const mockCache = {
+  match: vi.fn(async (request) => {
+    const key = request.url;
+    return cacheStore.get(key) || undefined;
+  }),
+  put: vi.fn(async (request, response) => {
+    const key = request.url;
+    cacheStore.set(key, response.clone());
+    return Promise.resolve();
+  }),
+};
+
+// Mock Global Caches
+vi.stubGlobal("caches", {
+  default: mockCache,
+});
+
+describe("Worker Tracks Proxy CORS and Error Cases", () => {
+  let mockFetch;
+
+  beforeEach(() => {
+    cacheStore.clear();
+    vi.clearAllMocks();
+
+    mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    vi.stubGlobal("env", { ENVIRONMENT: "test" });
+    vi.stubGlobal("ctx", {
+      waitUntil: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createRequest = (path, headersInit = {}) => {
+    const url = `https://circuit-weather.racing${path}`;
+    const headers = new Headers(headersInit);
+    if (!headers.has("Sec-Fetch-Site")) {
+      headers.set("Sec-Fetch-Site", "same-origin");
+    }
+    return new Request(url, {
+      method: "GET",
+      headers: headers,
+    });
+  };
+
+  it("applies strict CORS headers for tracks cache hit when valid Origin is provided", async () => {
+    mockCache.match.mockResolvedValueOnce(new Response('{"type":"FeatureCollection"}', {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    }));
+
+    const req = createRequest("/api/track/silverstone", {
+      Origin: "https://circuit-weather.racing"
+    });
+    const res = await worker.fetch(req, global.env, global.ctx);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Cache")).toBe("HIT");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://circuit-weather.racing");
+    expect(res.headers.get("Vary")).toBe("Origin");
+  });
+
+  it("deletes CORS headers for tracks cache hit when invalid Origin is provided", async () => {
+    mockCache.match.mockResolvedValueOnce(new Response('{"type":"FeatureCollection"}', {
+      status: 200,
+      headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "https://old.com" }
+    }));
+
+    const req = createRequest("/api/track/silverstone", {
+      Origin: "https://evil.com"
+    });
+    const res = await worker.fetch(req, global.env, global.ctx);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Cache")).toBe("HIT");
+    expect(res.headers.has("Access-Control-Allow-Origin")).toBe(false);
+  });
+
+  it("handles upstream non-ok response correctly", async () => {
+    mockFetch.mockResolvedValueOnce(new Response("Not Found", {
+        status: 404,
+        statusText: "Not Found"
+    }));
+
+    const req = createRequest("/api/track/silverstone");
+    const res = await worker.fetch(req, global.env, global.ctx);
+
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toBe("Track not found");
+    expect(data.status).toBe(404);
+  });
+});


### PR DESCRIPTION
💡 What: Added comprehensive test suites targeting the Cloudflare Worker proxy endpoints (`/api/health`, `/api/tiles/*`, `/api/assets/*`, `/api/tracks/*`, `/api/f1/*`) to assert correct `Access-Control-Allow-Origin` and `Vary` header logic on cache hits, as well as upstream network error fallback scenarios.
🎯 Why: The CORS validation logic on cached responses in `src/worker.js` was completely uncovered. This ensures the system explicitly validates XSSI protection behavior by safely stripping CORS headers when `Origin` fails verification, preventing future regressions.
📈 Maturity Impact: N/A - The project is already above business standards (> 80%), leaving the threshold intact as a strict guardrail while improving actual file coverage.

---
*PR created automatically by Jules for task [8098505725916113041](https://jules.google.com/task/8098505725916113041) started by @2fst4u*