### PR TITLE
🧪 Spec: Fix worker health tests noisy logs

### DIFF
--- a/tests/worker-edge-cases.test.js
+++ b/tests/worker-edge-cases.test.js
@@ -144,6 +144,7 @@ describe('Worker Edge Cases', () => {
         });
 
         it('reports unreachable upstreams', async () => {
+            const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
             const originalFetch = globalThis.fetch;
             globalThis.fetch = vi.fn().mockRejectedValue(new Error('Timeout'));
 
@@ -155,6 +156,7 @@ describe('Worker Edge Cases', () => {
             expect(body.upstreams.rainviewer).toContain('unreachable');
 
             globalThis.fetch = originalFetch;
+            errorSpy.mockRestore();
         });
     });
 

--- a/tests/worker-health-cache.test.js
+++ b/tests/worker-health-cache.test.js
@@ -76,6 +76,7 @@ describe("Worker Health Check Caching", () => {
   });
 
   it("marks upstream as unreachable on fetch error", async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     // Mock upstream to throw error
     mockFetch.mockRejectedValue(new Error("Network failure"));
 
@@ -93,6 +94,7 @@ describe("Worker Health Check Caching", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(3);
     expect(mockCache.put).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 
   it("serves subsequent requests from cache (cache hit)", async () => {


### PR DESCRIPTION
💡 What: Mocked and suppressed `console.error` during tests that intentionally throw fetch errors in `worker-edge-cases.test.js` and `worker-health-cache.test.js`, and properly restored them afterward.
🎯 Why: Vitest prints intentional errors caught by the application logic to stderr, creating messy logs that mask actual test suite failures. Silencing these expected errors improves suite readability.

---
*PR created automatically by Jules for task [543149971069046990](https://jules.google.com/task/543149971069046990) started by @2fst4u*