### PR TITLE
📚 Archivist: Clarify Rate Limiter limits in AGENTS.md

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -172,3 +172,8 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 
 **Learning:** Despite the project migrating to Cloudflare Workers with Static Assets, an outdated comment referencing Cloudflare Pages remained in `.gitignore`.
 **Action:** Updated `.gitignore` comment to correctly describe `wrangler.toml`'s role in Cloudflare Workers deployment to maintain accuracy.
+
+## 2026-03-29 - Rate Limiter Scope Clarification
+
+**Learning:** `AGENTS.md` documented the Rate Limiter as "1000 req/min", which was ambiguously worded and failed to specify that the limit applies *per IP* and *per isolate*. The implementation in `src/worker.js` instantiates the `RateLimiter` per isolate and keys by `CF-Connecting-IP`.
+**Action:** Updated `AGENTS.md` to explicitly state the limit is "1000 req/min per IP per isolate" to avoid confusion about global vs individual limits.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Circuit Weather is a real-time F1 race circuit weather radar application. It dis
 
 - **Hotlink Protection** - Strict `Sec-Fetch-Site`, `Origin`, and `Referer` checks in `src/worker.js` prevent unauthorized embedding.
 - **XSSI Protection** - Validates `Sec-Fetch-Dest` to prevent API endpoints from being loaded as scripts or objects.
-- **Rate Limiting** - In-memory IP-based limiting (1000 req/min) protects upstream APIs from abuse.
+- **Rate Limiting** - In-memory IP-based limiting (1000 req/min per IP per isolate) protects upstream APIs from abuse.
 
 ### Third-Party Services
 


### PR DESCRIPTION
💡 Problem: `AGENTS.md` ambiguously stated the rate limit was "1000 req/min" without specifying its scope, which could imply a global limit instead of per-IP/per-isolate, contradicting the implementation in `src/worker.js`.
🎯 Fix: Updated `AGENTS.md` to explicitly state the limit is "1000 req/min per IP per isolate".
🧪 Verification: Confirmed via `cat` and ran the full test suite (`pnpm run test:coverage`), which passed.
🔎 Scope: Only modified `AGENTS.md` and added an entry to `.jules/archivist.md`. No application code was modified.

---
*PR created automatically by Jules for task [4000524370878812829](https://jules.google.com/task/4000524370878812829) started by @2fst4u*