### PR TITLE
🧪 Spec: Add worker tests to cover cache-miss headers and XSSI blocks

### DIFF
--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -109,6 +109,27 @@ describe("Worker Logic", () => {
   });
 
   describe("F1 API Proxy (/api/f1/*)", () => {
+    it("sets CORS headers for cache miss when valid Origin is provided", async () => {
+      const upstreamData = { MRData: { raceTable: {} } };
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify(upstreamData), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const req = createRequest("/api/f1/current", {
+        headers: { Origin: "https://circuit-weather.racing" },
+      });
+      const res = await worker.fetch(req, global.env, global.ctx);
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://circuit-weather.racing",
+      );
+      expect(res.headers.get("Vary")).toBe("Origin");
+    });
+
     it("proxies request to Jolpica and caches result", async () => {
       const upstreamData = { MRData: { raceTable: {} } };
       mockFetch.mockResolvedValueOnce(
@@ -362,6 +383,17 @@ describe("Worker Logic", () => {
   });
 
   describe("Track Proxy (/api/track/*)", () => {
+    it("blocks track request with invalid fetch destination", async () => {
+      const req = new Request("https://circuit-weather.racing/api/track/monaco", {
+        headers: {
+          "Sec-Fetch-Dest": "script",
+          "Sec-Fetch-Site": "same-origin",
+        },
+      });
+      const res = await worker.fetch(req, global.env, global.ctx);
+      expect(res.status).toBe(403);
+    });
+
     it("fetches geojson from github", async () => {
       const mockGeoJson = { type: "FeatureCollection", features: [] };
       mockFetch.mockResolvedValueOnce(


### PR DESCRIPTION
💡 What: Added tests in `tests/worker.test.js` to assert that CORS headers are correctly appended when an upstream API fetch successfully bypasses the cache, and a test to verify that the worker correctly blocks invalid fetch destinations for track assets, returning a 403 Forbidden.
🎯 Why: Fortify the application logic around CORS headers handling and security rules. By adding these tests, lines 331-332 and 356-357 are now covered.

---
*PR created automatically by Jules for task [15913746739223801333](https://jules.google.com/task/15913746739223801333) started by @2fst4u*