### PR TITLE
🧪 Spec: Fix i18n locales completeness test

### DIFF
--- a/tests/i18n-locales-completeness.test.js
+++ b/tests/i18n-locales-completeness.test.js
@@ -27,7 +27,7 @@ const locales = {
 function collectLeafKeys(object, prefix = '') {
     const entries = [];
     Object.entries(object).forEach(([key, value]) => {
-        const path = prefix ? \`\${prefix}.\${key}\` : key;
+        const path = prefix ? `${prefix}.${key}` : key;
         if (value && typeof value === 'object' && !Array.isArray(value)) {
             entries.push(...collectLeafKeys(value, path));
         } else {
@@ -48,7 +48,7 @@ describe('i18n locale completeness', () => {
         Object.entries(locales).forEach(([locale, dictionary]) => {
             englishKeys.forEach((key) => {
                 const value = getValueByPath(dictionary, key);
-                expect(value, \`Missing key "\${key}" in locale "\${locale}"\`).toBeDefined();
+                expect(value, `Missing key "${key}" in locale "${locale}"`).toBeDefined();
             });
         });
     });


### PR DESCRIPTION
💡 What: Fixed incorrectly escaped template literals in `tests/i18n-locales-completeness.test.js`.
🎯 Why: The CI test suite was failing to run because the file could not be parsed due to a `SyntaxError: Invalid or unexpected token`. Fixing the template literal syntax (`` `${prefix}.${key}` `` and `` `Missing key "${key}" in locale "${locale}"` ``) restored functionality.
📈 Maturity Impact: No threshold changes, but ensures that all translated locales are checked against English key coverage, preventing unverified localized strings.

---
*PR created automatically by Jules for task [957688946283048341](https://jules.google.com/task/957688946283048341) started by @2fst4u*