### PR TITLE
🌍 Globe: Extract translation for radar change playback speed button

### DIFF
--- a/.jules/globe.md
+++ b/.jules/globe.md
@@ -1,0 +1,3 @@
+## 2024-04-24 - HTML data-i18n-attr for dynamically updated attributes
+**Learning:** Even if an element's attribute (like an `aria-label` or `title`) is dynamically updated by a JavaScript component after load (e.g. `WeatherRadar.js` updating playback speeds), the initial HTML markup must still use `data-i18n-attr` to localize the initial state. This ensures screen readers and crawlers see localized strings before the JS executes.
+**Action:** When extracting hardcoded strings from HTML, check if they represent an initial state for a dynamically updated attribute. If so, create a dedicated base translation key for that initial state and use `data-i18n-attr` to bind it.

--- a/public/index.html
+++ b/public/index.html
@@ -333,7 +333,7 @@
                     <div class="radar-relative" id="radarRelative"></div>
                 </div>
                 <button class="radar-speed-btn" id="radarSpeedBtn" aria-label="Change playback speed"
-                    title="Playback speed">
+                    title="Playback speed" data-i18n-attr="aria-label:radar.changePlaybackSpeed,title:radar.changePlaybackSpeed">
                     <span id="radarSpeedLabel">1x</span>
                 </button>
 

