### PR TITLE
🔭 Scout: Fix broken heading hierarchy in error state

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -151,7 +151,8 @@ export class CircuitWeatherApp {
                             <line x1="12" y1="16" x2="12.01" y2="16"></line>
                         </svg>
                     </div>
-                    <h3 data-i18n="errors.connectionFailed">${escapeHtml(i18n.t('errors.connectionFailed'))}</h3>
+                    <!-- Scout: Upgraded from h3 to h2 to fix broken heading hierarchy. When connection fails, this replaces the sidebar content which sits directly under the h1 sidebar-header. -->
+                    <h2 data-i18n="errors.connectionFailed">${escapeHtml(i18n.t('errors.connectionFailed'))}</h2>
                     <p>${escapeHtml(message)}</p>
                     <button class="retry-btn" type="button" data-i18n="common.retry" data-i18n-attr="aria-label:errors.retryConnection" aria-label="${escapeHtml(i18n.t('errors.retryConnection'))}">${escapeHtml(i18n.t('common.retry'))}</button>
                 </div>


### PR DESCRIPTION
**💡 What:** Upgraded the dynamically injected connection error heading from `<h3>` to `<h2>` in `public/src/CircuitWeatherApp.js`.
**🎯 Why:** When the app encounters a connection failure on startup, it completely replaces the contents of `sidebar-content` (which normally contains `<h2>` sub-sections) with an error state. Because the error state used an `<h3>`, the document outline would jump straight from `<h1>Circuit Weather</h1>` to the `<h3>` error message.
**📊 Value:** Fixes a broken heading hierarchy, ensuring search engine crawlers and assistive technologies can properly understand the document structure even in fallback/error states.
**🔬 Measurement:** Trigger a network error (or check the DOM output of the `showErrorState` function) and verify the element `<h2 data-i18n="errors.connectionFailed">` is rendered.

---
*PR created automatically by Jules for task [17110942885813887523](https://jules.google.com/task/17110942885813887523) started by @2fst4u*