### PR TITLE
Fix ResizeObserver memory leak in MapManager

### DIFF
--- a/public/src/map/MapManager.js
+++ b/public/src/map/MapManager.js
@@ -1,62 +1,62 @@
-import { CONFIG } from '../config.js';
+import { CONFIG } from "../config.js";
 
 /**
  * Manages the Leaflet map instance, tile layers, and theme switching.
  */
 export class MapManager {
-    constructor() {
-        this.map = null;
-        this.tileLayer = null;
-        this.resizeObserver = null;
-    }
+  constructor() {
+    this.map = null;
+    this.tileLayer = null;
+    this.resizeObserver = null;
+  }
 
-    init() {
-        this.map = L.map('map', {
-            center: CONFIG.defaultCenter,
-            zoom: CONFIG.defaultZoom,
-            zoomControl: true,
-        });
+  init() {
+    this.map = L.map("map", {
+      center: CONFIG.defaultCenter,
+      zoom: CONFIG.defaultZoom,
+      zoomControl: true,
+    });
 
-        // Bolt Optimization: Use ResizeObserver to automatically handle map resizing
-        // This is more efficient than window.resize listeners and manual timeouts
-        // TODO: This ResizeObserver implementation requires further investigation and confirmation.
-        // The current code creates a ResizeObserver instance and begins observing the map container,
-        // but there is no corresponding cleanup mechanism to disconnect the observer when the
-        // MapManager is destroyed or when the map is no longer needed. This could lead to a memory
-        // leak where the observer continues to hold references to DOM elements even after they have
-        // been removed from the document. Additionally, if the MapManager is re-initialized (for
-        // example, during a hot reload in development), a new observer would be created while the
-        // old one continues running, compounding the memory issue. A destroy() or cleanup() method
-        // should be added to the MapManager class that calls this.resizeObserver.disconnect() when
-        // the map is being torn down, ensuring proper cleanup of resources.
-        const mapContainer = document.getElementById('map');
-        if (mapContainer && window.ResizeObserver) {
-            this.resizeObserver = new ResizeObserver(() => {
-                if (this.map) {
-                    this.map.invalidateSize();
-                }
-            });
-            this.resizeObserver.observe(mapContainer);
+    // Bolt Optimization: Use ResizeObserver to automatically handle map resizing
+    // This is more efficient than window.resize listeners and manual timeouts
+    const mapContainer = document.getElementById("map");
+    if (mapContainer && window.ResizeObserver) {
+      this.resizeObserver = new ResizeObserver(() => {
+        if (this.map) {
+          this.map.invalidateSize();
         }
-
-        this.setTheme(document.documentElement.getAttribute('data-theme') || 'light');
-        return this.map;
+      });
+      this.resizeObserver.observe(mapContainer);
     }
 
-    setTheme(theme) {
-        const tileUrl = theme === 'dark' ? CONFIG.mapTilesDark : CONFIG.mapTiles;
+    this.setTheme(
+      document.documentElement.getAttribute("data-theme") || "light",
+    );
+    return this.map;
+  }
 
-        if (this.tileLayer) this.map.removeLayer(this.tileLayer);
-
-        this.tileLayer = L.tileLayer(tileUrl, {
-            attribution: '© <a href="https://carto.com/" target="_blank" rel="noopener noreferrer">CARTO</a> © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">OSM</a>',
-            maxZoom: 18,
-            subdomains: 'abcd',
-        });
-        this.tileLayer.addTo(this.map);
+  destroy() {
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
     }
+  }
 
-    setView(lat, lng, zoom = CONFIG.circuitZoom) {
-        if (this.map) this.map.setView([lat, lng], zoom);
-    }
+  setTheme(theme) {
+    const tileUrl = theme === "dark" ? CONFIG.mapTilesDark : CONFIG.mapTiles;
+
+    if (this.tileLayer) this.map.removeLayer(this.tileLayer);
+
+    this.tileLayer = L.tileLayer(tileUrl, {
+      attribution:
+        '© <a href="https://carto.com/" target="_blank" rel="noopener noreferrer">CARTO</a> © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">OSM</a>',
+      maxZoom: 18,
+      subdomains: "abcd",
+    });
+    this.tileLayer.addTo(this.map);
+  }
+
+  setView(lat, lng, zoom = CONFIG.circuitZoom) {
+    if (this.map) this.map.setView([lat, lng], zoom);
+  }
 }

--- a/tests/map-manager.test.js
+++ b/tests/map-manager.test.js
@@ -1,172 +1,200 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { CONFIG } from '../public/src/config.js';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CONFIG } from "../public/src/config.js";
 
 // Mock Leaflet (L)
 const mapMock = {
-    setView: vi.fn(),
-    removeLayer: vi.fn(),
-    invalidateSize: vi.fn(),
-    addLayer: vi.fn(),
-    on: vi.fn(),
-    off: vi.fn()
+  setView: vi.fn(),
+  removeLayer: vi.fn(),
+  invalidateSize: vi.fn(),
+  addLayer: vi.fn(),
+  on: vi.fn(),
+  off: vi.fn(),
 };
 
 const tileLayerMock = {
-    addTo: vi.fn(),
-    remove: vi.fn()
+  addTo: vi.fn(),
+  remove: vi.fn(),
 };
 
 const leafletMock = {
-    map: vi.fn(() => mapMock),
-    tileLayer: vi.fn(() => tileLayerMock),
+  map: vi.fn(() => mapMock),
+  tileLayer: vi.fn(() => tileLayerMock),
 };
 
-vi.stubGlobal('L', leafletMock);
+vi.stubGlobal("L", leafletMock);
 
 // Mock DOM
 const createMockElement = (id) => ({
-    id,
-    getAttribute: vi.fn(),
-    style: {},
+  id,
+  getAttribute: vi.fn(),
+  style: {},
 });
 
 const documentMock = {
-    getElementById: vi.fn((id) => createMockElement(id)),
-    documentElement: {
-        getAttribute: vi.fn((attr) => attr === 'data-theme' ? 'light' : null)
-    }
+  getElementById: vi.fn((id) => createMockElement(id)),
+  documentElement: {
+    getAttribute: vi.fn((attr) => (attr === "data-theme" ? "light" : null)),
+  },
 };
 
-vi.stubGlobal('document', documentMock);
+vi.stubGlobal("document", documentMock);
 
 // Mock ResizeObserver
 let resizeCallback;
 const resizeObserverMock = vi.fn((cb) => {
-    resizeCallback = cb;
-    return {
-        observe: vi.fn(),
-        unobserve: vi.fn(),
-        disconnect: vi.fn()
-    };
+  resizeCallback = cb;
+  return {
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  };
 });
 
 // Important: Mock window to include ResizeObserver as the code checks window.ResizeObserver
-vi.stubGlobal('ResizeObserver', resizeObserverMock);
-vi.stubGlobal('window', {
-    ResizeObserver: resizeObserverMock,
-    addEventListener: vi.fn()
+vi.stubGlobal("ResizeObserver", resizeObserverMock);
+vi.stubGlobal("window", {
+  ResizeObserver: resizeObserverMock,
+  addEventListener: vi.fn(),
 });
 
-
 // Import the class under test
-const { MapManager } = await import('../public/src/map/MapManager.js');
+const { MapManager } = await import("../public/src/map/MapManager.js");
 
-describe('MapManager', () => {
-    let mapManager;
+describe("MapManager", () => {
+  let mapManager;
 
-    beforeEach(() => {
-        vi.clearAllMocks();
-        mapManager = new MapManager();
-        resizeCallback = null; // Reset callback
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mapManager = new MapManager();
+    resizeCallback = null; // Reset callback
+  });
+
+  it("should initialize the map with default configuration", () => {
+    const map = mapManager.init();
+
+    expect(leafletMock.map).toHaveBeenCalledWith("map", {
+      center: CONFIG.defaultCenter,
+      zoom: CONFIG.defaultZoom,
+      zoomControl: true,
     });
+    expect(map).toBe(mapMock);
 
-    it('should initialize the map with default configuration', () => {
-        const map = mapManager.init();
+    // Verify ResizeObserver was set up
+    expect(resizeObserverMock).toHaveBeenCalled();
+    const observerInstance = resizeObserverMock.mock.results[0].value;
+    expect(observerInstance.observe).toHaveBeenCalled();
 
-        expect(leafletMock.map).toHaveBeenCalledWith('map', {
-            center: CONFIG.defaultCenter,
-            zoom: CONFIG.defaultZoom,
-            zoomControl: true,
-        });
-        expect(map).toBe(mapMock);
+    // Verify initial theme setting (defaults to light)
+    expect(leafletMock.tileLayer).toHaveBeenCalledWith(
+      CONFIG.mapTiles,
+      expect.any(Object),
+    );
+    expect(tileLayerMock.addTo).toHaveBeenCalledWith(mapMock);
+  });
 
-        // Verify ResizeObserver was set up
-        expect(resizeObserverMock).toHaveBeenCalled();
-        const observerInstance = resizeObserverMock.mock.results[0].value;
-        expect(observerInstance.observe).toHaveBeenCalled();
+  it("should set theme correctly (dark)", () => {
+    mapManager.init();
+    vi.clearAllMocks(); // clear initial calls
 
-        // Verify initial theme setting (defaults to light)
-        expect(leafletMock.tileLayer).toHaveBeenCalledWith(CONFIG.mapTiles, expect.any(Object));
-        expect(tileLayerMock.addTo).toHaveBeenCalledWith(mapMock);
-    });
+    mapManager.setTheme("dark");
 
-    it('should set theme correctly (dark)', () => {
-        mapManager.init();
-        vi.clearAllMocks(); // clear initial calls
+    expect(leafletMock.tileLayer).toHaveBeenCalledWith(
+      CONFIG.mapTilesDark,
+      expect.objectContaining({
+        maxZoom: 18,
+        subdomains: "abcd",
+      }),
+    );
+    expect(tileLayerMock.addTo).toHaveBeenCalledWith(mapMock);
+  });
 
-        mapManager.setTheme('dark');
+  it("should remove existing tile layer when setting new theme", () => {
+    mapManager.init(); // This sets the initial tile layer
+    vi.clearAllMocks(); // Clear mocks to reset counts
 
-        expect(leafletMock.tileLayer).toHaveBeenCalledWith(CONFIG.mapTilesDark, expect.objectContaining({
-            maxZoom: 18,
-            subdomains: 'abcd'
-        }));
-        expect(tileLayerMock.addTo).toHaveBeenCalledWith(mapMock);
-    });
+    // Mock that we have a tile layer set
+    const oldTileLayer = mapManager.tileLayer;
 
-    it('should remove existing tile layer when setting new theme', () => {
-        mapManager.init(); // This sets the initial tile layer
-        vi.clearAllMocks(); // Clear mocks to reset counts
+    mapManager.setTheme("dark");
 
-        // Mock that we have a tile layer set
-        const oldTileLayer = mapManager.tileLayer;
+    expect(mapMock.removeLayer).toHaveBeenCalledWith(oldTileLayer);
+    expect(leafletMock.tileLayer).toHaveBeenCalledTimes(1); // One new layer created
+  });
 
-        mapManager.setTheme('dark');
+  it("should update view with setView", () => {
+    mapManager.init();
+    const lat = 51.505;
+    const lng = -0.09;
+    const zoom = 13;
 
-        expect(mapMock.removeLayer).toHaveBeenCalledWith(oldTileLayer);
-        expect(leafletMock.tileLayer).toHaveBeenCalledTimes(1); // One new layer created
-    });
+    mapManager.setView(lat, lng, zoom);
 
-    it('should update view with setView', () => {
-        mapManager.init();
-        const lat = 51.505;
-        const lng = -0.09;
-        const zoom = 13;
+    expect(mapMock.setView).toHaveBeenCalledWith([lat, lng], zoom);
+  });
 
-        mapManager.setView(lat, lng, zoom);
+  it("should use default circuit zoom in setView if not provided", () => {
+    mapManager.init();
+    const lat = 51.505;
+    const lng = -0.09;
 
-        expect(mapMock.setView).toHaveBeenCalledWith([lat, lng], zoom);
-    });
+    mapManager.setView(lat, lng);
 
-    it('should use default circuit zoom in setView if not provided', () => {
-        mapManager.init();
-        const lat = 51.505;
-        const lng = -0.09;
+    expect(mapMock.setView).toHaveBeenCalledWith(
+      [lat, lng],
+      CONFIG.circuitZoom,
+    );
+  });
 
-        mapManager.setView(lat, lng);
+  it("should invalidate map size when ResizeObserver triggers", () => {
+    mapManager.init();
 
-        expect(mapMock.setView).toHaveBeenCalledWith([lat, lng], CONFIG.circuitZoom);
-    });
+    // Ensure callback was captured
+    expect(resizeCallback).toBeDefined();
 
-    it('should invalidate map size when ResizeObserver triggers', () => {
-        mapManager.init();
+    // Trigger the resize callback
+    resizeCallback();
 
-        // Ensure callback was captured
-        expect(resizeCallback).toBeDefined();
+    expect(mapMock.invalidateSize).toHaveBeenCalled();
+  });
 
-        // Trigger the resize callback
-        resizeCallback();
+  it("should handle missing map container gracefully during init", () => {
+    documentMock.getElementById.mockReturnValueOnce(null);
 
-        expect(mapMock.invalidateSize).toHaveBeenCalled();
-    });
+    mapManager.init();
 
-    it('should handle missing map container gracefully during init', () => {
-        documentMock.getElementById.mockReturnValueOnce(null);
+    expect(resizeObserverMock).not.toHaveBeenCalled();
+  });
 
-        mapManager.init();
+  it("should disconnect the ResizeObserver and set it to null when destroyed", () => {
+    mapManager.init();
+    const observerInstance = resizeObserverMock.mock.results[0].value;
 
-        expect(resizeObserverMock).not.toHaveBeenCalled();
-    });
+    expect(mapManager.resizeObserver).toBe(observerInstance);
 
-    it('should default to light theme if data-theme attribute is missing', () => {
-        // Mock getAttribute to return null
-        const originalGetAttribute = documentMock.documentElement.getAttribute;
-        documentMock.documentElement.getAttribute = vi.fn().mockReturnValue(null);
+    mapManager.destroy();
 
-        mapManager.init();
+    expect(observerInstance.disconnect).toHaveBeenCalled();
+    expect(mapManager.resizeObserver).toBeNull();
+  });
 
-        expect(leafletMock.tileLayer).toHaveBeenCalledWith(CONFIG.mapTiles, expect.any(Object));
+  it("should not throw an error if destroyed without a ResizeObserver", () => {
+    mapManager.destroy();
+    expect(mapManager.resizeObserver).toBeNull();
+  });
 
-        // Restore mock
-        documentMock.documentElement.getAttribute = originalGetAttribute;
-    });
+  it("should default to light theme if data-theme attribute is missing", () => {
+    // Mock getAttribute to return null
+    const originalGetAttribute = documentMock.documentElement.getAttribute;
+    documentMock.documentElement.getAttribute = vi.fn().mockReturnValue(null);
+
+    mapManager.init();
+
+    expect(leafletMock.tileLayer).toHaveBeenCalledWith(
+      CONFIG.mapTiles,
+      expect.any(Object),
+    );
+
+    // Restore mock
+    documentMock.documentElement.getAttribute = originalGetAttribute;
+  });
 });


### PR DESCRIPTION
Adds a `destroy()` method to `MapManager` to disconnect the `ResizeObserver` and prevent memory leaks. Also adds corresponding unit tests and removes the inline TODO.

---
*PR created automatically by Jules for task [14207282615919671195](https://jules.google.com/task/14207282615919671195) started by @2fst4u*