### PR TITLE
🔭 Scout: Fix heading hierarchy in noscript fallback

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -7,3 +7,8 @@
 
 **Learning:** Adding the `description` property to the dynamically injected `SportsEvent` JSON-LD schema (via `CircuitWeatherApp.js`) requires correctly reusing an existing localized description variable (`desc`) which is defined early in the `updatePageMetadata` method and interpolated using `i18n.t()`.
 **Action:** When injecting or expanding dynamic JSON-LD schemas in `updatePageMetadata`, carefully inspect the local variable scope (using tools like `sed` or `grep`) to reuse existing computed context strings (like `desc`, `title`, etc.) for metadata, ensuring rich SERP displays without duplicating localization logic or causing `ReferenceError`s.
+
+## 2025-04-01 - Managing multiple H1s across distinct DOM sections
+
+**Learning:** The `public/index.html` file employs separate DOM structures for desktop sidebars (`<aside class="sidebar">`), mobile headers (`<header class="mobile-header">`), and crawler fallbacks (`<noscript>`). When optimizing semantic HTML or heading hierarchies for SEO, carefully orchestrate updates across these distinct sections to avoid accidentally introducing duplicate root-level tags (like multiple `<h1>` elements) that could confuse search engines.
+**Action:** When modifying heading hierarchies for fallback or mobile content, always verify the global document context to maintain a strict, hierarchical outline (e.g., cascading from `<h2>` down) if an `<h1>` is already structurally necessary elsewhere in the SPA shell.

--- a/public/index.html
+++ b/public/index.html
@@ -389,12 +389,12 @@
                 <!-- Scout: Upgraded generic div to semantic article to explicitly declare the fallback content as an independent, self-contained composition for crawlers without JavaScript. -->
                 <article
                     style="padding: 2rem; max-width: 800px; margin: 0 auto; font-family: Inter, sans-serif; line-height: 1.6;">
-                    <!-- Scout: Upgraded fallback heading hierarchy to start with H1 and cascade to H2, ensuring proper document outline for crawlers that do not execute JavaScript. -->
-                    <h1>Circuit Weather — Live F1 Race Weather Radar &amp; Forecasts</h1>
+                    <!-- Scout: Upgraded fallback heading hierarchy to start with H2 and cascade to H3 to avoid multiple H1 tags on the page and maintain proper document outline for crawlers. -->
+                    <h2>Circuit Weather — Live F1 Race Weather Radar &amp; Forecasts</h2>
                     <p>Circuit Weather provides live weather radar overlays for motorsport race circuits worldwide.
                         Track precipitation, wind, and temperature conditions during race weekends to stay informed
                         about weather that could affect racing.</p>
-                    <h2>Features</h2>
+                    <h3>Features</h3>
                     <ul>
                         <li>Live weather radar with animated playback of the past 2 hours</li>
                         <li>Session-specific weather forecasts (temperature, rain probability, wind)</li>


### PR DESCRIPTION
💡 **What**: Upgraded the generic `<h1>` and `<h2>` elements inside the `<noscript>` fallback block to `<h2>` and `<h3>` respectively.
🎯 **Why**: The page already contains multiple `<h1>` elements (for the desktop sidebar and mobile header). The `<noscript>` block introduced yet another `<h1>` tag. Having multiple root-level `<h1>` tags on a single page breaks heading hierarchy conventions and can confuse search engine crawlers parsing the document.
📊 **Value**: Fixes heading hierarchy violations for better indexing and maintains proper document outline semantics.
🔬 **Measurement**: In `public/index.html`, verify that the `<noscript>` block correctly uses `<h2>Circuit Weather — Live F1 Race Weather Radar &amp; Forecasts</h2>` and `<h3>Features</h3>`. No `<h1>` tag will be found in the `<noscript>` block anymore.

---
*PR created automatically by Jules for task [765453042782113086](https://jules.google.com/task/765453042782113086) started by @2fst4u*