### PR TITLE
🔭 Scout: Downgrade mobile header H1 to H2 to fix heading hierarchy

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -279,8 +279,8 @@
                     </svg>
                 </button>
                 <div class="mobile-header-brand">
-                    <!-- Mobile H1 for SEO -->
-                    <h1 class="header-title">Circuit Weather</h1>
+                    <!-- Scout: Downgraded mobile header H1 to H2 to avoid duplicate H1 tags, maintaining a strict, hierarchical document outline for search engines. -->
+                    <h2 class="header-title">Circuit Weather</h2>
                     <span class="header-badge">
                         <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
                             <path fill-rule="evenodd"


### PR DESCRIPTION
💡 **What:** Changed `<h1 class="header-title">Circuit Weather</h1>` to `<h2 class="header-title">Circuit Weather</h2>` in the mobile header within `public/index.html`.
🎯 **Why:** The application previously rendered two `h1` elements on the page (one in the desktop sidebar and one in the mobile header). This violated heading hierarchy best practices by introducing multiple root-level tags.
📊 **Value:** Ensures a strict, single-H1 document outline (cascading from H2 down), making the page structure clearer and more understandable for search engine crawlers.
🔬 **Measurement:** Verify the change by inspecting the DOM or using `grep -rn "Circuit Weather" public/index.html | grep "<h"`. The output should show the mobile header using `<h2>` and the sidebar using `<h1>`.

---
*PR created automatically by Jules for task [10330381152964279112](https://jules.google.com/task/10330381152964279112) started by @2fst4u*