### PR TITLE
feat(api): implement LRU eviction strategy for in-memory cache

### DIFF
--- a/public/src/api/WeatherClient.js
+++ b/public/src/api/WeatherClient.js
@@ -3,17 +3,8 @@ import { CONFIG } from '../config.js';
 export class WeatherClient {
     constructor() {
         this.baseUrl = CONFIG.weatherApi;
-        // TODO: This in-memory cache implementation requires further investigation and confirmation.
-        // The current implementation uses a plain JavaScript Map with no maximum size limit or eviction
-        // policy. As users browse different circuits across the F1 season, each unique coordinate pair
-        // creates a new cache entry that is never removed. Over time, this could lead to unbounded
-        // memory growth in long-running sessions, potentially degrading performance or causing memory
-        // issues on devices with limited resources. Consider implementing an LRU (Least Recently Used)
-        // eviction strategy with a maximum cache size (for example, 50 entries) to prevent excessive
-        // memory usage. Additionally, the cache entries are only keyed by rounded coordinates and do
-        // not account for different forecast times, which could lead to stale data being served
-        // if the same location is queried for different session times.
         this.cache = new Map();
+        this.maxCacheSize = CONFIG.WEATHER_CACHE_MAX_ENTRIES;
         this.cacheTTL = CONFIG.SESSION_FORECAST_REFRESH_INTERVAL_MS;
     }
 
@@ -36,13 +27,18 @@ export class WeatherClient {
             // 2 decimal places is approx 1.1km, sufficient for general weather accuracy
             const rLat = Number(lat).toFixed(2);
             const rLon = Number(lon).toFixed(2);
-            const cacheKey = `${rLat},${rLon}`;
+            const cacheKey = `${rLat},${rLon},${sessionTime.getTime()}`;
             let data;
 
             if (this.cache.has(cacheKey)) {
                 const entry = this.cache.get(cacheKey);
                 if (Date.now() - entry.timestamp < this.cacheTTL) {
                     data = entry.data;
+                    // Move to most recently used
+                    this.cache.delete(cacheKey);
+                    this.cache.set(cacheKey, entry);
+                } else {
+                    this.cache.delete(cacheKey);
                 }
             }
 
@@ -67,6 +63,10 @@ export class WeatherClient {
 
                 data = await response.json();
                 this.cache.set(cacheKey, { timestamp: Date.now(), data });
+
+                if (this.cache.size > this.maxCacheSize) {
+                    this.cache.delete(this.cache.keys().next().value);
+                }
             }
 
             const hourlyFiltered = this.filterHourly(data.hourly, sessionTime);

--- a/public/src/config.js
+++ b/public/src/config.js
@@ -30,6 +30,7 @@ export const CONFIG = {
     SESSION_FORECAST_REFRESH_INTERVAL_MS: 900000, // 15 minutes
     TILE_LOAD_TIMEOUT_MS: 3000, // 3 seconds
     MIN_POLL_DELAY_MS: 30000, // 30 seconds
+    WEATHER_CACHE_MAX_ENTRIES: 50,
 };
 // SEC: Prevent runtime tampering with configuration
 Object.freeze(CONFIG);

--- a/tests/weather-client.test.js
+++ b/tests/weather-client.test.js
@@ -7,7 +7,8 @@ vi.mock('../public/src/config.js', () => ({
         SESSION_FORECAST_REFRESH_INTERVAL_MS: 900000,
         ONE_MINUTE_MS: 60000,
         TILE_LOAD_TIMEOUT_MS: 3000,
-        MIN_POLL_DELAY_MS: 30000
+        MIN_POLL_DELAY_MS: 30000,
+        WEATHER_CACHE_MAX_ENTRIES: 50
     }
 }));
 


### PR DESCRIPTION
The `WeatherClient` cache lacked an eviction policy and a maximum size bound, making it vulnerable to unbounded memory growth as the cache was built up across the F1 season. It also incorrectly served stale data if users queried the same location across different session times.
This commit implements an idiomatic JS Map-based LRU cache. It limits the cache to `WEATHER_CACHE_MAX_ENTRIES` (50), properly managing least-recently-used eviction. The cache key logic has also been correctly parameterized with the session time to solve the edge case.

---
*PR created automatically by Jules for task [8824398563273729827](https://jules.google.com/task/8824398563273729827) started by @2fst4u*