### PR TITLE
🎨 Palette: Improved error feedback on session selection failure

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -64,3 +64,7 @@
 ## 2026-03-09 - Continuous Animations in Skeleton Loaders
 **Learning:** Continuous CSS animations (like infinite gradients on skeleton loaders) can cause discomfort, dizziness, or adverse effects for users with vestibular disorders or motion sensitivity who have enabled `prefers-reduced-motion` in their OS or browser.
 **Action:** Always wrap continuous animations in a `@media (prefers-reduced-motion: reduce)` query to disable the animation (`animation: none`) and provide a static placeholder, ensuring the UI remains accessible and comfortable for all users.
+
+## 2025-05-15 - Async Operation Silent Failures
+**Learning:** When async operations tied to user interactions fail silently inside catch blocks, users are left staring at infinite loading skeletons or unchanged screens, which is confusing and feels broken.
+**Action:** Always provide explicit visual feedback (like an error toast) and properly tear down loading states (e.g., removing `aria-busy` and hiding skeletons) in the catch block of user-initiated async functions.

--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -582,19 +582,24 @@ export class CircuitWeatherApp {
 
             this.router.navigate('f1', this.selectedRace.round, sessionId);
         } catch (error) {
-            // TODO: This error handling requires further investigation and confirmation.
-            // When an error occurs during session selection, the current code only logs
-            // the error to the browser console and hides the loading overlay. The user
-            // receives no visual feedback at all about what went wrong — the loading spinner
-            // disappears and the application returns to its previous state silently. This
-            // means that if either the radar data fails to load or the session forecast
-            // fetch fails, the user has no way of knowing whether the operation succeeded,
-            // partially succeeded, or failed entirely. This is particularly confusing because
-            // both radar.load() and updateSessionForecast() run in parallel via Promise.all(),
-            // so either or both could have failed. Consider showing an error toast notification
-            // or updating the relevant UI panel to display an error state that tells the user
-            // which component failed and whether they should try again.
             console.error('Error selecting session:', error);
+
+            // Palette UX: Provide visual feedback when session data fails to load
+            if (this.radar && typeof this.radar.showErrorToast === 'function') {
+                this.radar.showErrorToast('Session Error', 'Failed to load session forecast or radar data.', 5);
+            }
+
+            // Clear skeleton and show error state in the forecast panel
+            if (this.ui.forecastContent) {
+                this.ui.forecastContent.innerHTML = '';
+                this.ui.forecastContent.removeAttribute('aria-busy');
+                this.ui.forecastContent.style.display = 'none';
+            }
+            if (this.ui.forecastUnavailable) {
+                this.ui.forecastUnavailable.style.display = 'block';
+                const p = this.ui.forecastUnavailable.querySelector('p');
+                if (p) p.textContent = 'Failed to load forecast data. Please try again.';
+            }
         } finally {
             this.showLoading(false);
         }


### PR DESCRIPTION
💡 What: Replaced the `TODO` in `selectSession`'s catch block with actual error handling that displays a toast notification (`this.radar.showErrorToast`) and updates the forecast panel to show an "unavailable" state instead of hanging the UI.
🎯 Why: When radar or session forecast data fails to load (e.g., due to a network error or rate limiting), the UI previously failed silently. The loading skeleton would disappear and the user was left wondering what happened. Providing immediate visual feedback reduces confusion and guides the user.
📸 Before/After: Screenshots captured locally via Playwright confirm the toast notification and empty state appear correctly.
♿ Accessibility: The loading state (`aria-busy="true"`) is correctly removed from the forecast panel upon failure, preventing screen readers from getting stuck waiting for content that will never arrive.

---
*PR created automatically by Jules for task [18339883291839054186](https://jules.google.com/task/18339883291839054186) started by @2fst4u*