### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix missing fetch timeouts

### DIFF
--- a/public/src/map/TrackLayer.js
+++ b/public/src/map/TrackLayer.js
@@ -148,7 +148,9 @@ export class TrackLayer {
                 url = `${CONFIG.trackApi}/${geoJsonId}.geojson`;
             }
 
-            const response = await fetch(url);
+            const response = await fetch(url, {
+                signal: AbortSignal.timeout(5000)
+            });
 
             if (!response.ok) throw new Error(`Track fetch failed: ${response.status}`);
 

--- a/public/src/map/WeatherRadar.js
+++ b/public/src/map/WeatherRadar.js
@@ -149,7 +149,9 @@ export class WeatherRadar {
 
     async getFramesFromApi() {
         try {
-            const response = await fetch(CONFIG.rainViewerApi);
+            const response = await fetch(CONFIG.rainViewerApi, {
+                signal: AbortSignal.timeout(5000)
+            });
             if (!response.ok) {
                 console.error(`RainViewer API error: ${response.status}`);
                 return [];
@@ -513,7 +515,7 @@ export class WeatherRadar {
         // Worker now passes through 429 status for this check
         const checkUrl = CONFIG.rainViewerApi;
 
-        fetch(checkUrl, { method: 'HEAD' })
+        fetch(checkUrl, { method: 'HEAD', signal: AbortSignal.timeout(5000) })
             .then(response => {
                 this.isCheckingStatus = false;
 

--- a/tests/track-layer.test.js
+++ b/tests/track-layer.test.js
@@ -153,7 +153,7 @@ describe('TrackLayer', () => {
 
         await trackLayer.loadTrack(circuitId);
 
-        expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining(geoJsonId));
+        expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining(geoJsonId), expect.objectContaining({ signal: expect.any(AbortSignal) }));
         expect(L.geoJSON).toHaveBeenCalledWith(mockData, expect.any(Object));
         expect(layerMock.addTo).toHaveBeenCalledWith(mapMock);
         expect(layerMock.bringToBack).toHaveBeenCalled();
@@ -238,7 +238,7 @@ describe('TrackLayer', () => {
         await trackLayer.loadTrack(circuitId);
 
         // Should include .geojson extension in GitHub mode
-        expect(fetchMock).toHaveBeenCalledWith(`${CONFIG.trackApi}/${geoJsonId}.geojson`);
+        expect(fetchMock).toHaveBeenCalledWith(`${CONFIG.trackApi}/${geoJsonId}.geojson`, expect.objectContaining({ signal: expect.any(AbortSignal) }));
 
         // Restore
         // @ts-ignore


### PR DESCRIPTION
**🚨 Severity:** HIGH
**💡 Vulnerability:** Missing timeouts on critical client-side API requests (`fetch` API).
**🎯 Impact:** A DoS or resiliency risk where an unresponsive backend or proxy could cause the application to hang indefinitely, blocking the main thread from completing critical initialization or UI updates.
**🔧 Fix:** Added `AbortSignal.timeout(5000)` to `fetch` calls in `public/src/map/WeatherRadar.js` and `public/src/map/TrackLayer.js`. Updated corresponding unit tests.
**✅ Verification:** Verified with `pnpm test`.

*(Adheres to Sentinel policy identified in `.jules/sentinel.md` entry: 2026-04-07 - [Missing Timeouts on Client-Side External API Calls])*

---
*PR created automatically by Jules for task [8425825971298011343](https://jules.google.com/task/8425825971298011343) started by @2fst4u*