### PR TITLE
🧹 Sweep: Remove unused getErrorHeaders import in worker.js

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -23,7 +23,6 @@ import {
   RateLimiter,
   API_SECURITY_HEADERS,
   API_SECURITY_HEADERS_ENTRIES,
-  getErrorHeaders,
   getAllowedOrigin,
   getEmptyRadarResponse,
   createErrorResponse


### PR DESCRIPTION
**🧹 Sweep: Removed unused `getErrorHeaders` import in `src/worker.js`**

💡 **What:**
Removed the `getErrorHeaders` import from `src/worker.js`. 

🎯 **Why:**
The function `getErrorHeaders` was imported from `worker-utils.js` but was never utilized anywhere in the `worker.js` file, constituting dead code/bloat.

🔬 **Verification:**
1. Ran `grep -n -C 5 'console.log' src/worker.js` and `npx eslint --no-eslintrc --env browser,node --parser-options="sourceType:module,ecmaVersion:2022" --rule '{"no-unused-vars":["error"]}' public/src src` locally.
2. Verified that ESLint threw an error for `getErrorHeaders` inside `src/worker.js` prior to removal.
3. Verified the codebase ran cleanly after removal.
4. Ran `pnpm test` and `pnpm run test:coverage` to ensure tests passed perfectly.

---
*PR created automatically by Jules for task [5872711443197865999](https://jules.google.com/task/5872711443197865999) started by @2fst4u*