### PR TITLE
🔭 Scout: Add GeoCoordinates to SportsEvent JSON-LD schema

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -613,7 +613,7 @@ export class CircuitWeatherApp {
                 "image": "https://circuit-weather.racing/icon-512.png",
                 "location": {
                     "@type": "Place",
-                    "name": this.selectedRace.circuit ? this.selectedRace.circuit.circuitName : this.selectedRace.location.country,
+                    "name": this.selectedRace.circuit ? this.selectedRace.circuit.circuitName : (this.selectedRace.location ? this.selectedRace.location.country : ""),
                     "address": {
                         "@type": "PostalAddress",
                         "addressCountry": this.selectedRace.location ? this.selectedRace.location.country : ""

--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -617,6 +617,13 @@ export class CircuitWeatherApp {
                     "address": {
                         "@type": "PostalAddress",
                         "addressCountry": this.selectedRace.location ? this.selectedRace.location.country : ""
+                    },
+                    // Scout: Injected precise GeoCoordinates into the Place schema.
+                    // Value: Helps search engines exactly geolocate the event for better local search relevance and map integrations.
+                    "geo": {
+                        "@type": "GeoCoordinates",
+                        "latitude": this.selectedRace.location ? this.selectedRace.location.lat : "",
+                        "longitude": this.selectedRace.location ? this.selectedRace.location.long : ""
                     }
                 }
             };

--- a/tests/seo.test.js
+++ b/tests/seo.test.js
@@ -264,4 +264,26 @@ describe('SEO Title Updates', () => {
 
         expect(removeSpy).toHaveBeenCalledWith(script);
     });
+
+    it('should safely handle missing location object in JSON-LD generation', async () => {
+        app.races.push({
+            round: '2',
+            name: 'Saudi Arabian Grand Prix',
+            sessions: [
+                { id: 'qualifying', name: 'Qualifying', date: '2024-03-08', time: '17:00:00Z' }
+            ],
+            // Deliberately missing location object
+        });
+
+        app.selectRound('2');
+        await app.selectSession('qualifying');
+
+        const script = document.getElementById('dynamic-json-ld');
+        expect(script).toBeDefined();
+
+        const schema = JSON.parse(script.textContent);
+        expect(schema.location.address.addressCountry).toBe('');
+        expect(schema.location.geo.latitude).toBe('');
+        expect(schema.location.geo.longitude).toBe('');
+    });
 });


### PR DESCRIPTION
💡 What: Added a `geo` property to the `SportsEvent` schema containing the exact latitude and longitude of the circuit location.
🎯 Why: Search engines rely on precise geographical coordinates within the `Place` object for local search and maps relevance. Currently, the schema relies solely on the track name and country, which might be ambiguous.
📊 Value: Improves local and map-based rich snippets in SERP by explicitly associating the event with its exact physical coordinates.
🔬 Measurement: Run the application, select a session, inspect the DOM for the script tag `#dynamic-json-ld`, and verify it contains the `geo` property with correct lat/long coordinates.

---
*PR created automatically by Jules for task [16720600650412831260](https://jules.google.com/task/16720600650412831260) started by @2fst4u*