### PR TITLE
📚 Archivist: Update PRIVACY.md to include language local storage key

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -177,3 +177,7 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 
 **Learning:** `AGENTS.md` documented the Rate Limiter as "1000 req/min", which was ambiguously worded and failed to specify that the limit applies *per IP* and *per isolate*. The implementation in `src/worker.js` instantiates the `RateLimiter` per isolate and keys by `CF-Connecting-IP`.
 **Action:** Updated `AGENTS.md` to explicitly state the limit is "1000 req/min per IP per isolate" to avoid confusion about global vs individual limits.
+
+## 2026-03-30 - Privacy Policy Drift for Local Storage Keys
+**Learning:** When adding new features like Internationalization (i18n) that persist user preferences (e.g., the `language` key via `SafeStorage`), the `PRIVACY.md` documentation detailing local storage usage often drifts from the actual implementation.
+**Action:** Always verify `PRIVACY.md` when introducing new client-side storage keys to ensure transparency about data residing on the user's device.

--- a/public/PRIVACY.md
+++ b/public/PRIVACY.md
@@ -82,6 +82,7 @@ The application stores preference settings locally in your browser to remember y
 
 - **theme:** `light` or `dark`
 - **unit:** `metric` or `imperial`
+- **language:** your selected locale (e.g., `en-NZ`, `fr`)
 
 This data resides solely on your device and is never transmitted to our servers.
 

--- a/public/privacy/PRIVACY.en-NZ.md
+++ b/public/privacy/PRIVACY.en-NZ.md
@@ -79,6 +79,7 @@ Preference settings are stored locally in your browser:
 
 - **theme:** `light` or `dark`
 - **unit:** `metric` or `imperial`
+- **language:** your selected locale (e.g., `en-NZ`, `fr`)
 
 This data remains on your device and is not sent to our servers.
 


### PR DESCRIPTION
**Problem:** 
The application recently introduced internationalization (i18n), which persists user language preferences in local storage under the `language` key. However, the privacy policies (`PRIVACY.md` and `PRIVACY.en-NZ.md`) failed to list this new key in the "Local Storage" section, leading to documentation drift and incomplete disclosure of data stored on the user's device.

**Fix:** 
Added `- **language:** your selected locale (e.g., en-NZ, fr)` to the "Local Storage" sections of both `public/PRIVACY.md` and `public/privacy/PRIVACY.en-NZ.md`.

**Verification:** 
- Inspected the source files using `sed` to verify the precise heading locations and existing lists.
- Edited both policy files and verified the diff accurately appended the `language` entry.
- Ran the test suite (`pnpm install && pnpm test`) to ensure no side effects occurred. 
- Appended a journal entry in `.jules/archivist.md` to establish a learning and prevention mechanism regarding this drift.

**Scope:**
This PR exclusively modifies documentation (`public/PRIVACY.md`, `public/privacy/PRIVACY.en-NZ.md`, and `.jules/archivist.md`) and contains no application logic changes.

---
*PR created automatically by Jules for task [16581189091382046552](https://jules.google.com/task/16581189091382046552) started by @2fst4u*