### PR TITLE
🌍 Globe: Extract translation for "Hourly forecast" aria-label

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -201,7 +201,7 @@
                                 </div>
                             </dl>
                             <div class="weather-timeline" id="weatherTimeline" tabindex="0" role="region"
-                                aria-label="Hourly forecast">
+                                aria-label="Hourly forecast" data-i18n-attr="aria-label:forecast.hourlyForecast">
                                 <ol class="weather-timeline-list">
                                     <!-- Timeline items injected here -->
                                 </ol>


### PR DESCRIPTION
What: Extracted the hardcoded `aria-label="Hourly forecast"` attribute in `public/index.html` by wrapping it with `data-i18n-attr="aria-label:forecast.hourlyForecast"`.
Why: The string was hardcoded and not being translated for international users, despite the corresponding key `forecast.hourlyForecast` already existing in the translation dictionary files.

---
*PR created automatically by Jules for task [4300463191455548704](https://jules.google.com/task/4300463191455548704) started by @2fst4u*