### PR TITLE
🎨 Palette: Add explicit visual styling for disabled buttons

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1698,6 +1698,8 @@ body {
     outline-offset: 2px;
 }
 
+button:disabled,
+.btn:disabled,
 .retry-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;


### PR DESCRIPTION
💡 What: Added generic `button:disabled, .btn:disabled` CSS rules to `public/styles.css` (`opacity: 0.5; cursor: not-allowed;`).
🎯 Why: When JavaScript dynamically disables a button (e.g., `btn.disabled = true` during a network retry or loading state), relying solely on the browser's default disabled styling is often insufficient. Without explicit CSS for the `:disabled` state, users may not visually register that the button is temporarily inactive, leading to confusion or repeated clicks.
📸 Before/After: Visual styling tested and verified using playwright test script, producing expected `opacity` drop.
♿ Accessibility: Ensures clear, immediate visual feedback that aligns with the semantic state of the element, making the UI more understandable for all users.

---
*PR created automatically by Jules for task [17347833608597420279](https://jules.google.com/task/17347833608597420279) started by @2fst4u*