--- a/public/src/i18n/locales/de.js
+++ b/public/src/i18n/locales/de.js
@@ -20,7 +20,7 @@ export const de = {
     },
     radar: {
         play: 'Radar abspielen', pause: 'Radar pausieren', playTitle: 'Abspielen (Leertaste)', pauseTitle: 'Pause (Leertaste)',
-        playbackSpeed: 'Wiedergabegeschwindigkeit: {{speed}}', sessionStart: 'Session-Start', beforeSession: '{{duration}} vor der Session',
+        changePlaybackSpeed: 'Wiedergabegeschwindigkeit ändern', playbackSpeed: 'Wiedergabegeschwindigkeit: {{speed}}', sessionStart: 'Session-Start', beforeSession: '{{duration}} vor der Session',
         afterSession: '{{duration}} nach der Session', forecast: 'Prognose', live: 'Live', liveAria: 'Live-Radar',
         minutesAgo: 'Vor {{count}} Min', minutesAgoPlural: 'Vor {{count}} Min', connectionInstability: 'Verbindungsinstabilitat',
         serviceError: 'Dienstfehler', highTraffic: 'Hohe Auslastung', rateLimitExceeded: 'Ratenlimit uberschritten. Kurz pausiert.',

--- a/public/src/i18n/locales/en.js
+++ b/public/src/i18n/locales/en.js
@@ -55,6 +55,7 @@ export const en = {
         pause: 'Pause radar animation',
         playTitle: 'Play (Space)',
         pauseTitle: 'Pause (Space)',
+        changePlaybackSpeed: 'Change playback speed',
         playbackSpeed: 'Playback speed: {{speed}}',
         sessionStart: 'Session start',
         beforeSession: '{{duration}} before session',

--- a/public/src/i18n/locales/es.js
+++ b/public/src/i18n/locales/es.js
@@ -21,7 +21,7 @@ export const es = {
     },
     radar: {
         play: 'Reproducir radar', pause: 'Pausar radar', playTitle: 'Reproducir (Espacio)', pauseTitle: 'Pausar (Espacio)',
-        playbackSpeed: 'Velocidad de reproduccion: {{speed}}', sessionStart: 'Inicio de sesion', beforeSession: '{{duration}} antes de la sesion',
+        changePlaybackSpeed: 'Cambiar velocidad de reproducción', playbackSpeed: 'Velocidad de reproduccion: {{speed}}', sessionStart: 'Inicio de sesion', beforeSession: '{{duration}} antes de la sesion',
         afterSession: '{{duration}} despues de la sesion', forecast: 'Pronostico', live: 'En vivo', liveAria: 'Radar en vivo',
         minutesAgo: 'Hace {{count}} min', minutesAgoPlural: 'Hace {{count}} mins', connectionInstability: 'Inestabilidad de conexion',
         serviceError: 'Error del servicio', highTraffic: 'Alto trafico', rateLimitExceeded: 'Limite de peticiones excedido. Pausa momentanea.',

--- a/public/src/i18n/locales/fr.js
+++ b/public/src/i18n/locales/fr.js
@@ -21,7 +21,7 @@ export const fr = {
     },
     radar: {
         play: 'Lire le radar', pause: 'Mettre le radar en pause', playTitle: 'Lire (Espace)', pauseTitle: 'Pause (Espace)',
-        playbackSpeed: 'Vitesse de lecture : {{speed}}', sessionStart: 'Debut de session', beforeSession: '{{duration}} avant la session',
+        changePlaybackSpeed: 'Modifier la vitesse de lecture', playbackSpeed: 'Vitesse de lecture : {{speed}}', sessionStart: 'Debut de session', beforeSession: '{{duration}} avant la session',
         afterSession: '{{duration}} apres la session', forecast: 'Previsions', live: 'En direct', liveAria: 'Radar en direct',
         minutesAgo: 'Il y a {{count}} min', minutesAgoPlural: 'Il y a {{count}} mins', connectionInstability: 'Connexion instable',
         serviceError: 'Erreur du service', highTraffic: 'Trafic eleve', rateLimitExceeded: 'Limite de requetes depassee. Pause momentanee.',

--- a/public/src/i18n/locales/hu.js
+++ b/public/src/i18n/locales/hu.js
@@ -55,7 +55,7 @@ export const hu = {
         pause: 'Radar animáció szüneteltetése',
         playTitle: 'Lejátszás (Szóköz)',
         pauseTitle: 'Szünet (Szóköz)',
-        playbackSpeed: 'Lejátszási sebesség: {{speed}}',
+        changePlaybackSpeed: 'Lejátszási sebesség módosítása', playbackSpeed: 'Lejátszási sebesség: {{speed}}',
         sessionStart: 'Esemény kezdete',
         beforeSession: '{{duration}} az esemény előtt',
         afterSession: '{{duration}} az esemény után',

--- a/public/src/i18n/locales/it.js
+++ b/public/src/i18n/locales/it.js
@@ -21,7 +21,7 @@ export const it = {
     },
     radar: {
         play: 'Avvia radar', pause: 'Pausa radar', playTitle: 'Avvia (Spazio)', pauseTitle: 'Pausa (Spazio)',
-        playbackSpeed: 'Velocita riproduzione: {{speed}}', sessionStart: 'Inizio sessione', beforeSession: '{{duration}} prima della sessione',
+        changePlaybackSpeed: 'Cambia velocità di riproduzione', playbackSpeed: 'Velocita riproduzione: {{speed}}', sessionStart: 'Inizio sessione', beforeSession: '{{duration}} prima della sessione',
         afterSession: '{{duration}} dopo la sessione', forecast: 'Previsioni', live: 'Live', liveAria: 'Radar live',
         minutesAgo: '{{count}} min fa', minutesAgoPlural: '{{count}} min fa', connectionInstability: 'Connessione instabile',
         serviceError: 'Errore servizio', highTraffic: 'Traffico elevato', rateLimitExceeded: 'Limite richieste superato. Pausa momentanea.',

--- a/public/src/i18n/locales/ja.js
+++ b/public/src/i18n/locales/ja.js
@@ -20,7 +20,7 @@ export const ja = {
     },
     radar: {
         play: 'レーダー再生', pause: 'レーダー一時停止', playTitle: '再生 (Space)', pauseTitle: '一時停止 (Space)',
-        playbackSpeed: '再生速度: {{speed}}', sessionStart: 'セッション開始', beforeSession: 'セッション {{duration}} 前', afterSession: 'セッション {{duration}} 後',
+        changePlaybackSpeed: '再生速度を変更', playbackSpeed: '再生速度: {{speed}}', sessionStart: 'セッション開始', beforeSession: 'セッション {{duration}} 前', afterSession: 'セッション {{duration}} 後',
         forecast: '予報', live: 'ライブ', liveAria: 'ライブレーダー', minutesAgo: '{{count}} 分前', minutesAgoPlural: '{{count}} 分前',
         connectionInstability: '接続が不安定です', serviceError: 'サービスエラー', highTraffic: 'アクセス集中',
         rateLimitExceeded: 'リクエスト上限を超えました。しばらく待機します。', retryingFailedTiles: '失敗したタイル {{count}} 件を再試行中...', radarStatus: 'レーダー状態: {{status}}',

--- a/public/src/i18n/locales/pt-BR.js
+++ b/public/src/i18n/locales/pt-BR.js
@@ -21,7 +21,7 @@ export const ptBR = {
     },
     radar: {
         play: 'Reproduzir radar', pause: 'Pausar radar', playTitle: 'Reproduzir (Espaco)', pauseTitle: 'Pausar (Espaco)',
-        playbackSpeed: 'Velocidade de reproducao: {{speed}}', sessionStart: 'Inicio da sessao', beforeSession: '{{duration}} antes da sessao',
+        changePlaybackSpeed: 'Alterar velocidade de reprodução', playbackSpeed: 'Velocidade de reproducao: {{speed}}', sessionStart: 'Inicio da sessao', beforeSession: '{{duration}} antes da sessao',
         afterSession: '{{duration}} depois da sessao', forecast: 'Previsao', live: 'Ao vivo', liveAria: 'Radar ao vivo',
         minutesAgo: '{{count}} min atras', minutesAgoPlural: '{{count}} mins atras', connectionInstability: 'Instabilidade de ligacao',
         serviceError: 'Erro de servico', highTraffic: 'Trafego elevado', rateLimitExceeded: 'Limite de pedidos excedido. Pausa momentanea.',

--- a/public/src/i18n/locales/zh-CN.js
+++ b/public/src/i18n/locales/zh-CN.js
@@ -20,7 +20,7 @@ export const zhCN = {
     },
     radar: {
         play: '播放雷达动画', pause: '暂停雷达动画', playTitle: '播放 (Space)', pauseTitle: '暂停 (Space)',
-        playbackSpeed: '播放速度: {{speed}}', sessionStart: '赛段开始', beforeSession: '距赛段开始前 {{duration}}', afterSession: '赛段开始后 {{duration}}',
+        changePlaybackSpeed: '更改播放速度', playbackSpeed: '播放速度: {{speed}}', sessionStart: '赛段开始', beforeSession: '距赛段开始前 {{duration}}', afterSession: '赛段开始后 {{duration}}',
         forecast: '预报', live: '实时', liveAria: '实时雷达', minutesAgo: '{{count}} 分钟前', minutesAgoPlural: '{{count}} 分钟前',
         connectionInstability: '连接不稳定', serviceError: '服务错误', highTraffic: '访问量高',
         rateLimitExceeded: '请求过于频繁，已暂时暂停。', retryingFailedTiles: '正在重试 {{count}} 个失败瓦片...', radarStatus: '雷达状态: {{status}}',


### PR DESCRIPTION
**What:** Extracted the hardcoded `aria-label` and `title` ("Change playback speed" / "Playback speed") from the `radar-speed-btn` element in `public/index.html` into a dedicated translation key `radar.changePlaybackSpeed`.
**Why:** While the button's attributes are updated dynamically by `WeatherRadar.js` later in the component lifecycle with a localized speed string, the initial hardcoded HTML attributes served as untranslated fallbacks that screen readers and crawlers would encounter before JS execution.
**Nuance:** Updated all 9 supported locale files with the correct initial fallback translation, utilizing the application's `data-i18n-attr` system to hook them onto the HTML element.

---
*PR created automatically by Jules for task [8304436425710275481](https://jules.google.com/task/8304436425710275481) started by @2fst4u*