### PR TITLE
🧹 Sweep: Remove unused getLocaleMeta function

### DIFF
--- a/public/src/utils/locale.js
+++ b/public/src/utils/locale.js
@@ -1,6 +1,6 @@
 const IMPERIAL_REGIONS = new Set(['US', 'LR', 'MM']);
 
-function parseLocale(locale) {
+export function parseLocale(locale) {
     if (!locale || typeof locale !== 'string') {
         return { language: 'en', region: 'NZ' };
     }
@@ -32,11 +32,7 @@ export function getUserLocale() {
     return locale || 'en-NZ';
 }
 
-export function getLocaleMeta(locale = getUserLocale()) {
-    return parseLocale(locale);
-}
-
 export function usesImperialUnits(locale = getUserLocale()) {
-    const { region } = getLocaleMeta(locale);
+    const { region } = parseLocale(locale);
     return IMPERIAL_REGIONS.has(region);
 }

--- a/tests/locale-utils.test.js
+++ b/tests/locale-utils.test.js
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { beforeEach, describe, expect, it } from 'vitest';
-import { getLocaleMeta, getUserLocale, usesImperialUnits } from '../public/src/utils/locale.js';
+import { parseLocale, getUserLocale, usesImperialUnits } from '../public/src/utils/locale.js';
 import { i18n } from '../public/src/i18n/index.js';
 
 describe('Locale helpers', () => {
@@ -18,8 +18,8 @@ describe('Locale helpers', () => {
     });
 
     it('parses language and region from locale strings', () => {
-        expect(getLocaleMeta('en-US')).toEqual({ language: 'en', region: 'US' });
-        expect(getLocaleMeta('en_NZ')).toEqual({ language: 'en', region: 'NZ' });
+        expect(parseLocale('en-US')).toEqual({ language: 'en', region: 'US' });
+        expect(parseLocale('en_NZ')).toEqual({ language: 'en', region: 'NZ' });
     });
 
     it('detects imperial unit regions correctly', () => {
@@ -60,16 +60,16 @@ describe('Locale helpers', () => {
 
 
     it('handles invalid locale types in parseLocale', () => {
-        expect(getLocaleMeta(null)).toEqual({ language: 'en', region: 'NZ' });
-        expect(getLocaleMeta(123)).toEqual({ language: 'en', region: 'NZ' });
+        expect(parseLocale(null)).toEqual({ language: 'en', region: 'NZ' });
+        expect(parseLocale(123)).toEqual({ language: 'en', region: 'NZ' });
     });
 
     it('handles cases where Intl.Locale fails or returns missing data', () => {
         // Fallback catch block handles non-standard but string formats
-        expect(getLocaleMeta('english')).toEqual({ language: 'english', region: '' });
-        expect(getLocaleMeta('-')).toEqual({ language: 'en', region: '' });
-        expect(getLocaleMeta('en-')).toEqual({ language: 'en', region: '' });
-        expect(getLocaleMeta('-US')).toEqual({ language: 'en', region: 'US' });
+        expect(parseLocale('english')).toEqual({ language: 'english', region: '' });
+        expect(parseLocale('-')).toEqual({ language: 'en', region: '' });
+        expect(parseLocale('en-')).toEqual({ language: 'en', region: '' });
+        expect(parseLocale('-US')).toEqual({ language: 'en', region: 'US' });
 
         // Mock Intl.Locale returning empty language to hit branch 11
         const originalIntlLocale = globalThis.Intl.Locale;
@@ -80,7 +80,7 @@ describe('Locale helpers', () => {
                     this.region = 'NZ';
                 }
             };
-            expect(getLocaleMeta('mock')).toEqual({ language: 'en', region: 'NZ' });
+            expect(parseLocale('mock')).toEqual({ language: 'en', region: 'NZ' });
         } finally {
             globalThis.Intl.Locale = originalIntlLocale;
         }


### PR DESCRIPTION
💡 **What**:
Removed the exported `getLocaleMeta` function from `public/src/utils/locale.js`. Exported the internal `parseLocale` function directly instead. Updated `usesImperialUnits` in the same file to call `parseLocale` directly, and updated `tests/locale-utils.test.js` to import and test `parseLocale` instead of `getLocaleMeta`.

🎯 **Why**:
`getLocaleMeta` was an unnecessary and mostly unused wrapper function that simply called `parseLocale` and returned its result without modification. It was not imported anywhere else in the application. Calling `parseLocale` directly removes a redundant layer of abstraction and keeps the codebase leaner.

🔬 **Verification**:
Ran `grep -rn "getLocaleMeta" tests/ public/ src/` across the repository. The only instances found were in the definition file (`public/src/utils/locale.js`) and its corresponding unit test (`tests/locale-utils.test.js`). 

To verify nothing was broken, the full test suite was run (`pnpm run test`) and test coverage checked (`pnpm run test:coverage`), both passing perfectly with coverage maintained.

---
*PR created automatically by Jules for task [7395639806321741332](https://jules.google.com/task/7395639806321741332) started by @2fst4u*