### PR TITLE
🔭 Scout: Upgrade weather metrics to semantic description lists (<dl>)

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -1,0 +1,3 @@
+## 2025-03-31 - Semantic description lists require corresponding unit test updates
+**Learning:** Upgrading generic `<div>` and `<span>` wrappers to semantic `<dl>`, `<dt>`, `<dd>` elements for SEO and accessibility can break brittle Vitest `.innerHTML` assertions that hardcode the expected tags (like `</span>` or `</div>`).
+**Action:** When modifying frontend HTML tags, always `grep` for the affected element IDs (e.g., `#weatherTemp`) in the `tests/` directory to update corresponding `.innerHTML` string assertions and prevent CI test regressions.

--- a/public/index.html
+++ b/public/index.html
@@ -179,21 +179,22 @@
                     <div class="forecast-content" id="forecastContent">
                         <!-- Content injected by JS -->
                         <div class="weather-dashboard">
-                            <div class="weather-current">
+                            <!-- Scout: Upgraded generic div/span wrappers to semantic description list (dl/dt/dd) to explicitly associate weather labels with their values for crawlers and assistive tech. -->
+                            <dl class="weather-current">
                                 <div class="weather-metric">
-                                    <span class="weather-label">Temp</span>
-                                    <span class="weather-value" id="weatherTemp">--°</span>
+                                    <dt class="weather-label">Temp</dt>
+                                    <dd class="weather-value" id="weatherTemp">--°</dd>
                                 </div>
                                 <div class="weather-metric">
-                                    <span class="weather-label">Rain</span>
-                                    <span class="weather-value" id="weatherRain">--%</span>
+                                    <dt class="weather-label">Rain</dt>
+                                    <dd class="weather-value" id="weatherRain">--%</dd>
                                 </div>
                                 <div class="weather-metric">
-                                    <span class="weather-label">Wind</span>
-                                    <span class="weather-value" id="weatherWind">--</span>
-                                    <span class="weather-sub" id="weatherWindDir">--</span>
+                                    <dt class="weather-label">Wind</dt>
+                                    <dd class="weather-value" id="weatherWind">--</dd>
+                                    <dd class="weather-sub" id="weatherWindDir">--</dd>
                                 </div>
-                            </div>
+                            </dl>
                             <div class="weather-timeline" id="weatherTimeline" tabindex="0" role="region"
                                 aria-label="Hourly forecast">
                                 <!-- Timeline items injected here -->
@@ -421,21 +422,22 @@
     <!-- Template for skeleton loading state in forecast panel -->
     <template id="forecast-skeleton-template">
         <div class="weather-dashboard" aria-hidden="true">
-            <div class="weather-current">
+            <!-- Scout: Upgraded generic div/span wrappers to semantic description list (dl/dt/dd) to explicitly associate weather labels with their values for crawlers and assistive tech. -->
+            <dl class="weather-current">
                 <div class="weather-metric">
-                    <span class="weather-label skeleton"><span class="skeleton-text" style="width: 30px"></span></span>
-                    <span class="weather-value skeleton"><span class="skeleton-text" style="width: 40px"></span></span>
+                    <dt class="weather-label skeleton"><span class="skeleton-text" style="width: 30px"></span></dt>
+                    <dd class="weather-value skeleton"><span class="skeleton-text" style="width: 40px"></span></dd>
                 </div>
                 <div class="weather-metric">
-                    <span class="weather-label skeleton"><span class="skeleton-text" style="width: 30px"></span></span>
-                    <span class="weather-value skeleton"><span class="skeleton-text" style="width: 40px"></span></span>
+                    <dt class="weather-label skeleton"><span class="skeleton-text" style="width: 30px"></span></dt>
+                    <dd class="weather-value skeleton"><span class="skeleton-text" style="width: 40px"></span></dd>
                 </div>
                 <div class="weather-metric">
-                    <span class="weather-label skeleton"><span class="skeleton-text" style="width: 30px"></span></span>
-                    <span class="weather-value skeleton"><span class="skeleton-text" style="width: 40px"></span></span>
-                    <span class="weather-sub skeleton"><span class="skeleton-text" style="width: 20px"></span></span>
+                    <dt class="weather-label skeleton"><span class="skeleton-text" style="width: 30px"></span></dt>
+                    <dd class="weather-value skeleton"><span class="skeleton-text" style="width: 40px"></span></dd>
+                    <dd class="weather-sub skeleton"><span class="skeleton-text" style="width: 20px"></span></dd>
                 </div>
