### PR TITLE
📚 Archivist: Update Cloudflare platform terminology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Circuit Weather is a real-time F1 race circuit weather radar application. It dis
 | -------- | --------------------------------------------------- |
 | Frontend | Vanilla HTML/CSS/JS                                 |
 | Mapping  | Leaflet.js with Carto basemaps                      |
-| Backend  | Cloudflare Workers with Assets                      |
+| Backend  | Cloudflare Workers with Static Assets               |
 | APIs     | Jolpica F1, RainViewer, Open-Meteo, GitHub (Tracks) |
 
 ---
@@ -114,7 +114,7 @@ circuit-weather/
 pnpm run dev # or 'npx wrangler dev' / 'wrangler dev' based on environment availability
 
 # Deploy to Cloudflare
-# Deployment is automatic via Cloudflare Git Integration (Workers with Assets)
+# Deployment is automatic via Cloudflare Git Integration (Workers with Static Assets)
 # when changes are merged to the 'main' branch.
 # See "Git Workflow for Changes" below.
 ```
@@ -161,7 +161,7 @@ main = "src/worker.js"
 compatibility_date = "2024-09-23"
 preview_urls = true
 
-# Cloudflare Workers with Assets configuration
+# Cloudflare Workers with Static Assets configuration
 # https://developers.cloudflare.com/workers/static-assets/routing/single-page-application/
 [assets]
 directory = "./public"


### PR DESCRIPTION
💡 **Problem:** The `AGENTS.md` documentation incorrectly referred to the deployment platform as "Cloudflare Workers with Assets" in the Technology Stack table and the Configuration section. This terminology was slightly inaccurate and did not reflect the official Cloudflare product name ("Workers Static Assets").
🎯 **Fix:** Updated the phrasing across the document to use "Cloudflare Workers with Static Assets", ensuring the map matches the territory regarding infrastructure naming conventions.
🧪 **Verification:** Ran a `grep` across the repository to verify all instances were updated correctly. Formatted the `AGENTS.md` file using `prettier` and ran the test suite (`pnpm test`) to ensure no functional regressions occurred.
🔎 **Scope:** This PR contains ONLY documentation changes to `AGENTS.md`.

---
*PR created automatically by Jules for task [4187947008916047221](https://jules.google.com/task/4187947008916047221) started by @2fst4u*