### PR TITLE
Fix "current conditions" heading i18n

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -132,9 +132,9 @@ export class CircuitWeatherApp {
                             <line x1="12" y1="16" x2="12.01" y2="16"></line>
                         </svg>
                     </div>
-                    <h3>${escapeHtml(i18n.t('errors.connectionFailed'))}</h3>
+                    <h3 data-i18n="errors.connectionFailed">${escapeHtml(i18n.t('errors.connectionFailed'))}</h3>
                     <p>${escapeHtml(message)}</p>
-                    <button class="retry-btn" type="button" aria-label="${escapeHtml(i18n.t('errors.retryConnection'))}">${escapeHtml(i18n.t('common.retry'))}</button>
+                    <button class="retry-btn" type="button" data-i18n="common.retry" data-i18n-attr="aria-label:errors.retryConnection" aria-label="${escapeHtml(i18n.t('errors.retryConnection'))}">${escapeHtml(i18n.t('common.retry'))}</button>
                 </div>
             `;
             const btn = sidebarContent.querySelector('.retry-btn');
@@ -772,15 +772,15 @@ export class CircuitWeatherApp {
                 <!-- Scout: Upgraded generic div/span wrappers to semantic description list (dl/dt/dd) to explicitly associate weather labels with their values for crawlers and assistive tech. -->
                 <dl class="weather-current">
                     <div class="weather-metric">
-                        <dt class="weather-label">${escapeHtml(i18n.t('weather.temp'))}</dt>
+                        <dt class="weather-label" data-i18n="weather.temp">${escapeHtml(i18n.t('weather.temp'))}</dt>
                         <dd class="weather-value" id="weatherTemp">${escapeHtml(temp)}${escapeHtml(weather.units.temperature_2m)}</dd>
                     </div>
                     <div class="weather-metric">
-                        <dt class="weather-label">${escapeHtml(i18n.t('weather.rain'))}</dt>
+                        <dt class="weather-label" data-i18n="weather.rain">${escapeHtml(i18n.t('weather.rain'))}</dt>
                         <dd class="weather-value" id="weatherRain">${escapeHtml(maxPrecip)}%</dd>
                     </div>
                     <div class="weather-metric">
-                        <dt class="weather-label">${escapeHtml(i18n.t('weather.wind'))}</dt>
+                        <dt class="weather-label" data-i18n="weather.wind">${escapeHtml(i18n.t('weather.wind'))}</dt>
                         <dd class="weather-value" id="weatherWind">${escapeHtml(wind)} ${escapeHtml(weather.units.wind_speed_10m)}</dd>
                         <dd class="weather-sub" id="weatherWindDir" title="${escapeHtml(dir)}°" aria-label="${escapeHtml(i18n.t('weather.windDirection', { direction: windInfo.text, degrees: dir }))}">
                             ${escapeHtml(windInfo.text)}
@@ -834,7 +834,7 @@ export class CircuitWeatherApp {
 
             // Scout: Upgraded generic unordered list (ul) to an ordered list (ol) to semantically indicate to search engines and screen readers that the hourly forecast is a chronological, time-ordered sequence of events.
             timelineHtml = `
-                <div class="weather-timeline" id="weatherTimeline" tabindex="0" role="region" aria-label="${escapeHtml(i18n.t('forecast.hourlyForecast'))}">
+                <div class="weather-timeline" id="weatherTimeline" tabindex="0" role="region" data-i18n-attr="aria-label:forecast.hourlyForecast" aria-label="${escapeHtml(i18n.t('forecast.hourlyForecast'))}">
                     <ol class="weather-timeline-list">
                         ${items}
                     </ol>

--- a/public/src/map/MapWeatherWidget.js
+++ b/public/src/map/MapWeatherWidget.js
@@ -8,25 +8,26 @@ export const MapWeatherWidget = L.Control.extend({
         this._div = L.DomUtil.create('div', 'leaflet-control-weather');
         this._div.setAttribute('role', 'region');
         this._div.setAttribute('aria-label', i18n.t('weather.currentCircuitWeather'));
+        this._div.setAttribute('data-i18n-attr', 'aria-label:weather.currentCircuitWeather');
         this._div.setAttribute('tabindex', '0');
 
         // Bolt Optimization: Create DOM structure once and reuse
         // This avoids frequent innerHTML parsing/GC during map interactions
         this._div.innerHTML = `
-            <h2 class="weather-widget-heading">${i18n.t('weather.currentConditions')}</h2>
-            <div class="weather-widget-metric" role="group" aria-label="${i18n.t('weather.temperature')}" title="${i18n.t('weather.temperature')}">
+            <h2 class="weather-widget-heading" data-i18n="weather.currentConditions">${i18n.t('weather.currentConditions')}</h2>
+            <div class="weather-widget-metric" role="group" aria-label="${i18n.t('weather.temperature')}" title="${i18n.t('weather.temperature')}" data-i18n-attr="aria-label:weather.temperature,title:weather.temperature">
                 <svg class="icon-weather icon-temp" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0z" /></svg>
                 <span class="temp-value">--</span>
             </div>
-            <div class="weather-widget-metric" role="group" aria-label="${i18n.t('weather.rainChance')}" title="${i18n.t('weather.rainChance')}">
+            <div class="weather-widget-metric" role="group" aria-label="${i18n.t('weather.rainChance')}" title="${i18n.t('weather.rainChance')}" data-i18n-attr="aria-label:weather.rainChance,title:weather.rainChance">
                 <svg class="icon-weather icon-rain" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242"/><path d="M16 14v6"/><path d="M8 14v6"/><path d="M12 16v6"/></svg>
                 <span class="rain-value">--%</span>
             </div>
-            <div class="weather-widget-metric" role="group" aria-label="${i18n.t('weather.humidity')}" title="${i18n.t('weather.humidity')}">
+            <div class="weather-widget-metric" role="group" aria-label="${i18n.t('weather.humidity')}" title="${i18n.t('weather.humidity')}" data-i18n-attr="aria-label:weather.humidity,title:weather.humidity">
                 <svg class="icon-weather icon-humidity" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0z" /></svg>
                 <span class="humid-value">--%</span>
             </div>
-            <div class="weather-widget-metric" role="group" aria-label="${i18n.t('weather.windSpeed')}" title="${i18n.t('weather.wind')}">
+            <div class="weather-widget-metric" role="group" aria-label="${i18n.t('weather.windSpeed')}" title="${i18n.t('weather.wind')}" data-i18n-attr="aria-label:weather.windSpeed,title:weather.wind">
                  <svg class="icon-weather icon-wind" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9.59 4.59A2 2 0 1 1 11 8H2m10.59 11.41A2 2 0 1 0 14 16H2m15.73-8.27A2.5 2.5 0 1 1 19.5 12H2" /></svg>
                 <span class="wind-value">--</span>
             </div>

--- a/tests/map-weather-widget.test.js
+++ b/tests/map-weather-widget.test.js
@@ -73,8 +73,12 @@ describe('MapWeatherWidget', () => {
     it('should initialize with correct DOM structure', () => {
         expect(L.DomUtil.create).toHaveBeenCalledWith('div', 'leaflet-control-weather');
         expect(widget._div).toBeDefined();
-        // Check if innerHTML was set (contains SVG icons, etc.)
+        expect(widget._div.setAttribute).toHaveBeenCalledWith('data-i18n-attr', 'aria-label:weather.currentCircuitWeather');
+
+        // Check if innerHTML was set and contains i18n bindings
         expect(widget._div.innerHTML).toContain('weather-widget-metric');
+        expect(widget._div.innerHTML).toContain('data-i18n="weather.currentConditions"');
+        expect(widget._div.innerHTML).toContain('data-i18n-attr="aria-label:weather.temperature,title:weather.temperature"');
 
         // Verify UI cache was created
         expect(widget._ui).toBeDefined();


### PR DESCRIPTION
This change fixes an issue where the "Current conditions" heading in the map weather widget did not update its language when a new locale was selected. By adding `data-i18n` and `data-i18n-attr` attributes, the application's i18n system can now automatically update these elements upon locale changes. Similar improvements were made to the forecast dashboard and error states for better consistency.

Fixes #521

---
*PR created automatically by Jules for task [4228778091868293349](https://jules.google.com/task/4228778091868293349) started by @2fst4u*