### PR TITLE
Refactor DOM Caching in CircuitWeatherApp

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -36,16 +36,11 @@ export class CircuitWeatherApp {
         this.router = new Router(params => this.handleRoute(params));
         this.mobileQuery = window.matchMedia('(max-width: 768px)');
 
+        this.ui = {};
+    }
+
+    async init() {
         // Bolt Optimization: Cache frequently accessed DOM elements
-        // TODO: This DOM element caching implementation requires further investigation and confirmation.
-        // The constructor attempts to cache DOM elements using document.getElementById() immediately
-        // when the class is instantiated. However, if the CircuitWeatherApp class is instantiated
-        // before the DOMContentLoaded event fires, these elements will not exist in the document yet
-        // and all cached references will be null. While the current code works because init() is
-        // called after DOMContentLoaded in main.js, this creates a fragile dependency that could
-        // break if the initialization order changes. Consider moving this DOM caching logic to the
-        // init() method instead, or add null checks before using these cached elements to ensure
-        // the application handles cases where elements are not found gracefully.
         this.ui = {
             loadingOverlay: document.getElementById('loadingOverlay'),
             roundSelect: document.getElementById('roundSelect'),
@@ -67,9 +62,7 @@ export class CircuitWeatherApp {
             mobileRaceInfoName: document.getElementById('mobileRaceInfoName'),
             mobileRaceInfoCircuit: document.getElementById('mobileRaceInfoCircuit'),
         };
-    }
 
-    async init() {
         this.showLoading(true, 'Loading race schedule...');
 
         try {

--- a/tests/session-labels.test.js
+++ b/tests/session-labels.test.js
@@ -51,6 +51,10 @@ describe('CircuitWeatherApp Session Labels', () => {
         vi.clearAllMocks();
         vi.useFakeTimers();
         app = new CircuitWeatherApp();
+        app.ui = {
+            roundSelect: createMockElement('roundSelect'),
+            sessionSelect: createMockElement('sessionSelect')
+        };
         app.races = [
             {
                 round: '1',


### PR DESCRIPTION
Moved `this.ui` DOM element caching from `CircuitWeatherApp.js`'s constructor to its `init()` method to prevent issues where the class might be instantiated before the DOM is fully loaded. Updated corresponding test files to ensure proper mocking of UI elements when the constructor is called directly during testing.

---
*PR created automatically by Jules for task [3001219871561895400](https://jules.google.com/task/3001219871561895400) started by @2fst4u*