### PR TITLE
🧪 Spec: Add invalid fetch destination test for F1 API Proxy

### DIFF
--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -109,6 +109,17 @@ describe("Worker Logic", () => {
   });
 
   describe("F1 API Proxy (/api/f1/*)", () => {
+    it("blocks request with invalid fetch destination", async () => {
+      const req = new Request("https://circuit-weather.racing/api/f1/current", {
+        headers: {
+          "Sec-Fetch-Dest": "script",
+          "Sec-Fetch-Site": "same-origin",
+        },
+      });
+      const res = await worker.fetch(req, global.env, global.ctx);
+      expect(res.status).toBe(403);
+    });
+
     it("rejects path that is too long (length > 255)", async () => {
       const longPath = "a".repeat(256);
       const req = createRequest(`/api/f1/${longPath}`);


### PR DESCRIPTION
💡 What: Added a test case in `tests/worker.test.js` under `F1 API Proxy (/api/f1/*)` to verify that requests with an invalid `Sec-Fetch-Dest` header (e.g. `script`) are correctly blocked.
🎯 Why: To lock in the XSSI protection and ensure the `checkFetchDest` validation for the F1 API Proxy is always tested and defended against regression.
📈 Maturity Impact: Fortifies existing test coverage for security rules without modifying application logic.

---
*PR created automatically by Jules for task [3155148227952780527](https://jules.google.com/task/3155148227952780527) started by @2fst4u*