### PR TITLE
🧪 Spec: Add missing test branches for i18n apply logic

### DIFF
--- a/tests/i18n.test.js
+++ b/tests/i18n.test.js
@@ -116,4 +116,18 @@ describe('i18n', () => {
         document.removeEventListener('i18n:change', handler);
     });
 
+    it('handles invalid root or missing attributes gracefully in apply()', () => {
+        expect(() => i18n.apply(null)).not.toThrow();
+        expect(() => i18n.apply({})).not.toThrow();
+
+        document.body.innerHTML = '<label data-i18n="">Empty key</label>';
+        expect(() => i18n.apply()).not.toThrow();
+
+        document.body.innerHTML = '<button data-i18n-attr="">Empty rule</button>';
+        expect(() => i18n.apply()).not.toThrow();
+
+        document.body.innerHTML = '<button data-i18n-attr="aria-label:,:common.openMenu,invalidFormat">Bad Mapping</button>';
+        expect(() => i18n.apply()).not.toThrow();
+    });
+
 });


### PR DESCRIPTION
💡 What: Added missing branch tests for `i18n.apply()` in `tests/i18n.test.js` to handle invalid root parameters, empty `data-i18n` keys, and malformed `data-i18n-attr` mappings.
🎯 Why: These edge cases in `apply()` were missing coverage and represented unprotected application logic, leaving the codebase vulnerable to silent DOM errors if malformed templates were used.
📈 Maturity Impact: Increased branch coverage for `public/src/i18n/index.js` above the 85% project threshold.

---
*PR created automatically by Jules for task [7105602988617558455](https://jules.google.com/task/7105602988617558455) started by @2fst4u*