### PR TITLE
🧪 Spec: Add coverage for WeatherRadar updateTheme lifecycle

### DIFF
--- a/tests/weather-radar-lifecycle.test.js
+++ b/tests/weather-radar-lifecycle.test.js
@@ -598,6 +598,52 @@ describe('WeatherRadar Lifecycle & Playback', () => {
     });
 
     describe('Additional Coverage', () => {
+        it('updateTheme re-adds layers if they were on the map or visible', () => {
+            // Simulate Mapbox environment by not having hasLayer method
+            radar.map.hasLayer = undefined;
+            radar.map.getLayer = vi.fn((id) => id === 'layer-on-map' ? {} : null);
+
+            const mockLayerOnMap = { id: 'layer-on-map', addTo: vi.fn(), setOpacity: vi.fn() };
+            const mockLayerNotOnMap = { id: 'layer-not-on-map', addTo: vi.fn(), setOpacity: vi.fn() };
+            const mockLayerVisible = { id: 'layer-visible', addTo: vi.fn(), setOpacity: vi.fn() };
+
+            // Set up 3 layers: index 0 is on map, index 1 is not, index 2 is visible
+            radar.layers = [ mockLayerOnMap, mockLayerNotOnMap, mockLayerVisible ];
+            radar.visibleLayerIndex = 2;
+
+            vi.spyOn(radar, 'getLayer').mockImplementation((index) => {
+                if (index === 0) return mockLayerOnMap;
+                if (index === 1) return mockLayerNotOnMap;
+                if (index === 2) return mockLayerVisible;
+            });
+
+            radar.updateTheme();
+
+            // Check that radar.layers were reset to null
+            expect(radar.layers).toEqual([null, null, null]);
+
+            // Check layer 0 (was on map)
+            expect(mockLayerOnMap.addTo).toHaveBeenCalledWith(radar.map);
+            expect(mockLayerOnMap.setOpacity).toHaveBeenCalledWith(0);
+
+            // Check layer 1 (not on map, not visible)
+            expect(mockLayerNotOnMap.addTo).not.toHaveBeenCalled();
+
+            // Check layer 2 (visible)
+            expect(mockLayerVisible.addTo).toHaveBeenCalledWith(radar.map);
+            // In tests we mock CONFIG but there's no import here. We'll verify setOpacity was called.
+            expect(mockLayerVisible.setOpacity).toHaveBeenCalled();
+        });
+
+        it('updateTheme returns early if using Leaflet (hasLayer exists)', () => {
+            radar.map.hasLayer = vi.fn(); // Leaflet mock
+            radar.layers = [ { id: 'test' } ];
+
+            radar.updateTheme();
+
+            expect(radar.layers[0]).not.toBeNull();
+        });
+
         it('formatDuration calculates correctly for >1 days, >1 hours, >1 minutes', () => {
             const minutesInDay = 24 * 60;
             const minutesInHour = 60;


### PR DESCRIPTION
💡 What: Added two unit tests targeting the previously uncovered `updateTheme` method in `WeatherRadar`.
🎯 Why: To ensure that theme changes properly re-initialize and restore map layers, preventing regressions in Mapbox handling during visual mode switches.
📈 Maturity Impact: N/A - The current globally configured threshold of ~97% is already well above the required business standard (75-80%+). Following the "Spec" agent directives, I am not bumping the `vitest.config.js` thresholds further just to chase a 100% score, treating the current high threshold as a strict guardrail.

---
*PR created automatically by Jules for task [14249837982144924854](https://jules.google.com/task/14249837982144924854) started by @2fst4u*