### PR TITLE
🎨 Palette: Dynamic ARIA labels for sidebar toggles

### DIFF
--- a/public/src/ui/SidebarManager.js
+++ b/public/src/ui/SidebarManager.js
@@ -73,8 +73,14 @@ export class SidebarManager {
             this.sidebar.addEventListener('keydown', this._handleFocusTrap);
 
             // Update ARIA states
-            if (this.mobileMenuBtn) this.mobileMenuBtn.setAttribute('aria-expanded', 'true');
-            if (this.toggleBtn) this.toggleBtn.setAttribute('aria-expanded', 'true');
+            if (this.mobileMenuBtn) {
+                this.mobileMenuBtn.setAttribute('aria-expanded', 'true');
+                this.mobileMenuBtn.setAttribute('aria-label', 'Close menu');
+            }
+            if (this.toggleBtn) {
+                this.toggleBtn.setAttribute('aria-expanded', 'true');
+                this.toggleBtn.setAttribute('aria-label', 'Close menu');
+            }
 
             // Move focus to close button inside sidebar for accessibility
             if (this.toggleBtn) {
@@ -94,8 +100,14 @@ export class SidebarManager {
             this.sidebar.removeEventListener('keydown', this._handleFocusTrap);
 
             // Update ARIA states
-            if (this.mobileMenuBtn) this.mobileMenuBtn.setAttribute('aria-expanded', 'false');
-            if (this.toggleBtn) this.toggleBtn.setAttribute('aria-expanded', 'false');
+            if (this.mobileMenuBtn) {
+                this.mobileMenuBtn.setAttribute('aria-expanded', 'false');
+                this.mobileMenuBtn.setAttribute('aria-label', 'Open menu');
+            }
+            if (this.toggleBtn) {
+                this.toggleBtn.setAttribute('aria-expanded', 'false');
+                this.toggleBtn.setAttribute('aria-label', 'Open menu');
+            }
 
             // Return focus to menu button if it's visible (mobile)
             // This restores context to the user after closing the menu


### PR DESCRIPTION
💡 What: Added dynamic `aria-label` updates to the sidebar toggle buttons (`mobileMenuBtn` and `sidebarToggle`).

🎯 Why: Previously, screen readers would only hear that the element was expanded or collapsed, but the static label ("Open menu" or "Toggle sidebar") did not accurately reflect the current action. Now the label actively changes to describe the action ("Open menu" vs. "Close menu"), greatly improving accessibility for screen reader users.

♿ Accessibility: Ensures the `aria-label` correctly matches the action the button will perform when clicked, rather than a generic or static state.

---
*PR created automatically by Jules for task [16365319214675237729](https://jules.google.com/task/16365319214675237729) started by @2fst4u*