### PR TITLE
🎨 Palette: Automatically close language menu on focusout

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -89,3 +89,7 @@ s (colors, spacing) to blend in.
 ## 2024-05-15 - Language Selection UI in Sidebar Footer
 **Learning:** Implementing a language selector in a constrained space like a sidebar footer requires a "pop-out" (upward-opening) menu to avoid obscuring other elements and to ensure accessibility across various screen sizes. Manual selection should always override automatic locale detection and persist across sessions via local storage.
 **Action:** Added a `LanguageManager` component that handles an upward-expanding menu (`bottom: 100%`) in the sidebar footer. Integrated with the i18n system to ensure real-time UI updates via `data-i18n` attributes and persistent storage using `SafeStorage`.
+
+## 2026-10-26 - Keyboard Focus bounds on Pop-Out Menus
+**Learning:** For pop-out menus (like the Language selector), clicking outside will reliably close the menu via standard document click handlers. However, if a keyboard user tabs out of the menu container, the menu often remains open while focus moves to unrelated elements, creating a confusing and inaccessible experience.
+**Action:** Always bind a `focusout` event listener to pop-out menus that uses `requestAnimationFrame` (or a brief `setTimeout`) to verify if `document.activeElement` has moved outside the widget's bounds, and close it automatically if so.

--- a/public/src/ui/LanguageManager.js
+++ b/public/src/ui/LanguageManager.js
@@ -59,6 +59,19 @@ export class LanguageManager {
                 this.close();
             }
         });
+
+        // Palette A11y: Close when focus moves outside the menu (e.g., tabbing away)
+        this.menu.addEventListener('focusout', (e) => {
+            if (!this.isOpen) return;
+
+            // Wait a tick to let the browser update document.activeElement
+            requestAnimationFrame(() => {
+                if (!this.menu.contains(document.activeElement) &&
+                    document.activeElement !== this.toggleBtn) {
+                    this.close();
+                }
+            });
+        });
     }
 
     toggle() {


### PR DESCRIPTION
💡 **What**: Added a `focusout` event listener to `LanguageManager.js` that automatically closes the language selector pop-out menu when keyboard focus leaves the menu and its toggle button.
🎯 **Why**: Previously, when a user opened the menu and tabbed past the last item, focus would move to the next page element, but the menu would awkwardly remain open. This disrupted the flow of keyboard navigation.
📸 **Before/After**: See frontend verification screenshots. 
♿ **Accessibility**: Significant improvement for keyboard users and screen readers navigating the interface. Ensures standard focus management behavior for pop-out menus.

---
*PR created automatically by Jules for task [8062062850328316263](https://jules.google.com/task/8062062850328316263) started by @2fst4u*