### PR TITLE
Refactor Privacy Modal to Use Native Dialog

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -436,37 +436,21 @@
     </div>
 
     <!-- Privacy Policy Modal -->
-    <!-- TODO: This modal implementation requires further investigation and confirmation.
-         The current implementation uses a generic div element with role="dialog" and
-         aria-modal="true" attributes instead of the native HTML5 dialog element. While
-         this approach works, it requires manual implementation of focus management,
-         keyboard handling for the Escape key, and click-outside-to-close behavior that
-         the native dialog element provides automatically. The dialog element has built-in
-         focus trapping, proper modal behavior, and accessibility features that are
-         difficult to replicate correctly with ARIA attributes alone. Using the native
-         dialog element would simplify the code, improve accessibility, and reduce
-         the risk of bugs in focus management. However, this change would require
-         updating the JavaScript that controls the modal to use the dialog's showModal()
-         and close() methods instead of toggling CSS classes or display properties.
-    -->
-    <div class="privacy-modal-backdrop" id="privacyModalBackdrop" role="dialog" aria-modal="true"
-        aria-labelledby="privacyTitle">
-        <div class="privacy-modal">
-            <div class="privacy-modal-header">
-                <h2 id="privacyTitle">Privacy Policy</h2>
-                <button class="privacy-modal-close" id="privacyModalClose" aria-label="Close privacy policy"
-                    title="Close privacy policy (Esc)" aria-keyshortcuts="Escape">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <line x1="18" y1="6" x2="6" y2="18"></line>
-                        <line x1="6" y1="6" x2="18" y2="18"></line>
-                    </svg>
-                </button>
-            </div>
-            <div class="privacy-modal-content" id="privacyModalContent" tabindex="0" role="region" aria-label="Privacy Policy content">
-                <!-- Privacy content loaded here -->
-            </div>
+    <dialog id="privacyModal" class="privacy-modal" aria-labelledby="privacyTitle">
+        <div class="privacy-modal-header">
+            <h2 id="privacyTitle">Privacy Policy</h2>
+            <button class="privacy-modal-close" id="privacyModalClose" aria-label="Close privacy policy"
+                title="Close privacy policy (Esc)" aria-keyshortcuts="Escape">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <line x1="18" y1="6" x2="6" y2="18"></line>
+                    <line x1="6" y1="6" x2="18" y2="18"></line>
+                </svg>
+            </button>
         </div>
-    </div>
+        <div class="privacy-modal-content" id="privacyModalContent" tabindex="0" role="region" aria-label="Privacy Policy content">
+            <!-- Privacy content loaded here -->
+        </div>
+    </dialog>
 
     <!-- Leaflet JS (Proxied for strict CSP) -->
     <script src="/api/assets/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="

