### PR TITLE
refactor: extract ONE_MINUTE_MS constant

### DIFF
--- a/public/src/api/WeatherClient.js
+++ b/public/src/api/WeatherClient.js
@@ -172,7 +172,7 @@ export class WeatherClient {
     }
 
     getAccessibleRelativeTime(timestamp, sessionTime) {
-        const diffMins = (timestamp * 1000 - sessionTime.getTime()) / 60000;
+        const diffMins = (timestamp * 1000 - sessionTime.getTime()) / CONFIG.ONE_MINUTE_MS;
 
         if (Math.abs(diffMins) < 30) return 'Session start';
         const hours = Math.round(diffMins / 60);

--- a/public/src/config.js
+++ b/public/src/config.js
@@ -23,6 +23,7 @@ export const CONFIG = {
     defaultSpeedIndex: 1, // Start at 1x
 
     // Time Constants
+    ONE_MINUTE_MS: 60000,
     RACE_DURATION_BUFFER_HOURS: 4, // Assume race + podium + post-race takes ~4 hours
     RACE_DAY_END_HOUR: 23, // Fallback to end of day if session time is missing
     WEATHER_REFRESH_INTERVAL_MS: 300000, // 5 minutes

--- a/public/src/map/WeatherRadar.js
+++ b/public/src/map/WeatherRadar.js
@@ -57,20 +57,11 @@ export class WeatherRadar {
         this.updateSpeedLabel();
 
         // Palette UX: Start a 1-minute timer to keep the relative time updated
-        // TODO: This magic number requires further investigation and confirmation.
-        // The value 60000 is the number of milliseconds in one minute, used to set the
-        // interval at which the relative time display is refreshed in the radar controls.
-        // While the comment above partially explains the intent, having the literal number
-        // in the code means developers need to do the mental arithmetic to understand the
-        // interval duration. This should be extracted to a named constant such as
-        // ONE_MINUTE_MS or RELATIVE_TIME_REFRESH_INTERVAL_MS alongside the other
-        // time-related constants in the codebase, making the intent clear at a glance
-        // without requiring any calculation.
         this.relativeTimeInterval = setInterval(() => {
             if (this.visibleLayerIndex >= 0) {
                 this.updateTimeDisplay(this.frames[this.visibleLayerIndex]?.time);
             }
-        }, 60000);
+        }, CONFIG.ONE_MINUTE_MS);
     }
 
     bindEvents() {
@@ -226,9 +217,8 @@ export class WeatherRadar {
      */
     scheduleNextPoll() {
         const now = Date.now();
-        const msPerMin = 60000;
-        const updateIntervalMs = 10 * msPerMin; // RainViewer updates every 10 minutes
-        const offsetMs = 1 * msPerMin; // Poll 1 minute after update to ensure data is ready
+        const updateIntervalMs = 10 * CONFIG.ONE_MINUTE_MS; // RainViewer updates every 10 minutes
+        const offsetMs = 1 * CONFIG.ONE_MINUTE_MS; // Poll 1 minute after update to ensure data is ready
 
         // Calculate ms since last :X0 mark (e.g., :00, :10, :20, etc.)
         const msSinceLastUpdate = now % updateIntervalMs;
@@ -867,7 +857,7 @@ export class WeatherRadar {
 
         // Show relative to session if available
         if (this.ui.relative && this.sessionTime) {
-            const diff = (effectiveTimeMs - this.sessionTime.getTime()) / 60000; // minutes
+            const diff = (effectiveTimeMs - this.sessionTime.getTime()) / CONFIG.ONE_MINUTE_MS; // minutes
             const absDiff = Math.abs(Math.round(diff));
             const durationText = this.formatDuration(absDiff);
 
@@ -890,7 +880,7 @@ export class WeatherRadar {
                 accessibleText = 'Forecast';
             } else {
                 // Palette UX: For past frames when no session is selected, show "X mins ago"
-                const diffMin = Math.round((Date.now() - effectiveTimeMs) / 60000);
+                const diffMin = Math.round((Date.now() - effectiveTimeMs) / CONFIG.ONE_MINUTE_MS);
 
                 if (diffMin < 1) {
                     relativeText = 'Live';

--- a/public/src/ui/CountdownTimer.js
+++ b/public/src/ui/CountdownTimer.js
@@ -1,3 +1,5 @@
+import { CONFIG } from '../config.js';
+
 export class CountdownTimer {
     constructor() {
         this.timer = null;
@@ -40,8 +42,8 @@ export class CountdownTimer {
         }
 
         const hours = Math.floor(diff / 3600000);
-        const mins = Math.floor((diff % 3600000) / 60000);
-        const secs = Math.floor((diff % 60000) / 1000);
+        const mins = Math.floor((diff % 3600000) / CONFIG.ONE_MINUTE_MS);
+        const secs = Math.floor((diff % CONFIG.ONE_MINUTE_MS) / 1000);
 
         let timeText;
         if (hours > 24) {
@@ -62,8 +64,8 @@ export class CountdownTimer {
 
     getAccessibleDuration(diff) {
         const hours = Math.floor(diff / 3600000);
-        const mins = Math.floor((diff % 3600000) / 60000);
-        const secs = Math.floor((diff % 60000) / 1000);
+        const mins = Math.floor((diff % 3600000) / CONFIG.ONE_MINUTE_MS);
+        const secs = Math.floor((diff % CONFIG.ONE_MINUTE_MS) / 1000);
 
         if (hours > 24) {
             const days = Math.floor(hours / 24);

--- a/tests/weather-client.test.js
+++ b/tests/weather-client.test.js
@@ -4,7 +4,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 vi.mock('../public/src/config.js', () => ({
     CONFIG: {
         weatherApi: 'https://api.open-meteo.com/v1/forecast',
-        SESSION_FORECAST_REFRESH_INTERVAL_MS: 900000
+        SESSION_FORECAST_REFRESH_INTERVAL_MS: 900000,
+        ONE_MINUTE_MS: 60000
     }
 }));
 


### PR DESCRIPTION
Replaced the magic number `60000` with a named constant `ONE_MINUTE_MS` in the centralized `CONFIG` object to improve codebase readability. Updates were made across `WeatherRadar.js`, `WeatherClient.js`, and `CountdownTimer.js`. Test config mocks were updated to prevent regressions.

---
*PR created automatically by Jules for task [9245021586273341091](https://jules.google.com/task/9245021586273341091) started by @2fst4u*