### PR TITLE
🧪 Spec: Add cache expiration & i18n edge-case tests

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -18,3 +18,7 @@
 
 **Learning:** When testing Mapbox GL JS map 'move' event throttlers, stubbing `requestAnimationFrame` as a `setTimeout` alongside fake timers allows for testing asynchronous debouncing synchronously.
 **Action:** Implemented a new `Move Optimization` test within `tests/range-circles-logic.test.js` ensuring full branch coverage of the Mapbox `map.on('move', ...)` throttle logic.
+
+## 2026-05-18 - WeatherClient sessionTime Mocking
+**Learning:** In `WeatherClient` tests, ensure the `sessionTime` parameter passed to methods like `getForecast()` is explicitly constructed as a valid `Date` object, not a generic string or default mock, because the internal caching logic directly invokes `sessionTime.getTime()` to generate cache keys.
+**Action:** Updated tests to explicitly pass `new Date()` as `sessionTime` to avoid `TypeError: sessionTime.getTime is not a function`.

--- a/tests/i18n.test.js
+++ b/tests/i18n.test.js
@@ -131,3 +131,33 @@ describe('i18n', () => {
     });
 
 });
+
+
+describe('i18n branch coverage edge cases', () => {
+    it('handles falsy locale in normalise via setLocale', () => {
+        i18n.setLocale(null);
+        expect(i18n.locale).toBe('en-NZ');
+    });
+
+    it('resolves aliased locales correctly', () => {
+        i18n.setLocale('pt-PT');
+        expect(i18n.locale).toBe('pt-BR');
+
+        i18n.setLocale('zh-TW');
+        expect(i18n.locale).toBe('zh-CN');
+    });
+
+    it('returns the key if translation is missing', () => {
+        expect(i18n.t('missing.key')).toBe('missing.key');
+    });
+
+    it('returns the key if intermediate path is missing', () => {
+        expect(i18n.t('missing.path.key')).toBe('missing.path.key');
+    });
+
+    it('returns empty string if interpolation parameter is missing', () => {
+        i18n.setLocale('en-NZ');
+        const result = i18n.t('forecast.availableFrom');
+        expect(result).toBe('Forecast available from ');
+    });
+});

--- a/tests/weather-client.test.js
+++ b/tests/weather-client.test.js
@@ -374,3 +374,73 @@ describe('WeatherClient', () => {
         });
     });
 });
+
+describe('WeatherClient cache edge cases', () => {
+    let client;
+    beforeEach(() => {
+        client = new WeatherClient();
+    });
+
+    it('evicts the oldest cache entry when exceeding maxCacheSize', async () => {
+        const sessionTime = new Date();
+        const rLat = Number(51.5).toFixed(2);
+        const rLon = Number(-0.1).toFixed(2);
+        const cacheKey = `${rLat},${rLon},${sessionTime.getTime()}`;
+
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                current: { temp: 20 },
+                current_units: { temp: 'C' },
+                hourly: {
+                    time: [Math.floor(sessionTime.getTime() / 1000)],
+                    temperature_2m: [20],
+                    relative_humidity_2m: [50],
+                    precipitation_probability: [0],
+                    wind_speed_10m: [10],
+                    wind_direction_10m: [180],
+                    weather_code: [0]
+                }
+            })
+        });
+
+        for (let i = 0; i < client.maxCacheSize; i++) {
+            client.cache.set(`old-key-${i}`, { timestamp: Date.now(), data: {} });
+        }
+
+        await client.getForecast(51.5, -0.1, sessionTime);
+
+        expect(client.cache.size).toBe(client.maxCacheSize);
+        expect(client.cache.has('old-key-0')).toBe(false);
+        expect(client.cache.has(cacheKey)).toBe(true);
+    });
+
+    it('deletes cache entry when entry timestamp is older than TTL', async () => {
+        const sessionTime = new Date();
+        const rLat = Number(51.5).toFixed(2);
+        const rLon = Number(-0.1).toFixed(2);
+        const cacheKey = `${rLat},${rLon},${sessionTime.getTime()}`;
+
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                current: { temp: 20 },
+                current_units: { temp: 'C' },
+                hourly: {
+                    time: [Math.floor(sessionTime.getTime() / 1000)],
+                    temperature_2m: [20],
+                    relative_humidity_2m: [50],
+                    precipitation_probability: [0],
+                    wind_speed_10m: [10],
+                    wind_direction_10m: [180],
+                    weather_code: [0]
+                }
+            })
+        });
+
+        const past = Date.now() - (client.cacheTTL + 1000);
+        client.cache.set(cacheKey, { timestamp: past, data: {} });
+
+        await client.getForecast(51.5, -0.1, sessionTime);
+    });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -19,8 +19,8 @@ export default defineConfig({
       // due to V8 engine differences. Thresholds are ratcheted to match CI results.
       thresholds: {
         lines: 97,
-        functions: 93,
-        branches: 93,
+        functions: 94,
+        branches: 94,
         statements: 97,
       },
       // Report formats: text for CI logs, lcov for future GitHub integration


### PR DESCRIPTION
💡 **What**: Added specific edge-case unit tests to `i18n.test.js` and `weather-client.test.js` to ensure critical logic branches are covered. Bumped coverage thresholds in `vitest.config.js`.
🎯 **Why**: Identified missing test coverage via vitest coverage output for both `i18n` locale fallbacks and `WeatherClient`'s client-side LRU cache eviction mechanism. Filling these ensures robust behavior around limit-handling and localization anomalies.
📈 **Maturity Impact**: Bumped globally configured coverage threshold for branches and functions to 94% to lock in the newly established progress.

---
*PR created automatically by Jules for task [9579929459736021990](https://jules.google.com/task/9579929459736021990) started by @2fst4u*