### PR TITLE
📚 Archivist: Clarify API routes handled by worker in inline comments

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -108,7 +108,7 @@ export default {
       return createErrorResponse(request, 403, 'Forbidden');
     }
 
-    // Only /api/f1/* routes reach this worker (configured via run_worker_first)
+    // Only /api/* routes reach this worker (configured via run_worker_first)
     if (path.startsWith('/api/f1/')) {
       return handleApiRequest(request, env, ctx);
     }


### PR DESCRIPTION
💡 **Problem:** The inline comment at line 111 in `src/worker.js` misleadingly stated `// Only /api/f1/* routes reach this worker (configured via run_worker_first)`. However, `wrangler.toml` configures the worker to run first for all `/api/*` routes, and the worker itself explicitly handles multiple routes (like `/api/health`, `/api/tiles/*`, etc.) immediately following this comment. This caused ambiguity about the routing architecture.
🎯 **Fix:** Updated the comment to accurately state `// Only /api/* routes reach this worker (configured via run_worker_first)`, aligning it with reality.
🧪 **Verification:** Used `cat` to verify the modified line in `src/worker.js` and ran `pnpm test` to ensure the change did not cause any regressions (all 575 tests passed).
🔎 **Scope:** Confirmed this PR contains ONLY documentation/comment changes within the source file.

---
*PR created automatically by Jules for task [2107939068839124204](https://jules.google.com/task/2107939068839124204) started by @2fst4u*