### PR TITLE
🧪 Spec: Add MapManager, MapWeatherWidget, and TrackLayer tests

### DIFF
--- a/tests/map-manager.test.js
+++ b/tests/map-manager.test.js
@@ -517,6 +517,32 @@ describe("MapManager", () => {
       });
     });
 
+    it("should handle language change event when isMapbox is true", () => {
+      mapManager.isMapbox = true;
+      vi.spyOn(mapManager, 'applyMapLanguage').mockImplementation(() => {});
+      vi.spyOn(mapManager, 'getMapboxLanguageCode').mockReturnValue('en');
+      mapManager.handleLanguageChange({ detail: { locale: 'en-US' } });
+      expect(mapManager.getMapboxLanguageCode).toHaveBeenCalledWith('en-US');
+      expect(mapManager.applyMapLanguage).toHaveBeenCalledWith('en');
+    });
+
+    it("should catch setLayoutProperty errors for slot-managed layers", async () => {
+      mapboxMapMock.getStyle.mockReturnValue({
+        layers: [
+          { id: 'layer1', type: 'symbol' },
+        ]
+      });
+      mapboxMapMock.getLayoutProperty.mockReturnValue(['get', 'name']);
+      mapboxMapMock.setLayoutProperty.mockImplementation(() => {
+        throw new Error('slot-managed');
+      });
+      mapManager.isMapbox = true;
+      mapManager.map = mapboxMapMock;
+      expect(() => {
+        mapManager.applyMapLanguage('en');
+      }).not.toThrow();
+    });
+
     it("should log error if Mapbox runtime error occurs after load", async () => {
       const mockZoomIn = createMockElement('zoomIn');
       const mockZoomOut = createMockElement('zoomOut');

--- a/tests/map-weather-widget.test.js
+++ b/tests/map-weather-widget.test.js
@@ -175,6 +175,10 @@ describe('MapWeatherWidget', () => {
         expect(() => uninitializedWidget.update(null)).not.toThrow();
     });
 
+    it('should return top-right for Mapbox default position', () => {
+        expect(widget.getDefaultPosition()).toBe('top-right');
+    });
+
     it('should not throw if update called after onRemove', () => {
         widget.onRemove(mapMock);
         // Should return early

--- a/tests/track-layer.test.js
+++ b/tests/track-layer.test.js
@@ -385,6 +385,19 @@ describe('Mapbox Environment', () => {
         expect(mapboxMapMock.setPaintProperty).toHaveBeenCalledWith('track-layer-monaco', 'line-color', '#123456');
     });
 
+    it('should skip redundant style updates', () => {
+        trackLayer.currentCircuitId = 'monaco';
+        trackLayer.mapboxLayers.add('track-layer-monaco');
+        trackLayer.trackColor = '#123456';
+
+        trackLayer.updateStyle();
+        expect(mapboxMapMock.setPaintProperty).toHaveBeenCalledTimes(2);
+
+        // Call again with no zoom change or color change
+        trackLayer.updateStyle();
+        expect(mapboxMapMock.setPaintProperty).toHaveBeenCalledTimes(2);
+    });
+
     it('should trigger reload if layer is missing during updateStyle', () => {
         trackLayer.currentCircuitId = 'monaco';
         // Layer missing because we didn't add it to mapboxLayers


### PR DESCRIPTION
* **What:** Added tests to `MapManager.js`, `MapWeatherWidget.js`, and `TrackLayer.js` to cover edge cases and improve code coverage. Reverted the `vitest.config.js` change per code review feedback, as it violated the > 80% read-only threshold constraint.
* **Why:** These tests fortify critical Map-related components. For instance, testing `setLayoutProperty` error swallowing ensures robust fallback behavior for slot-managed Mapbox styles.
* **Maturity Impact:** Coverage thresholds kept read-only per rules (already safely above standard at > 93%). Tests independently improve coverage safety net.

---
*PR created automatically by Jules for task [11522436092736242304](https://jules.google.com/task/11522436092736242304) started by @2fst4u*