### PR TITLE
🧪 Spec: Add coverage for PrivacyModal missing elements and DOMParser fallback

### DIFF
--- a/tests/privacy-modal.test.js
+++ b/tests/privacy-modal.test.js
@@ -222,6 +222,23 @@ describe("PrivacyModal", () => {
       global.DOMParser = originalDOMParser;
     });
 
+    it("returns #unsafe-url if DOMParser throws an error", () => {
+      const originalDOMParser = global.DOMParser;
+      class ThrowingDOMParser {
+        parseFromString() {
+          throw new Error("Parse error");
+        }
+      }
+      global.DOMParser = ThrowingDOMParser;
+
+      const md = "[link](https://example.com/safe)";
+      const html = modal.parseMarkdown(md);
+      expect(extractHref(html)).toBe("#unsafe-url");
+
+      // Restore original mock
+      global.DOMParser = originalDOMParser;
+    });
+
     it("fails securely and blocks URL if DOMParser returns null doc", () => {
       const originalDOMParser = global.DOMParser;
       class NullDocDOMParser {
@@ -488,6 +505,30 @@ describe("PrivacyModal", () => {
       expect(modal.triggerElement).toBeNull();
     });
 
+    it("handles missing content element when fetch fails", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      global.fetch.mockRejectedValue(new Error("Network error"));
+
+      modal.content = null;
+      await modal.open();
+
+      expect(modal.loaded).toBe(false);
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+
+    it("throws an error when no translation is available", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      global.fetch.mockResolvedValue({ ok: true, text: async () => "" });
+
+      await modal.open();
+
+      expect(modal.loaded).toBe(false);
+      expect(errorSpy).toHaveBeenCalledWith("Failed to load privacy policy:", expect.any(Error));
+      expect(modal.content.innerHTML).toContain("Failed to load privacy policy");
+      errorSpy.mockRestore();
+    });
+
     it("handles fetch errors gracefully", async () => {
       const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       global.fetch.mockRejectedValue(new Error("Network error"));
@@ -516,6 +557,11 @@ describe("PrivacyModal", () => {
         "/privacy/PRIVACY.en-US.md",
         "/PRIVACY.md",
       ]);
+    });
+
+    it("falls back to en-NZ for completely unknown locales", () => {
+      i18n.locale = "xx-YY";
+      expect(modal.resolvePrivacyLocale("xx-YY")).toBe("en-NZ");
     });
 
     it("normalises regional locales to supported translation files", () => {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -18,10 +18,10 @@ export default defineConfig({
       // Note: Branch coverage may vary slightly between local and CI environments
       // due to V8 engine differences. Thresholds are ratcheted to match CI results.
       thresholds: {
-        lines: 90,
-        functions: 90,
-        branches: 85,
-        statements: 90,
+        lines: 97,
+        functions: 93,
+        branches: 93,
+        statements: 97,
       },
       // Report formats: text for CI logs, lcov for future GitHub integration
       reporter: ['text', 'text-summary'],


### PR DESCRIPTION
### 💡 What:
- Added `tests/privacy-modal.test.js` cases to verify that `modal.content` gracefully handles missing elements during fetch errors without crashing the app.
- Added a test to verify `modal.content` gracefully throws a targeted error and sets the DOM string accordingly if an empty translation payload is served.
- Added a test to simulate `DOMParser` throwing an exception in `parseMarkdown`, returning the safe fallback string `#unsafe-url`.
- Added test coverage for `resolvePrivacyLocale` handling unknown locale inputs.
- Updated `vitest.config.js` to increase the minimum coverage thresholds to lock in the maturity.

### 🎯 Why:
- Previous tests missed corner cases like missing DOM element (`this.content`) assignments on `fetch` failures.
- `DOMParser` handling was exposed in `parseMarkdown` without adequate safety-net testing to guarantee that URL injection via parsing exceptions could not occur.
- Maturing testing coverage sets an improved floor for the project overall.

### 📈 Maturity Impact:
- Increased `lines` threshold from 90% to 97%.
- Increased `functions` threshold from 90% to 93%.
- Increased `branches` threshold from 85% to 93%.
- Increased `statements` threshold from 90% to 97%.

---
*PR created automatically by Jules for task [3572917173251601863](https://jules.google.com/task/3572917173251601863) started by @2fst4u*