### PR TITLE
🔭 Scout: Remove role="button" from native anchor tag

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -12,3 +12,8 @@
 
 **Learning:** The `public/index.html` file employs separate DOM structures for desktop sidebars (`<aside class="sidebar">`), mobile headers (`<header class="mobile-header">`), and crawler fallbacks (`<noscript>`). When optimizing semantic HTML or heading hierarchies for SEO, carefully orchestrate updates across these distinct sections to avoid accidentally introducing duplicate root-level tags (like multiple `<h1>` elements) that could confuse search engines.
 **Action:** When modifying heading hierarchies for fallback or mobile content, always verify the global document context to maintain a strict, hierarchical outline (e.g., cascading from `<h2>` down) if an `<h1>` is already structurally necessary elsewhere in the SPA shell.
+
+## 2025-04-24 - Role="button" on native anchors
+
+**Learning:** Memory explicitly states that native `<a href="...">` anchor tags should not use `role="button"` as it overrides their semantic identity, causing crawlers to treat them as widgets rather than navigational paths.
+**Action:** Always scan for and remove `role="button"` from native `<a>` tags with `href` attributes, but ensure existing CSS classes (like `.link-button`) are retained so visual layout remains completely unaffected.

--- a/public/index.html
+++ b/public/index.html
@@ -245,8 +245,8 @@
                     <div id="languageMenu" class="language-menu" role="menu"></div>
                 </div>
                 <span>•</span>
-                <!-- Scout: Converted privacy button to an anchor tag with href for crawler discoverability -->
-                <a href="/PRIVACY.md" id="privacyLink" class="link-button" role="button" data-i18n="privacy.link">Privacy</a>
+                <!-- Scout: Converted privacy button to an anchor tag with href for crawler discoverability. Removed role="button" so search engines treat it as a followable navigational path, not an interactive widget. -->
+                <a href="/PRIVACY.md" id="privacyLink" class="link-button" data-i18n="privacy.link">Privacy</a>
                 <span>•</span>
                 <!-- Scout: Added title attribute to external link to provide search engines with more context about the destination -->
                 <a href="https://github.com/circuit-weather/circuit-weather" target="_blank" rel="noopener noreferrer"


### PR DESCRIPTION
💡 **What**: Removed the `role="button"` attribute from the Privacy Policy anchor tag (`<a>`) in `public/index.html`.
🎯 **Why**: Using `role="button"` on a native `<a href="...">` anchor tag overrides its semantic identity. This causes search engine crawlers and screen readers to treat the link as an interactive widget (which cannot be "followed") rather than a standard navigational path.
📊 **Value**: Enhances SEO discoverability by allowing crawlers to natively follow the link to the Privacy Policy while maintaining proper accessibility semantics.
🔬 **Measurement**: Inspect the DOM element `#privacyLink` to verify that `role="button"` has been removed and that it acts as a standard navigational link.

---
*PR created automatically by Jules for task [4010896807942197255](https://jules.google.com/task/4010896807942197255) started by @2fst4u*