--- a/public/src/ui/PrivacyModal.js
+++ b/public/src/ui/PrivacyModal.js
@@ -2,13 +2,12 @@ import { escapeHtml } from "../utils/escapeHtml.js";
 
 export class PrivacyModal {
   constructor() {
-    this.backdrop = document.getElementById("privacyModalBackdrop");
+    this.modal = document.getElementById("privacyModal");
     this.content = document.getElementById("privacyModalContent");
     this.closeBtn = document.getElementById("privacyModalClose");
     this.privacyLink = document.getElementById("privacyLink");
     this.loaded = false;
     this.triggerElement = null;
-    this._handleFocusTrap = this.handleFocusTrap.bind(this);
     this.bindEvents();
   }
 
@@ -31,31 +30,28 @@ export class PrivacyModal {
       this.closeBtn.addEventListener("click", () => this.close());
     }
 
-    if (this.backdrop) {
-      this.backdrop.addEventListener("click", (e) => {
-        if (e.target === this.backdrop) this.close();
+    if (this.modal) {
+      this.modal.addEventListener("click", (e) => {
+        if (e.target === this.modal) this.close();
+      });
+
+      this.modal.addEventListener("close", () => {
+        document.body.style.overflow = "";
+        if (this.triggerElement) {
+          this.triggerElement.focus();
+          this.triggerElement = null;
+        }
       });
     }
-
-    // Close on Escape key
-    document.addEventListener("keydown", (e) => {
-      if (e.key === "Escape" && this.backdrop?.classList.contains("visible")) {
-        this.close();
-      }
-    });
   }
 
   async open() {
     this.triggerElement = document.activeElement;
 
     // Palette UX: Show modal immediately to prevent perceived lag
-    if (this.backdrop) {
-      this.backdrop.classList.add("visible");
+    if (this.modal) {
+      this.modal.showModal();
       document.body.style.overflow = "hidden";
-      // Move focus to close button for accessibility
-      if (this.closeBtn) this.closeBtn.focus();
-      // Enable focus trap
-      this.backdrop.addEventListener("keydown", this._handleFocusTrap);
     }
 
     if (!this.loaded) {
@@ -77,44 +73,8 @@ export class PrivacyModal {
   }
 
   close() {
-    if (this.backdrop) {
-      this.backdrop.classList.remove("visible");
-      document.body.style.overflow = "";
-      // Remove focus trap
-      this.backdrop.removeEventListener("keydown", this._handleFocusTrap);
-      // Restore focus to trigger element
-      if (this.triggerElement) {
-        this.triggerElement.focus();
-        this.triggerElement = null;
-      }
-    }
-  }
-
-  handleFocusTrap(e) {
-    if (e.key !== "Tab") return;
-
-    const focusableSelectors =
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
-    // Palette A11y: Filter out hidden elements to prevent focus trap from getting stuck
-    const focusableElements = Array.from(
-      this.backdrop.querySelectorAll(focusableSelectors),
-    ).filter((el) => el.offsetParent !== null);
-
-    if (focusableElements.length === 0) return;
-
-    const firstElement = focusableElements[0];
-    const lastElement = focusableElements[focusableElements.length - 1];
-
-    if (e.shiftKey) {
-      if (document.activeElement === firstElement) {
-        e.preventDefault();
-        lastElement.focus();
-      }
-    } else {
-      if (document.activeElement === lastElement) {
-        e.preventDefault();
-        firstElement.focus();
-      }
+    if (this.modal) {
+      this.modal.close();
     }
   }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1545,30 +1545,10 @@ body {
    Privacy Modal
    =================================== */
 
-.privacy-modal-backdrop {
-    display: none;
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.5);
-    backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
-    z-index: 3000;
-    align-items: center;
-    justify-content: center;
-    padding: var(--spacing-md);
-    opacity: 0;
-    transition: opacity var(--transition-normal);
-}
-
-.privacy-modal-backdrop.visible {
-    display: flex;
-    opacity: 1;
-}
-
 .privacy-modal {
+    display: none;
+    padding: 0;
+    margin: auto;
     background: var(--color-surface);
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow-lg);
@@ -1576,9 +1556,19 @@ body {
     max-width: 600px;
     width: 100%;
     max-height: 80vh;
+    animation: modalSlideIn 0.3s ease;
+    color: inherit;
+}
+
+.privacy-modal[open] {
     display: flex;
     flex-direction: column;
-    animation: modalSlideIn 0.3s ease;
+}
+
+.privacy-modal::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
 }
 
 @keyframes modalSlideIn {

--- a/tests/privacy-modal.test.js
+++ b/tests/privacy-modal.test.js
@@ -22,6 +22,8 @@ const createMockElement = (id) => {
     }),
     querySelectorAll: vi.fn(() => []),
     offsetParent: {},
+    showModal: vi.fn(),
+    close: vi.fn(),
   };
   return el;
 };
@@ -354,12 +356,12 @@ describe("PrivacyModal", () => {
         "click",
         expect.any(Function),
       );
-      expect(modal.backdrop.addEventListener).toHaveBeenCalledWith(
+      expect(modal.modal.addEventListener).toHaveBeenCalledWith(
         "click",
         expect.any(Function),
       );
-      expect(document.addEventListener).toHaveBeenCalledWith(
-        "keydown",
+      expect(modal.modal.addEventListener).toHaveBeenCalledWith(
+        "close",
         expect.any(Function),
       );
     });
@@ -412,18 +414,18 @@ describe("PrivacyModal", () => {
       expect(openSpy).not.toHaveBeenCalled();
     });
 
-    it("closes when backdrop is clicked directly", () => {
+    it("closes when modal is clicked directly (backdrop click)", () => {
       const closeSpy = vi.spyOn(modal, "close").mockImplementation(() => {});
-      const clickHandler = modal.backdrop.addEventListener.mock.calls.find(
+      const clickHandler = modal.modal.addEventListener.mock.calls.find(
         (call) => call[0] === "click",
       )[1];
-      clickHandler({ target: modal.backdrop });
+      clickHandler({ target: modal.modal });
       expect(closeSpy).toHaveBeenCalled();
     });
 
-    it("does not close when inner content of backdrop is clicked", () => {
+    it("does not close when inner content of modal is clicked", () => {
       const closeSpy = vi.spyOn(modal, "close").mockImplementation(() => {});
-      const clickHandler = modal.backdrop.addEventListener.mock.calls.find(
+      const clickHandler = modal.modal.addEventListener.mock.calls.find(
         (call) => call[0] === "click",
       )[1];
       clickHandler({ target: {} });
@@ -442,11 +444,10 @@ describe("PrivacyModal", () => {
       expect(modal.loaded).toBe(true);
 
       // Verify visibility
-      expect(modal.backdrop.classList.add).toHaveBeenCalledWith("visible");
+      expect(modal.modal.showModal).toHaveBeenCalled();
       expect(document.body.style.overflow).toBe("hidden");
 
       // Verify focus management
-      expect(modal.closeBtn.focus).toHaveBeenCalled();
       expect(modal.triggerElement).toBe(trigger); // Should store the trigger
     });
 
@@ -456,46 +457,29 @@ describe("PrivacyModal", () => {
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it("closes, restores focus, and unlocks body", async () => {
+    it("closes the native modal", async () => {
       // Setup open state
       const trigger = { tagName: "BUTTON", focus: vi.fn(), id: "trigger-btn" };
       modal.triggerElement = trigger;
-      modal.backdrop.classList.contains.mockReturnValue(true);
 
       modal.close();
 
-      expect(modal.backdrop.classList.remove).toHaveBeenCalledWith("visible");
+      expect(modal.modal.close).toHaveBeenCalled();
+    });
+
+    it("restores focus and unlocks body on native close event", () => {
+      const trigger = { tagName: "BUTTON", focus: vi.fn(), id: "trigger-btn" };
+      modal.triggerElement = trigger;
+
+      const closeHandler = modal.modal.addEventListener.mock.calls.find(
+        (call) => call[0] === "close",
+      )[1];
+
+      closeHandler();
+
       expect(document.body.style.overflow).toBe("");
       expect(trigger.focus).toHaveBeenCalled();
       expect(modal.triggerElement).toBeNull();
-    });
-
-    it("closes on Escape key press when visible", () => {
-      // Spy on close
-      const closeSpy = vi.spyOn(modal, "close");
-      // Setup visible state
-      modal.backdrop.classList.contains.mockReturnValue(true);
-
-      // Simulate Escape key
-      // Note: We need to find the listener bound in constructor
-      const calls = document.addEventListener.mock.calls;
-      const keydownHandler = calls.find((call) => call[0] === "keydown")[1];
-
-      keydownHandler({ key: "Escape" });
-
-      expect(closeSpy).toHaveBeenCalled();
-    });
-
-    it("ignores Escape key press when not visible", () => {
-      const closeSpy = vi.spyOn(modal, "close");
-      modal.backdrop.classList.contains.mockReturnValue(false);
-
-      const calls = document.addEventListener.mock.calls;
-      const keydownHandler = calls.find((call) => call[0] === "keydown")[1];
-
-      keydownHandler({ key: "Escape" });
-
-      expect(closeSpy).not.toHaveBeenCalled();
     });
 
     it("handles fetch errors gracefully", async () => {
@@ -517,88 +501,9 @@ describe("PrivacyModal", () => {
   });
 
   describe("Focus Trap", () => {
-    let firstElement, lastElement;
-
-    beforeEach(async () => {
-      // Open modal to attach focus trap listener
-      await modal.open();
-
-      // Setup mock focusable elements
-      firstElement = { id: "first", focus: vi.fn(), offsetParent: {} };
-      lastElement = { id: "last", focus: vi.fn(), offsetParent: {} };
-
-      // Mock querySelectorAll to return our elements
-      modal.backdrop.querySelectorAll.mockReturnValue([
-        firstElement,
-        lastElement,
-      ]);
-    });
-
-    it("loops focus to first element when tabbing from last element", () => {
-      document.activeElement = lastElement;
-
-      // Trigger handler directly (it's bound to backdrop keydown)
-      // Find the listener added to backdrop in open()
-      const calls = modal.backdrop.addEventListener.mock.calls;
-      const trapHandler = calls.find((call) => call[0] === "keydown")[1];
-
-      const event = {
-        key: "Tab",
-        shiftKey: false,
-        preventDefault: vi.fn(),
-      };
-
-      trapHandler(event);
-
-      expect(event.preventDefault).toHaveBeenCalled();
-      expect(firstElement.focus).toHaveBeenCalled();
-    });
-
-    it("loops focus to last element when shift-tabbing from first element", () => {
-      document.activeElement = firstElement;
-
-      const calls = modal.backdrop.addEventListener.mock.calls;
-      const trapHandler = calls.find((call) => call[0] === "keydown")[1];
-
-      const event = {
-        key: "Tab",
-        shiftKey: true,
-        preventDefault: vi.fn(),
-      };
-
-      trapHandler(event);
-
-      expect(event.preventDefault).toHaveBeenCalled();
-      expect(lastElement.focus).toHaveBeenCalled();
-    });
-
-    it("does nothing for non-Tab keys", () => {
-      const calls = modal.backdrop.addEventListener.mock.calls;
-      const trapHandler = calls.find((call) => call[0] === "keydown")[1];
-
-      const event = {
-        key: "Enter",
-        preventDefault: vi.fn(),
-      };
-
-      trapHandler(event);
-
-      expect(event.preventDefault).not.toHaveBeenCalled();
-    });
-
-    it("does nothing if no focusable elements found", () => {
-      modal.backdrop.querySelectorAll.mockReturnValue([]);
-
-      const calls = modal.backdrop.addEventListener.mock.calls;
-      const trapHandler = calls.find((call) => call[0] === "keydown")[1];
-
-      const event = {
-        key: "Tab",
-        preventDefault: vi.fn(),
-      };
-
-      trapHandler(event);
-      expect(event.preventDefault).not.toHaveBeenCalled();
+    it("is skipped natively by the dialog element, removing manual logic", () => {
+      // Focus trap is handled natively by HTML dialog, testing it manually is obsolete
+      expect(modal.handleFocusTrap).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Addresses the TODO in `public/index.html` regarding the Privacy Policy modal implementation. The custom ARIA-based modal logic has been fully replaced with a native HTML `<dialog>` element. This reduces JavaScript complexity by offloading focus trapping and keyboard handling (Escape key) to the browser. The UI remains visually identical, utilizing the `::backdrop` CSS pseudo-element to maintain the dark overlay behind the dialog. Tests have been updated to cover the native DOM methods.

---
*PR created automatically by Jules for task [8049949962377211757](https://jules.google.com/task/8049949962377211757) started by @2fst4u*