### PR TITLE
📚 Archivist: Fix dangling reference in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,6 @@ pnpm run dev # or 'npx wrangler dev' / 'wrangler dev' based on environment avail
 # Deploy to Cloudflare
 # Deployment is automatic via Cloudflare Git Integration (Workers with Static Assets)
 # when changes are merged to the 'main' branch.
-# See "Git Workflow for Changes" below.
 ```
 
 **Note**: The project is connected to Cloudflare via GitHub integration. Pushing to `main` triggers automatic deployment - no manual `wrangler deploy` needed.


### PR DESCRIPTION
💡 **Problem:** `AGENTS.md` contained a dangling comment (`# See "Git Workflow for Changes" below.`) on line 120, but the referenced section does not exist anywhere in the document, creating ambiguity for developers and agents reading the setup instructions.

🎯 **Fix:** Removed the broken internal reference from the bash codeblock.

🧪 **Verification:** Checked the `AGENTS.md` file to ensure the reference is gone, and ran `pnpm test` locally to confirm the documentation change did not break any functionality. 

🔎 **Scope:** ONLY documentation changes in `AGENTS.md`.

---
*PR created automatically by Jules for task [1145855676143524005](https://jules.google.com/task/1145855676143524005) started by @2fst4u*