-            </div>
+            </dl>
             <div class="weather-timeline" id="weatherTimeline">
                 <!-- Scout: Upgraded generic div wrapper to semantic time element in skeletons -->
                 <div class="weather-timeline-item">

--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -769,27 +769,28 @@ export class CircuitWeatherApp {
             const rotation = windInfo.rotation;
 
             currentHtml = `
-                <div class="weather-current">
+                <!-- Scout: Upgraded generic div/span wrappers to semantic description list (dl/dt/dd) to explicitly associate weather labels with their values for crawlers and assistive tech. -->
+                <dl class="weather-current">
                     <div class="weather-metric">
-                        <span class="weather-label">${escapeHtml(i18n.t('weather.temp'))}</span>
-                        <span class="weather-value" id="weatherTemp">${escapeHtml(temp)}${escapeHtml(weather.units.temperature_2m)}</span>
+                        <dt class="weather-label">${escapeHtml(i18n.t('weather.temp'))}</dt>
+                        <dd class="weather-value" id="weatherTemp">${escapeHtml(temp)}${escapeHtml(weather.units.temperature_2m)}</dd>
                     </div>
                     <div class="weather-metric">
-                        <span class="weather-label">${escapeHtml(i18n.t('weather.rain'))}</span>
-                        <span class="weather-value" id="weatherRain">${escapeHtml(maxPrecip)}%</span>
+                        <dt class="weather-label">${escapeHtml(i18n.t('weather.rain'))}</dt>
+                        <dd class="weather-value" id="weatherRain">${escapeHtml(maxPrecip)}%</dd>
                     </div>
                     <div class="weather-metric">
-                        <span class="weather-label">${escapeHtml(i18n.t('weather.wind'))}</span>
-                        <span class="weather-value" id="weatherWind">${escapeHtml(wind)} ${escapeHtml(weather.units.wind_speed_10m)}</span>
-                        <span class="weather-sub" id="weatherWindDir" title="${escapeHtml(dir)}°" aria-label="${escapeHtml(i18n.t('weather.windDirection', { direction: windInfo.text, degrees: dir }))}">
+                        <dt class="weather-label">${escapeHtml(i18n.t('weather.wind'))}</dt>
+                        <dd class="weather-value" id="weatherWind">${escapeHtml(wind)} ${escapeHtml(weather.units.wind_speed_10m)}</dd>
+                        <dd class="weather-sub" id="weatherWindDir" title="${escapeHtml(dir)}°" aria-label="${escapeHtml(i18n.t('weather.windDirection', { direction: windInfo.text, degrees: dir }))}">
                             ${escapeHtml(windInfo.text)}
                             <svg class="icon-wind-arrow" style="transform: rotate(${escapeHtml(rotation)}deg); width: 14px; height: 14px;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                 <line x1="12" y1="19" x2="12" y2="5"></line>
                                 <polyline points="5 12 12 5 19 12"></polyline>
                             </svg>
-                        </span>
+                        </dd>
                     </div>
-                </div>
+                </dl>
             `;
         }
 

--- a/tests/circuit-weather-app.test.js
+++ b/tests/circuit-weather-app.test.js
@@ -661,7 +661,7 @@ describe('CircuitWeatherApp Pure Methods', () => {
 
             // The closest point is 14:15 (26 degrees)
             // We check that the primary temperature value is 26
-            expect(app.ui.forecastContent.innerHTML).toContain('id="weatherTemp">26°C</span>');
+            expect(app.ui.forecastContent.innerHTML).toContain('id="weatherTemp">26°C</dd>');
             // 24 should still be in the timeline, but not the primary temp
             expect(app.ui.forecastContent.innerHTML).toContain('<div>24°</div>');
         });


### PR DESCRIPTION
💡 **What:** Upgraded the generic `<div>` and `<span>` wrappers in the weather metrics dashboard to a semantic description list (`<dl>`, `<dt>`, `<dd>`).
🎯 **Why:** To create a clear, programmatic association between the label (e.g., "Wind") and its value for search engine crawlers and assistive technologies. Generic tags do not convey meaning or relationships.
📊 **Value:** Improves page semantics and discoverability, allowing search engines and screen readers to explicitly understand that the data presented are key-value pairs representing weather metrics.
🔬 **Measurement:** Verify the DOM output in the browser's Elements panel when a session is selected; the `.weather-current` container should now be a `<dl>`, with labels wrapped in `<dt>` and values wrapped in `<dd>`. The visual layout remains identical due to existing CSS Flexbox properties mapping 1:1.

---
*PR created automatically by Jules for task [16105045605548403458](https://jules.google.com/task/16105045605548403458) started by @2fst4u*