### PR TITLE
🎨 Palette: Implement manual language selection in sidebar footer

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -85,3 +85,7 @@ s (colors, spacing) to blend in.
 ## 2026-10-25 - Explicit Visual Styling for Dynamically Disabled Buttons
 **Learning:** When JavaScript dynamically disables a button (e.g., `btn.disabled = true` during a network retry or loading state), relying solely on the browser's default disabled styling is often insufficient. Without explicit CSS for the `:disabled` state (like reduced opacity and a `not-allowed` cursor), users may not visually register that the button is temporarily inactive, leading to confusion or repeated clicks.
 **Action:** Always pair dynamic `disabled = true` logic with explicit `.btn:disabled` CSS rules (e.g., `opacity: 0.5; cursor: not-allowed;`) to ensure clear, immediate visual feedback that aligns with the semantic state of the element.
+
+## 2024-05-15 - Language Selection UI in Sidebar Footer
+**Learning:** Implementing a language selector in a constrained space like a sidebar footer requires a "pop-out" (upward-opening) menu to avoid obscuring other elements and to ensure accessibility across various screen sizes. Manual selection should always override automatic locale detection and persist across sessions via local storage.
+**Action:** Added a `LanguageManager` component that handles an upward-expanding menu (`bottom: 100%`) in the sidebar footer. Integrated with the i18n system to ensure real-time UI updates via `data-i18n` attributes and persistent storage using `SafeStorage`.

--- a/public/index.html
+++ b/public/index.html
@@ -231,6 +231,11 @@
 
             <!-- Scout: Upgraded generic div to semantic footer for better structure -->
             <footer class="sidebar-footer">
+                <div class="language-selector">
+                    <button id="languageToggle" class="link-button" aria-haspopup="true" aria-expanded="false" data-i18n="common.selectLanguage">Language</button>
+                    <div id="languageMenu" class="language-menu" role="menu"></div>
+                </div>
+                <span>•</span>
                 <!-- Scout: Converted privacy button to an anchor tag with href for crawler discoverability -->
                 <a href="/PRIVACY.md" id="privacyLink" class="link-button" role="button" data-i18n="privacy.link">Privacy</a>
                 <span>•</span>

--- a/public/src/i18n/index.js
+++ b/public/src/i18n/index.js
@@ -1,4 +1,5 @@
 import { getUserLocale } from '../utils/locale.js';
+import { SafeStorage } from '../utils/storage.js';
 import { de } from './locales/de.js';
 import { en } from './locales/en.js';
 import { enGB } from './locales/en-GB.js';
@@ -25,6 +26,19 @@ const TRANSLATIONS = {
     'zh-CN': zhCN,
 };
 
