### PR TITLE
🔭 Scout: Upgrade generic unordered list to ordered list for forecast timeline

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -832,11 +832,12 @@ export class CircuitWeatherApp {
                 `;
             }).join('');
 
+            // Scout: Upgraded generic unordered list (ul) to an ordered list (ol) to semantically indicate to search engines and screen readers that the hourly forecast is a chronological, time-ordered sequence of events.
             timelineHtml = `
                 <div class="weather-timeline" id="weatherTimeline" tabindex="0" role="region" aria-label="${escapeHtml(i18n.t('forecast.hourlyForecast'))}">
-                    <ul class="weather-timeline-list">
+                    <ol class="weather-timeline-list">
                         ${items}
-                    </ul>
+                    </ol>
                 </div>
             `;
         }


### PR DESCRIPTION
💡 **What:** Upgraded the `<ul class="weather-timeline-list">` element to an `<ol>` (ordered list) in `public/src/CircuitWeatherApp.js`. Additionally, documented the change with a JS comment to minimize the client payload.

🎯 **Why:** Hourly forecasts represent a specific, chronological sequence of time-ordered events. A generic unordered list (`<ul>`) does not convey this relationship semantically. By upgrading to an ordered list (`<ol>`), we explicitly communicate the time-bound sequence to search engines and assistive technologies, improving structural understanding without changing the layout.

📊 **Value:** Improves structural indexing and accessibility for screen readers by enforcing the sequential nature of the timeline.

🔬 **Measurement:** The `<ol class="weather-timeline-list">` element can be verified in the DOM by inspecting the `#weatherTimeline` container after rendering the application forecast.

---
*PR created automatically by Jules for task [269807507982944536](https://jules.google.com/task/269807507982944536) started by @2fst4u*