### PR TITLE
📚 Archivist: Clarify Mapbox integration and config caching in architecture docs

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -203,3 +203,8 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 
 **Learning:** Internal endpoints like `/api/config` were implemented but missing from `AGENTS.md` and `src/worker.js` headers, leading to an incomplete API documentation.
 **Action:** When adding or modifying routes in `src/worker.js`, always update the API Endpoints table in `AGENTS.md` and the docstring in `src/worker.js`.
+
+## 2026-04-09 - Architecture Documentation Drift
+
+**Learning:** When core infrastructure components (like the primary map renderer or proxy endpoints) change, documentation in files like `AGENTS.md` and `README.md` often drift and fail to reflect the new architecture accurately (e.g., omitting Mapbox CDN from the proxied services list).
+**Action:** Always cross-reference architecture claims in documentation with the actual implementation (like `src/worker.js` and `_headers`) to ensure accuracy.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -33,7 +33,9 @@
 **Vulnerability:** Several critical client-side API requests (`F1API.js`, `MapManager.js`, `PrivacyModal.js`) used the `fetch` API without a timeout. This is a DoS or resiliency risk where an unresponsive backend or proxy could cause the application to hang indefinitely, blocking the main thread from completing critical initialization or UI updates.
 **Learning:** Even when the backend Cloudflare Worker has its own strict upstream timeouts configured, the client browser still needs local request timeouts because the network connection between the client and the worker proxy itself can stall or hang.
 **Prevention:** Always include `signal: AbortSignal.timeout(duration)` on all client-side external `fetch` calls to ensure the application fails securely and gracefully.
+
 ## 2025-02-28 - Validate localStorage inputs against DOM attribute injection
+
 **Vulnerability:** Application read the `theme` value directly from `localStorage` and injected it unconditionally into the `data-theme` attribute of the DOM root (`document.documentElement.setAttribute("data-theme", theme)`). While `setAttribute` inherently blocks traditional XSS, a malicious actor or cross-site scripting vulnerability could poison `localStorage`, injecting an unexpected attribute value that breaks the visual layout or sets up a CSS injection attack vector.
 **Learning:** Even within an SPA where user inputs are generally escaped, values retrieved from local browser storage (which could be modified by other scripts on the same origin or physical access) must be treated as untrusted user input.
 **Prevention:** Strictly validate `localStorage` values against expected enumerations (e.g., `"dark"` or `"light"`) before injecting them into the DOM.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,10 @@ Circuit Weather is a real-time F1 race circuit weather radar application. It dis
 | Jolpica F1 API  | Race schedule data (1-hour cache)                                | Proxied (Cached)     |
 | RainViewer      | Weather radar tiles (2-hour cache) and metadata (1-minute cache) | Proxied (Cached)     |
 | Open-Meteo      | Weather forecasts                                                | Direct (Client-side) |
-| Carto           | Map basemap tiles                                                | Direct (Client-side) |
+| Mapbox API      | Primary map basemap tiles and rendering                          | Direct (Client-side) |
+| Carto           | Fallback map basemap tiles                                       | Direct (Client-side) |
 | GitHub          | Track GeoJSON data (24-hour cache)                               | Proxied (Cached)     |
+| Mapbox CDN      | Map library assets (1-year cache)                                | Proxied (Cached)     |
 | Unpkg (Leaflet) | Map library assets (1-year cache)                                | Proxied (Cached)     |
 | Google Fonts    | Typography                                                       | Direct (Client-side) |
 | FlagCDN         | Country flags                                                    | Direct (Client-side) |
@@ -204,15 +206,15 @@ mode = "smart"
 
 ### API Endpoints
 
-| Endpoint        | Purpose                                                                              |
-| --------------- | ------------------------------------------------------------------------------------ |
-| `/api/f1/*`     | Proxies to Jolpica F1 API with 1-hour edge caching                                   |
-| `/api/radar`    | Proxies to RainViewer Maps API with 1-minute caching (initializes animation)         |
-| `/api/tiles/*`  | Proxies to RainViewer tile API with 2-hour edge caching (512px optimized)            |
-| `/api/track/*`  | Proxies to GitHub for GeoJSON track data with 24-hour caching                        |
-| `/api/assets/*` | Proxies to Leaflet and Mapbox assets with 1-year immutable caching (strict CSP)      |
-| `/api/health`   | System status check (connectivity to upstreams, version, env) with 60-second caching |
-| `/api/config`   | Securely provides client configuration (e.g., Mapbox token) to the frontend          |
+| Endpoint        | Purpose                                                                                          |
+| --------------- | ------------------------------------------------------------------------------------------------ |
+| `/api/f1/*`     | Proxies to Jolpica F1 API with 1-hour edge caching                                               |
+| `/api/radar`    | Proxies to RainViewer Maps API with 1-minute caching (initializes animation)                     |
+| `/api/tiles/*`  | Proxies to RainViewer tile API with 2-hour edge caching (512px optimized)                        |
+| `/api/track/*`  | Proxies to GitHub for GeoJSON track data with 24-hour caching                                    |
+| `/api/assets/*` | Proxies to Leaflet and Mapbox assets with 1-year immutable caching (strict CSP)                  |
+| `/api/health`   | System status check (connectivity to upstreams, version, env) with 60-second caching             |
+| `/api/config`   | Securely provides client configuration (e.g., Mapbox token) to the frontend with 24-hour caching |
 
 ---
 


### PR DESCRIPTION
💡 Problem: The architecture documentation in AGENTS.md had drifted after the migration to Mapbox. It omitted Mapbox API (Direct) and Mapbox CDN (Proxied) from the Third-Party Services table, did not clarify Carto was the fallback, and did not document the 24-hour cache for the `/api/config` endpoint.

🎯 Fix: Updated the Third-Party Services table in AGENTS.md to include Mapbox API and Mapbox CDN, and marked Carto as fallback. Added the `with 24-hour caching` detail to the `/api/config` entry in the API Endpoints table. Added an entry to `.jules/archivist.md` journaling the drift.

🧪 Verification: Verified changes in AGENTS.md using `sed`. Formatted using `prettier`. Tests ran and passed with `pnpm run test:coverage`.

🔎 Scope: This PR contains ONLY documentation changes.

---
*PR created automatically by Jules for task [12045397595641899830](https://jules.google.com/task/12045397595641899830) started by @2fst4u*