### PR TITLE
🎨 Palette: Add smooth transitions to footer links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -98,3 +98,6 @@ ors (LIVE, NEXT) to the visible label, rather than relying on external badges th
 
 **Learning:** When icon-only buttons (like a hamburger menu or sidebar toggle) change their `aria-label` dynamically to reflect state changes (e.g., from 'Open menu' to 'Close menu'), relying only on `aria-label` leaves visual users without an updated tooltip on hover.
 **Action:** Always ensure the `title` attribute is updated synchronously alongside the `aria-label` when the action verb of an icon button changes.
+## 2024-04-19 - Smooth Link Transitions
+**Learning:** The `.link-button` and `.sidebar-footer a` elements lacked a hover/focus transition out-of-the-box, making color changes feel abrupt.
+**Action:** Always verify if non-primary interactive elements (like footer links or text-only buttons) are utilizing the design system's established `var(--transition-fast)` for hover/focus state changes to maintain a polished, cohesive feel.

--- a/public/styles.css
+++ b/public/styles.css
@@ -573,6 +573,7 @@ body {
 .sidebar-footer a {
     color: var(--color-text-secondary);
     text-decoration: none;
+    transition: color var(--transition-fast);
 }
 
 .sidebar-footer a:hover {
@@ -587,6 +588,7 @@ body {
     cursor: pointer;
     color: var(--color-text-secondary);
     text-decoration: none;
+    transition: color var(--transition-fast);
 }
 
 .link-button:hover {


### PR DESCRIPTION
💡 What: Added CSS color transitions (`var(--transition-fast)`) to `.link-button` and `.sidebar-footer a` elements.
🎯 Why: Prevented abrupt color changes on hover/focus, improving the overall interactive polish and consistency with the rest of the application's components.
📸 Before/After: Hovering the language or privacy links now fades in smoothly.
♿ Accessibility: N/A - purely a visual polish enhancement.

---
*PR created automatically by Jules for task [10783452110999739386](https://jules.google.com/task/10783452110999739386) started by @2fst4u*