### PR TITLE
🧪 Spec: Add RangeCircles move optimization test

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -13,3 +13,8 @@
 **Action:** Updated `tests/track-layer.test.js` to mock `getLayer`, `addLayer`, `getSource`, `addSource`, and `removeLayer` to act as a proper stateful `Set` to prevent infinite loading recursion.
 
 ## 2026-04-09 - WeatherRadar Timer Logic\n**Learning:** The `WeatherRadar` implementation dynamically calculates the remaining time for rate limit toasts (using `Math.ceil((this.rateLimitResetTime - Date.now()) / 1000)`) rather than using a static timeout, which requires testing to accommodate fractional seconds or potential drift. Additionally, the `hideErrorTimer` debounces the removal of the toast to prevent flickering, and tests must assert its cancellation (using fake timers) when new errors are actively injected.\n**Action:** When testing UI timer components like `WeatherRadar`, explicitly use `vi.useFakeTimers()` to isolate debouncing behavior and verify that timers like `hideErrorTimer` are cleanly cancelled (e.g., set to null) upon state transitions, avoiding flaky real-time assertions.
+
+## 2026-04-11 - Mocking requestAnimationFrame Mapbox Move Events
+
+**Learning:** When testing Mapbox GL JS map 'move' event throttlers, stubbing `requestAnimationFrame` as a `setTimeout` alongside fake timers allows for testing asynchronous debouncing synchronously.
+**Action:** Implemented a new `Move Optimization` test within `tests/range-circles-logic.test.js` ensuring full branch coverage of the Mapbox `map.on('move', ...)` throttle logic.

--- a/tests/range-circles-logic.test.js
+++ b/tests/range-circles-logic.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Imports must be at top level
 import { RangeCircles } from '../public/src/map/RangeCircles.js';
@@ -372,6 +372,39 @@ describe('RangeCircles Logic (Mapbox GL JS)', () => {
         vi.clearAllMocks();
         rangeCircles = new RangeCircles(mapboxMock);
         rangeCircles.unit = 'metric';
+    });
+
+    describe('Move Optimization', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+            vi.stubGlobal('requestAnimationFrame', vi.fn((cb) => setTimeout(cb, 0)));
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('throttles map move events using requestAnimationFrame', () => {
+            rangeCircles.updateVisibility = vi.fn();
+
+            expect(mapboxMock.on).toHaveBeenCalledWith('move', expect.any(Function));
+
+            const moveHandler = mapboxMock.on.mock.calls.find(call => call[0] === 'move')[1];
+
+            // Trigger move multiple times synchronously
+            moveHandler();
+            moveHandler();
+            moveHandler();
+
+            // Initially, updateVisibility shouldn't be called yet
+            expect(rangeCircles.updateVisibility).not.toHaveBeenCalled();
+
+            // Fast forward timers to let requestAnimationFrame (mocked as setTimeout) execute
+            vi.runAllTimers();
+
+            // updateVisibility should only be called once due to throttling
+            expect(rangeCircles.updateVisibility).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe('Drawing & Clearing Mapbox Layers', () => {


### PR DESCRIPTION
What: Added missing test coverage for `requestAnimationFrame` debouncing on mapbox 'move' events in `RangeCircles.js`.
Why: To ensure the throttling correctly handles synchronous burst events on map movement without missing the eventual UI redraw callback, maintaining robust safety nets against regressions.
Maturity Impact: Added coverage testing boundary edge cases, reinforcing existing coverage limits without altering baseline thresholds.

---
*PR created automatically by Jules for task [12666299975778329783](https://jules.google.com/task/12666299975778329783) started by @2fst4u*