### PR TITLE
refactor: extract magic number 3000 to shared constant TILE_LOAD_TIMEOUT_MS

### DIFF
--- a/public/src/config.js
+++ b/public/src/config.js
@@ -28,6 +28,7 @@ export const CONFIG = {
     RACE_DAY_END_HOUR: 23, // Fallback to end of day if session time is missing
     WEATHER_REFRESH_INTERVAL_MS: 300000, // 5 minutes
     SESSION_FORECAST_REFRESH_INTERVAL_MS: 900000, // 15 minutes
+    TILE_LOAD_TIMEOUT_MS: 3000, // 3 seconds
 };
 // SEC: Prevent runtime tampering with configuration
 Object.freeze(CONFIG);

--- a/public/src/map/WeatherRadar.js
+++ b/public/src/map/WeatherRadar.js
@@ -682,16 +682,7 @@ export class WeatherRadar {
 
             currentLayer.on('load', onLoad);
 
-            // Timeout fallback (3 seconds)
-            // TODO: This magic number requires further investigation and confirmation.
-            // The value 3000 represents a 3-second timeout used as a fallback to resolve
-            // the tile-loading promise in case the layer's 'load' event never fires, which
-            // can happen if tiles fail silently or if the Leaflet layer gets into an
-            // unexpected state. While the comment above identifies this as "3 seconds",
-            // the literal value requires mental arithmetic to verify. This same 3-second
-            // value is also used in the preloadSequence timeout below, suggesting it should
-            // be a shared named constant such as TILE_LOAD_TIMEOUT_MS to ensure both
-            // timeouts remain consistent and can be adjusted from one location.
+            // Timeout fallback
             setTimeout(() => {
                 if (!resolved) {
                     resolved = true;
@@ -699,7 +690,7 @@ export class WeatherRadar {
                     this.showFrame(this.currentFrame);
                     resolve();
                 }
-            }, 3000);
+            }, CONFIG.TILE_LOAD_TIMEOUT_MS);
         });
     }
 
@@ -757,21 +748,11 @@ export class WeatherRadar {
             layer.on('load', onComplete);
             layer.on('tileerror', onComplete);
 
-            // Timeout to prevent stuck queue (3s per frame)
-            // TODO: This magic number requires further investigation and confirmation.
-            // The value 3000 here serves the same purpose as the 3-second fallback
-            // in waitForTilesToLoad() above — it prevents the preload queue from
-            // becoming stuck if a tile frame never completes loading. Since both
-            // locations use the same 3000ms value for the same conceptual reason,
-            // they should both reference a single shared constant such as
-            // TILE_LOAD_TIMEOUT_MS rather than duplicating the literal value.
-            // If one of these timeouts is changed without updating the other,
-            // it could create inconsistent behaviour between the initial load
-            // and the sequential preload phase of the animation.
+            // Timeout to prevent stuck queue
             setTimeout(() => {
                 cleanup();
                 resolve();
-            }, 3000);
+            }, CONFIG.TILE_LOAD_TIMEOUT_MS);
         });
     }
 

--- a/tests/recentre-control.test.js
+++ b/tests/recentre-control.test.js
@@ -3,7 +3,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // Mock Config first
 vi.mock('../public/src/config.js', () => ({
     CONFIG: {
-        circuitZoom: 10
+        circuitZoom: 10,
+        TILE_LOAD_TIMEOUT_MS: 3000
     }
 }));
 

--- a/tests/weather-client.test.js
+++ b/tests/weather-client.test.js
@@ -5,7 +5,8 @@ vi.mock('../public/src/config.js', () => ({
     CONFIG: {
         weatherApi: 'https://api.open-meteo.com/v1/forecast',
         SESSION_FORECAST_REFRESH_INTERVAL_MS: 900000,
-        ONE_MINUTE_MS: 60000
+        ONE_MINUTE_MS: 60000,
+        TILE_LOAD_TIMEOUT_MS: 3000
     }
 }));
 


### PR DESCRIPTION
Extracted the 3000ms magic number used for tile loading timeouts in `public/src/map/WeatherRadar.js` into a shared named constant `TILE_LOAD_TIMEOUT_MS` within the central `CONFIG` object (`public/src/config.js`). Updated both the initial tile load fallback and the preload sequence timeout to reference this constant, ensuring consistent behavior. Removed the associated TODO comments that noted the magic number. Also updated the relevant test mocks in `tests/weather-client.test.js` and `tests/recentre-control.test.js` to include the new constant, preventing test failures caused by undefined values.

---
*PR created automatically by Jules for task [16834562785776070995](https://jules.google.com/task/16834562785776070995) started by @2fst4u*