+export const LANGUAGE_NAMES = {
+    'en-NZ': 'English (NZ)',
+    'en-GB': 'English (UK)',
+    'en-US': 'English (US)',
+    'de': 'Deutsch',
+    'es': 'Español',
+    'fr': 'Français',
+    'it': 'Italiano',
+    'pt-BR': 'Português (BR)',
+    'zh-CN': '简体中文',
+    'ja': '日本語',
+};
+
 const LOCALE_ALIASES = {
     pt: 'pt-BR',
     zh: 'zh-CN',
@@ -49,13 +63,15 @@ function normalise(locale) {
         localeString = rawLocale;
     }
 
-    if (TRANSLATIONS[localeString]) return localeString;
-
     const base = localeString.split('-')[0];
     if (base === 'en') {
         if (localeString.startsWith('en-GB')) return 'en-GB';
-        return localeString.startsWith('en-US') ? 'en-US' : 'en-NZ';
+        if (localeString.startsWith('en-US')) return 'en-US'
+        return 'en-NZ';
     }
+
+    if (TRANSLATIONS[localeString]) return localeString;
+
     if (TRANSLATIONS[base]) return base;
     if (LOCALE_ALIASES[base]) return LOCALE_ALIASES[base];
     return 'en-NZ';
@@ -63,11 +79,12 @@ function normalise(locale) {
 
 class I18n {
     constructor() {
-        this.locale = 'en';
+        this.locale = 'en-NZ';
     }
 
     init(locale = getUserLocale()) {
-        this.locale = normalise(locale);
+        const stored = SafeStorage.getItem('language');
+        this.locale = normalise(stored || locale);
         if (typeof document !== 'undefined' && document.documentElement) {
             document.documentElement.lang = this.locale;
         }
@@ -75,6 +92,7 @@ class I18n {
 
     setLocale(locale) {
         this.locale = normalise(locale);
+        SafeStorage.setItem('language', this.locale);
         if (typeof document !== 'undefined' && document.documentElement) {
             document.documentElement.lang = this.locale;
             this.apply();

--- a/public/src/i18n/locales/de.js
+++ b/public/src/i18n/locales/de.js
@@ -1,5 +1,5 @@
 export const de = {
-    common: { loading: 'Wird geladen...', retry: 'Erneut versuchen', retrying: 'Versuche erneut...', openMenu: 'Menu offnen', closeMenu: 'Menu schliessen' },
+    common: { loading: 'Wird geladen...', retry: 'Erneut versuchen', retrying: 'Versuche erneut...', selectLanguage: 'Sprache', openMenu: 'Menu offnen', closeMenu: 'Menu schliessen' },
     theme: { toggle: 'Hell/Dunkelmodus umschalten', switchToLight: 'Zu hellem Modus wechseln', switchToDark: 'Zu dunklem Modus wechseln' },
     loading: { schedule: 'Lade Rennkalender...', session: 'Lade Sessiondaten...' },
     controls: {

--- a/public/src/i18n/locales/en.js
+++ b/public/src/i18n/locales/en.js
@@ -3,6 +3,7 @@ export const en = {
         loading: 'Loading...',
         retry: 'Retry',
         retrying: 'Retrying...',
+        selectLanguage: 'Language',
         openMenu: 'Open menu',
         closeMenu: 'Close menu',
     },

--- a/public/src/i18n/locales/es.js
+++ b/public/src/i18n/locales/es.js
@@ -1,5 +1,5 @@
 export const es = {
-    common: { loading: 'Cargando...', retry: 'Reintentar', retrying: 'Reintentando...', openMenu: 'Abrir menu', closeMenu: 'Cerrar menu' },
+    common: { loading: 'Cargando...', retry: 'Reintentar', retrying: 'Reintentando...', selectLanguage: 'Idioma', openMenu: 'Abrir menu', closeMenu: 'Cerrar menu' },
     theme: { toggle: 'Cambiar modo claro/oscuro', switchToLight: 'Cambiar a modo claro', switchToDark: 'Cambiar a modo oscuro' },
     loading: { schedule: 'Cargando calendario de carreras...', session: 'Cargando datos de la sesion...' },
     controls: {

--- a/public/src/i18n/locales/fr.js
+++ b/public/src/i18n/locales/fr.js
@@ -1,5 +1,5 @@
 export const fr = {
-    common: { loading: 'Chargement...', retry: 'Reessayer', retrying: 'Nouvelle tentative...', openMenu: 'Ouvrir le menu', closeMenu: 'Fermer le menu' },
+    common: { loading: 'Chargement...', retry: 'Reessayer', retrying: 'Nouvelle tentative...', selectLanguage: 'Langue', openMenu: 'Ouvrir le menu', closeMenu: 'Fermer le menu' },
     theme: { toggle: 'Basculer mode clair/sombre', switchToLight: 'Passer en mode clair', switchToDark: 'Passer en mode sombre' },
     loading: { schedule: 'Chargement du calendrier des courses...', session: 'Chargement des donnees de session...' },
     controls: {

--- a/public/src/i18n/locales/it.js
+++ b/public/src/i18n/locales/it.js
@@ -1,5 +1,5 @@
 export const it = {
-    common: { loading: 'Caricamento...', retry: 'Riprova', retrying: 'Nuovo tentativo...', openMenu: 'Apri menu', closeMenu: 'Chiudi menu' },
+    common: { loading: 'Caricamento...', retry: 'Riprova', retrying: 'Nuovo tentativo...', selectLanguage: 'Lingua', openMenu: 'Apri menu', closeMenu: 'Chiudi menu' },
     theme: { toggle: 'Attiva tema chiaro/scuro', switchToLight: 'Passa al tema chiaro', switchToDark: 'Passa al tema scuro' },
     loading: { schedule: 'Caricamento calendario gare...', session: 'Caricamento dati sessione...' },
     controls: {

--- a/public/src/i18n/locales/ja.js
+++ b/public/src/i18n/locales/ja.js
@@ -1,5 +1,5 @@
 export const ja = {
-    common: { loading: '読み込み中...', retry: '再試行', retrying: '再試行中...', openMenu: 'メニューを開く', closeMenu: 'メニューを閉じる' },
+    common: { loading: '読み込み中...', retry: '再試行', retrying: '再試行中...', selectLanguage: '言語', openMenu: 'メニューを開く', closeMenu: 'メニューを閉じる' },
     theme: { toggle: 'ライト/ダークモードを切り替え', switchToLight: 'ライトモードに切り替え', switchToDark: 'ダークモードに切り替え' },
     loading: { schedule: 'レーススケジュールを読み込み中...', session: 'セッションデータを読み込み中...' },
     controls: {

--- a/public/src/i18n/locales/pt-BR.js
+++ b/public/src/i18n/locales/pt-BR.js
@@ -1,5 +1,5 @@
 export const ptBR = {
-    common: { loading: 'A carregar...', retry: 'Tentar novamente', retrying: 'A tentar novamente...', openMenu: 'Abrir menu', closeMenu: 'Fechar menu' },
+    common: { loading: 'A carregar...', retry: 'Tentar novamente', retrying: 'A tentar novamente...', selectLanguage: 'Idioma', openMenu: 'Abrir menu', closeMenu: 'Fechar menu' },
     theme: { toggle: 'Alternar modo claro/escuro', switchToLight: 'Mudar para modo claro', switchToDark: 'Mudar para modo escuro' },
     loading: { schedule: 'A carregar calendario de corridas...', session: 'A carregar dados da sessao...' },
     controls: {

--- a/public/src/i18n/locales/zh-CN.js
+++ b/public/src/i18n/locales/zh-CN.js
@@ -1,5 +1,5 @@
 export const zhCN = {
-    common: { loading: '加载中...', retry: '重试', retrying: '正在重试...', openMenu: '打开菜单', closeMenu: '关闭菜单' },
+    common: { loading: '加载中...', retry: '重试', retrying: '正在重试...', selectLanguage: '语言', openMenu: '打开菜单', closeMenu: '关闭菜单' },
     theme: { toggle: '切换明亮/深色模式', switchToLight: '切换到明亮模式', switchToDark: '切换到深色模式' },
     loading: { schedule: '正在加载比赛赛历...', session: '正在加载赛段数据...' },
     controls: {

--- a/public/src/main.js
+++ b/public/src/main.js
@@ -1,5 +1,6 @@
 import { CircuitWeatherApp } from './CircuitWeatherApp.js';
 import { PrivacyModal } from './ui/PrivacyModal.js';
+import { LanguageManager } from './ui/LanguageManager.js';
 import { i18n } from './i18n/index.js';
 
 /**
@@ -15,6 +16,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Initialize the privacy modal
     new PrivacyModal();
+
+    // Initialize the language manager
+    new LanguageManager();
 
     // Register Service Worker for offline support and PWA features
     if ('serviceWorker' in navigator) {

--- a/public/src/ui/LanguageManager.js
+++ b/public/src/ui/LanguageManager.js
@@ -1,0 +1,98 @@
+import { i18n, LANGUAGE_NAMES } from '../i18n/index.js';
+
+export class LanguageManager {
+    constructor() {
+        this.toggleBtn = document.getElementById('languageToggle');
+        this.menu = document.getElementById('languageMenu');
+        this.isOpen = false;
+
+        if (this.toggleBtn && this.menu) {
+            this.init();
+        }
+    }
+
+    init() {
+        this.populateMenu();
+        this.bindEvents();
+        this.updateActiveLanguage();
+
+        // Listen for language changes from other sources
+        document.addEventListener('i18n:change', () => {
+            this.updateActiveLanguage();
+        });
+    }
+
+    populateMenu() {
+        this.menu.innerHTML = '';
+        Object.entries(LANGUAGE_NAMES).forEach(([locale, name]) => {
+            const button = document.createElement('button');
+            button.className = 'language-item';
+            button.dataset.locale = locale;
+            button.textContent = name;
+            button.type = 'button';
+
+            button.addEventListener('click', () => {
+                i18n.setLocale(locale);
+                this.close();
+            });
+
+            this.menu.appendChild(button);
+        });
+    }
+
+    bindEvents() {
+        this.toggleBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this.toggle();
+        });
+
+        // Close when clicking outside
+        document.addEventListener('click', (e) => {
+            if (this.isOpen && !this.menu.contains(e.target) && !this.toggleBtn.contains(e.target)) {
+                this.close();
+            }
+        });
+
+        // Close on Escape
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && this.isOpen) {
+                this.close();
+            }
+        });
+    }
+
+    toggle() {
+        if (this.isOpen) {
+            this.close();
+        } else {
+            this.open();
+        }
+    }
+
+    open() {
+        this.isOpen = true;
+        this.menu.classList.add('visible');
+        this.toggleBtn.setAttribute('aria-expanded', 'true');
+
+        // Focus first item
+        const firstItem = this.menu.querySelector('.language-item');
+        if (firstItem) {
+            setTimeout(() => firstItem.focus(), 50);
+        }
+    }
+
+    close() {
+        this.isOpen = false;
+        this.menu.classList.remove('visible');
+        this.toggleBtn.setAttribute('aria-expanded', 'false');
+    }
+
+    updateActiveLanguage() {
+        const currentLocale = i18n.locale;
+        this.menu.querySelectorAll('.language-item').forEach(item => {
+            const isActive = item.dataset.locale === currentLocale;
+            item.classList.toggle('active', isActive);
+            item.setAttribute('aria-current', isActive ? 'true' : 'false');
+        });
+    }
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -507,8 +507,55 @@ body {
     border-top: 1px solid var(--color-border);
     display: flex;
     justify-content: center;
+    align-items: center;
     gap: var(--spacing-sm);
     font-size: 0.7rem;
+    position: relative;
+}
+
+.language-selector {
+    position: relative;
+}
+
+.language-menu {
+    position: absolute;
+    bottom: 100%;
+    left: 0;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+    display: none;
+    flex-direction: column;
+    min-width: 150px;
+    z-index: 1000;
+    margin-bottom: var(--spacing-xs);
+    overflow: hidden;
+}
+
+.language-menu.visible {
+    display: flex;
+}
+
+.language-item {
+    padding: var(--spacing-sm) var(--spacing-md);
+    background: none;
+    border: none;
+    text-align: left;
+    font: inherit;
+    color: var(--color-text);
+    cursor: pointer;
+    transition: background-color var(--transition-fast);
+}
+
+.language-item:hover {
+    background: var(--color-bg);
+    color: var(--color-primary);
+}
+
+.language-item.active {
+    font-weight: 700;
+    color: var(--color-primary);
 }
 
 .sidebar-footer a {


### PR DESCRIPTION
### 🎨 Palette: Implement manual language selection in sidebar footer

**What**
Added a language selection button and an upward-opening "pop-out" menu to the sidebar footer.

**Why**
While language is automatically detected, users frequently need to manually override this setting for preference or testing. The selection must persist across sessions.

**Value**
Provides explicit user control over the interface language, improving accessibility for multilingual users and those whose locale detection may be inaccurate.

**Measurement**
- **Persistence:** Selecting a language saves it to `localStorage` (via `SafeStorage`); it remains active on reload.
- **Visuals:** The menu opens above the footer (`bottom: 100%`) ensuring it remains visible without scrolling the sidebar.
- **i18n Logic:** Refined `normalise` function ensures `en-US`, `en-GB`, and `en-NZ` are treated as distinct selectable options in the UI.
- **Verification:** 611 tests passed. Frontend verified with Playwright screenshots showing menu interaction and state changes.

**Accessibility**
- Uses `aria-haspopup` and `aria-expanded`.
- Manages focus by jumping to the first menu item on open.
- Supports `Escape` key to close the menu.

Fixes #518

---
*PR created automatically by Jules for task [7533380054103960395](https://jules.google.com/task/7533380054103960395) started by @2fst4u*