### PR TITLE
Extract magic number 30000 into a named constant

### DIFF
--- a/public/src/config.js
+++ b/public/src/config.js
@@ -29,6 +29,7 @@ export const CONFIG = {
     WEATHER_REFRESH_INTERVAL_MS: 300000, // 5 minutes
     SESSION_FORECAST_REFRESH_INTERVAL_MS: 900000, // 15 minutes
     TILE_LOAD_TIMEOUT_MS: 3000, // 3 seconds
+    MIN_POLL_DELAY_MS: 30000, // 30 seconds
 };
 // SEC: Prevent runtime tampering with configuration
 Object.freeze(CONFIG);

--- a/public/src/map/WeatherRadar.js
+++ b/public/src/map/WeatherRadar.js
@@ -232,15 +232,7 @@ export class WeatherRadar {
         }
 
         // Minimum delay of 30 seconds to avoid tight loops on clock edge cases
-        // TODO: This magic number requires further investigation and confirmation.
-        // The value 30000 represents a minimum polling delay of 30 seconds, used as
-        // a floor to prevent tight polling loops if the calculated delay comes out
-        // unexpectedly small due to clock edge cases or arithmetic rounding. The comment
-        // explains the purpose, but the literal value still requires mental arithmetic
-        // to verify against the comment. This should be extracted to a named constant
-        // such as MIN_POLL_DELAY_MS to make the intent immediately clear and to allow
-        // it to be adjusted in one place if the minimum threshold ever needs changing.
-        delay = Math.max(delay, 30000);
+        delay = Math.max(delay, CONFIG.MIN_POLL_DELAY_MS);
 
         this.pollingTimeout = setTimeout(() => {
             this.checkForUpdates();

--- a/tests/recentre-control.test.js
+++ b/tests/recentre-control.test.js
@@ -4,7 +4,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 vi.mock('../public/src/config.js', () => ({
     CONFIG: {
         circuitZoom: 10,
-        TILE_LOAD_TIMEOUT_MS: 3000
+        TILE_LOAD_TIMEOUT_MS: 3000,
+        MIN_POLL_DELAY_MS: 30000
     }
 }));
 

--- a/tests/track-layer.test.js
+++ b/tests/track-layer.test.js
@@ -45,7 +45,10 @@ vi.mock('../public/src/config.js', async (importOriginal) => {
     const actual = await importOriginal();
     return {
         ...actual,
-        CONFIG: { ...actual.CONFIG }
+        CONFIG: {
+            ...actual.CONFIG,
+            MIN_POLL_DELAY_MS: 30000
+        }
     };
 });
 

--- a/tests/weather-client.test.js
+++ b/tests/weather-client.test.js
@@ -6,7 +6,8 @@ vi.mock('../public/src/config.js', () => ({
         weatherApi: 'https://api.open-meteo.com/v1/forecast',
         SESSION_FORECAST_REFRESH_INTERVAL_MS: 900000,
         ONE_MINUTE_MS: 60000,
-        TILE_LOAD_TIMEOUT_MS: 3000
+        TILE_LOAD_TIMEOUT_MS: 3000,
+        MIN_POLL_DELAY_MS: 30000
     }
 }));
 


### PR DESCRIPTION
Extracts the magic number `30000` into a named constant `MIN_POLL_DELAY_MS` to clarify the code intent and allow it to be adjusted from a centralized location.

---
*PR created automatically by Jules for task [10925853871627826944](https://jules.google.com/task/10925853871627826944) started by @2fst4u*