### PR TITLE
🎨 Palette: Add tactile active states to primary icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -68,3 +68,7 @@
 ## 2025-05-15 - Async Operation Silent Failures
 **Learning:** When async operations tied to user interactions fail silently inside catch blocks, users are left staring at infinite loading skeletons or unchanged screens, which is confusing and feels broken.
 **Action:** Always provide explicit visual feedback (like an error toast) and properly tear down loading states (e.g., removing `aria-busy` and hiding skeletons) in the catch block of user-initiated async functions.
+
+## 2026-03-20 - Tactile Active States on Icon Buttons
+**Learning:** While focus and hover states provide visual feedback for mouse and keyboard users, pure icon buttons can feel "dead" during the physical click event itself. Adding a subtle, fast scale-down effect (`transform: scale(0.95); transition: transform 0.1s ease;`) on the `:active` pseudo-class provides immediate, tactile visual feedback that makes the UI feel significantly more responsive and polished.
+**Action:** Always consider adding subtle `:active` scale states to primary interactive elements, especially icon-only buttons, to enhance the perceived performance and physical feel of the application.

--- a/public/index.html
+++ b/public/index.html
@@ -124,7 +124,7 @@
                 </button>
                 <h1>Circuit Weather</h1>
                 <span class="header-badge">
-                    <svg viewBox="0 0 24 24" fill="currentColor">
+                    <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
                         <path fill-rule="evenodd"
                             d="M14.4,6L14,4H5V21H7V14H12.6L13,16H20V6H14.4M14,14H16V12H18V10H16V8H14V10L13,8V6H11V8H9V6H7V8H9V10H7V12H9V10H11V12H13V10L14,12V14M11,10V8H13V10H11M14,10H16V12H14V10Z" />
                     </svg>
@@ -299,7 +299,7 @@
                     <!-- Mobile H1 for SEO -->
                     <h1 class="header-title">Circuit Weather</h1>
                     <span class="header-badge">
-                        <svg viewBox="0 0 24 24" fill="currentColor">
+                        <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
                             <path fill-rule="evenodd"
                                 d="M14.4,6L14,4H5V21H7V14H12.6L13,16H20V6H14.4M14,14H16V12H18V10H16V8H14V10L13,8V6H11V8H9V6H7V8H9V10H7V12H9V10H11V12H13V10L14,12V14M11,10V8H13V10H11M14,10H16V12H14V10Z" />
                         </svg>
@@ -398,7 +398,7 @@
             <!-- Error Toast -->
             <div id="errorToast" class="error-toast" role="alert" aria-live="assertive">
                 <div class="error-icon">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <circle cx="12" cy="12" r="10"></circle>
                         <line x1="12" y1="8" x2="12" y2="12"></line>
                         <line x1="12" y1="16" x2="12.01" y2="16"></line>
@@ -441,7 +441,7 @@
             <h2 id="privacyTitle">Privacy Policy</h2>
             <button class="privacy-modal-close" id="privacyModalClose" aria-label="Close privacy policy"
                 title="Close privacy policy (Esc)" aria-keyshortcuts="Escape">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <line x1="18" y1="6" x2="6" y2="18"></line>
                     <line x1="6" y1="6" x2="18" y2="18"></line>
                 </svg>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1849,3 +1849,18 @@ body {
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
 }
+/* ===================================
+   Active States (Tactile Feedback)
+   =================================== */
+.theme-toggle:active,
+.mobile-menu-btn:active,
+.radar-play-btn:active,
+.radar-speed-btn:active,
+.sidebar-toggle:active,
+.privacy-modal-close:active,
+.retry-btn:active,
+.leaflet-control-zoom a:active,
+.leaflet-control-zoom-recentre:active {
+    transform: scale(0.95);
+    transition: transform 0.1s ease;
+}


### PR DESCRIPTION
💡 What: Added a subtle scale-down effect (`transform: scale(0.95)`) on the `:active` pseudo-class for primary icon buttons (radar controls, theme toggle, mobile menu, sidebar toggle, modal close, and map zoom controls).
🎯 Why: To provide immediate, tactile visual feedback upon physical interaction, making the UI feel significantly more responsive, polished, and satisfying to use.
📸 Before/After: Verified locally with Playwright screenshots.
♿ Accessibility: Added `aria-hidden="true"` to decorative SVGs (like the header badge, error toast icon, and modal close icon) to ensure screen readers ignore these purely visual elements, reducing noise and improving clarity.

---
*PR created automatically by Jules for task [15535768265901712591](https://jules.google.com/task/15535768265901712591) started by @2fst4u*