### PR TITLE
🔭 Scout: Add dynamic twitter:url metadata update

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -377,6 +377,10 @@ export class CircuitWeatherApp {
         const twitterDesc = document.querySelector('meta[name="twitter:description"]');
         if (twitterDesc) twitterDesc.setAttribute('content', desc);
 
+        // Scout: Update Twitter Card URL to ensure accurate link attribution when shared
+        const twitterUrl = document.querySelector('meta[name="twitter:url"]');
+        if (twitterUrl) twitterUrl.setAttribute('content', window.location.href);
+
         // Scout: Inject dynamic JSON-LD structured data for the selected session
         // Value: Improves rich snippets in SERP by providing explicit event details (SportsEvent) to search engines.
         if (this.selectedRace && this.selectedSession && this.selectedSession.date && this.selectedSession.time) {


### PR DESCRIPTION
💡 **What:** Added dynamic updating of the `<meta name="twitter:url">` tag to match the canonical URL whenever `updatePageMetadata()` is called.
🎯 **Why:** While the application updates `og:url` dynamically, it was missing the equivalent attribute for Twitter Cards. This could cause misattribution or broken previews if shared links didn't explicitly match the static meta tags.
📊 **Value:** Ensures accurate link attribution and better rich snippet previews on Twitter.
🔬 **Measurement:** You can verify by opening a session page and running `document.querySelector('meta[name="twitter:url"]').content` in the console.

---
*PR created automatically by Jules for task [17150535689578404382](https://jules.google.com/task/17150535689578404382) started by @2fst4u*