### PR TITLE
📚 Archivist: Clarify Privacy Proxy list to include Leaflet assets

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -162,3 +162,8 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 
 **Learning:** `AGENTS.md` local development instructions incorrectly suggested using `npx wrangler dev` alongside a commented-out `# pnpm run dev` fallback. While standardizing on `pnpm run dev` ensures exact version matching with CI, developers may not have `pnpm` available, or may have `wrangler` installed globally. Documenting a single standard path without explaining *why* or providing fallbacks for varying environments creates friction for contributors.
 **Action:** Updated `AGENTS.md` to explicitly state `pnpm run dev` as the standard (for CI parity), while actively documenting `wrangler dev` (for global installs) and `npx wrangler dev` (for dynamic fetching) as explicitly reasoned fallbacks.
+
+## 2026-03-14 - Privacy Proxy Drift for Proxied Assets
+
+**Learning:** `PRIVACY.md` documented the "Privacy Proxy" strategy for F1 schedules, Track Layouts, and RainViewer tiles, but failed to mention that Leaflet library assets fetched from Unpkg are also proxied. Documentation of privacy architectures must be kept strictly in sync with actual implementation details (like those found in `src/worker.js`) to ensure users have accurate information about what data is obscured.
+**Action:** Updated `PRIVACY.md` to explicitly include Leaflet library assets in the list of resources protected by the Cloudflare Worker proxy.

--- a/public/PRIVACY.md
+++ b/public/PRIVACY.md
@@ -22,7 +22,7 @@ However, the application relies on third-party services and infrastructure which
 
 This website is hosted on **Cloudflare Workers** (using Static Assets) which serves both the website and powers its API. We leverage Cloudflare's global edge network to aggressively cache data close to you.
 
-- **Privacy Proxy:** To enhance your privacy, requests for F1 schedules, Track Layouts, and **all RainViewer Radar Tiles** are proxied through our Cloudflare Worker. This hides your IP address from these third-party services.
+- **Privacy Proxy:** To enhance your privacy, requests for F1 schedules, Track Layouts, Leaflet library assets, and **all RainViewer Radar Tiles** are proxied through our Cloudflare Worker. This hides your IP address from these third-party services.
 - **Advanced Caching:** We utilize advanced edge caching features to store API responses on Cloudflare's servers. This minimizes data usage and reduces load on the open-source community APIs we rely on.
 - **Data Processed:** Cloudflare processes your IP address and request metadata to deliver the website and protect against security threats.
 - **Privacy Policy:** [cloudflare.com/privacypolicy](https://www.cloudflare.com/privacypolicy/)


### PR DESCRIPTION
💡 Problem: The "Privacy Proxy" documentation in `public/PRIVACY.md` claimed to proxy F1 schedules, Track Layouts, and RainViewer Radar Tiles, but it omitted Leaflet library assets which are also proxied through the worker for CSP compliance and privacy. This was a documentation drift issue since the worker code was updated to include Leaflet assets from Unpkg.
🎯 Fix: Added "Leaflet library assets" to the list of proxied services in the `Privacy Proxy` section of `public/PRIVACY.md` to reflect the current worker implementation.
🧪 Verification: Read the updated file and confirmed the wording was successfully applied. Ran the project test suite (`pnpm test`) to ensure no regressions were introduced.
🔎 Scope: Only modified documentation (`public/PRIVACY.md` and `.jules/archivist.md` journal). No code changes were made.

---
*PR created automatically by Jules for task [18373619800841873738](https://jules.google.com/task/18373619800841873738) started by @2fst4u*