### PR TITLE
🧹 Sweep: Remove unused `prevIndex` variable from radar test

### DIFF
--- a/tests/weather-radar-frames.test.js
+++ b/tests/weather-radar-frames.test.js
@@ -169,7 +169,6 @@ describe('WeatherRadar Frame & Speed Logic', () => {
             // Set to last index
             // CONFIG.radarSpeeds is imported inside WeatherRadar, we need to figure out its length
             // We can infer from speeedIndex wrapping
-            let prevIndex = radar.speedIndex;
             let cycleCount = 0;
 
             // Cycle until we wrap back to 0


### PR DESCRIPTION
💡 What: Removed the unused variable `prevIndex` from `tests/weather-radar-frames.test.js`.
🎯 Why: The variable was declared (`let prevIndex = radar.speedIndex;`) but never actually read or used in any assertions or logic throughout the test suite, making it dead code. Removing it reduces test file clutter.
🔬 Verification: Ran the full test suite via `pnpm test`, verifying that all 582 tests passed successfully and that this deletion had zero impact on application functionality.

---
*PR created automatically by Jules for task [7363702329743481827](https://jules.google.com/task/7363702329743481827) started by @2fst4u*