### PR TITLE
🔭 Scout: Align HTML lang attribute with Open Graph locale

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html lang="en">
+<!-- Scout: Changed lang attribute to match New Zealand English locale configuration (og:locale is en_NZ), ensuring search engines correctly target the content for regional variations. -->
+<html lang="en-NZ">
 
 <head>
     <meta charset="UTF-8">


### PR DESCRIPTION
💡 **What:** Changed `<html lang="en">` to `<html lang="en-NZ">` in `public/index.html` and added an explanatory SEO comment.
🎯 **Why:** The document's root language attribute (`en`) did not match the explicitly declared Open Graph locale metadata (`og:locale` set to `en_NZ`). 
📊 **Value:** Synchronizing the root HTML `lang` attribute with the defined Open Graph locale strengthens the page's regional relevance signals, ensuring search engines properly classify and rank the content for New Zealand English regional variations without conflicting dialect interpretations.
🔬 **Measurement:** Open the DOM or view the page source of `index.html` to confirm the root tag is now `<html lang="en-NZ">`.

---
*PR created automatically by Jules for task [7687653421697756612](https://jules.google.com/task/7687653421697756612) started by @2fst4u*