### PR TITLE
🛡️ Sentinel: [LOW] Fix SRI validation by adding crossorigin attribute

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -93,7 +93,7 @@
          the current behavior and ensure the integrity validation is actually being enforced.
     -->
     <link rel="stylesheet" href="/api/assets/leaflet.css"
-        integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=">
+        integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="anonymous">
 
     <!-- App CSS -->
     <link rel="stylesheet" href="/styles.css">
@@ -470,7 +470,7 @@
 
     <!-- Leaflet JS (Proxied for strict CSP) -->
     <script src="/api/assets/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
-        crossorigin=""></script>
+        crossorigin="anonymous"></script>
 
     <!-- App JS -->
     <script type="module" src="/src/main.js"></script>


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: Missing `crossorigin` attribute on SRI-protected assets
🎯 Impact: Browsers may not enforce Subresource Integrity (SRI) checks on external assets, allowing potentially compromised or MITM-modified files to execute/render if the upstream CDN is compromised.
🔧 Fix: Added `crossorigin="anonymous"` to the Leaflet CSS and JS tags in `public/index.html`.
✅ Verification: Ensure the app loads the map properly and `pnpm test` passes successfully.

---
*PR created automatically by Jules for task [15523893907265020550](https://jules.google.com/task/15523893907265020550) started by @2fst4u*