### PR TITLE
🔭 Scout: Fix heading hierarchy in <noscript> fallback content

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -373,11 +373,12 @@
             <noscript>
                 <div
                     style="padding: 2rem; max-width: 800px; margin: 0 auto; font-family: Inter, sans-serif; line-height: 1.6;">
-                    <h2>Circuit Weather — Live F1 Race Weather Radar &amp; Forecasts</h2>
+                    <!-- Scout: Upgraded fallback heading hierarchy to start with H1 and cascade to H2, ensuring proper document outline for crawlers that do not execute JavaScript. -->
+                    <h1>Circuit Weather — Live F1 Race Weather Radar &amp; Forecasts</h1>
                     <p>Circuit Weather provides live weather radar overlays for motorsport race circuits worldwide.
                         Track precipitation, wind, and temperature conditions during race weekends to stay informed
                         about weather that could affect racing.</p>
-                    <h3>Features</h3>
+                    <h2>Features</h2>
                     <ul>
                         <li>Live weather radar with animated playback of the past 2 hours</li>
                         <li>Session-specific weather forecasts (temperature, rain probability, wind)</li>


### PR DESCRIPTION
💡 What: Fixed the heading hierarchy within the `<noscript>` tag by upgrading the initial `<h2>` to an `<h1>` and the subsequent `<h3>` to an `<h2>`. Added an HTML comment explaining the SEO value.
🎯 Why: The fallback content for crawlers that do not execute JavaScript was violating heading hierarchy rules by starting with an `<h2>`, causing the document outline to be improperly structured for those bots.
📊 Value: Ensures search engines parsing the fallback content construct a proper semantic document outline, improving accessibility and indexability of the non-JS content.
🔬 Measurement: Verify that `public/index.html` contains an `<h1>` inside the `<noscript>` block, and `<h2>` for its children.

---
*PR created automatically by Jules for task [12223069593832617219](https://jules.google.com/task/12223069593832617219) started by @2fst4u*