### PR TITLE
📚 Archivist: Update privacy policy local storage keys

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -218,3 +218,8 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 
 **Learning:** `AGENTS.md` omitted "Language Toggle" from its "Core Features" section, even though the feature is fully implemented, documented in `PRIVACY.md`, and is an active feature.
 **Action:** Added the "Language Toggle" feature to `AGENTS.md` to ensure a single source of truth for application capabilities.
+## 2026-04-25 - Fixing Privacy Policy Drift across Localized Versions\n**Learning:** When updating  to reflect new local storage keys (like `language` and `f1_schedule_cache`), it's crucial to also update all localized versions in `public/privacy/` to maintain consistency and compliance. Python or JS scripts can be used to safely append new items while matching surrounding formatting.\n**Action:** Always write a script or manually ensure that any modifications to the root `PRIVACY.md` list of local storage items are faithfully replicated across all `public/privacy/PRIVACY.*.md` variants.
+
+## 2026-04-25 - Fixing Privacy Policy Drift across Localized Versions
+**Learning:** When updating `PRIVACY.md` to reflect new local storage keys (like `language` and `f1_schedule_cache`), it's crucial to also update all localized versions in `public/privacy/` to maintain consistency and compliance. Scripts can be used to safely append new items while matching surrounding formatting.
+**Action:** Always write a script or manually ensure that any modifications to the root `PRIVACY.md` list of local storage items are faithfully replicated across all `public/privacy/PRIVACY.*.md` variants.

--- a/public/privacy/PRIVACY.de.md
+++ b/public/privacy/PRIVACY.de.md
@@ -79,6 +79,8 @@ Lokale Einstellungen im Browser:
 
 - **theme:** `light` oder `dark`
 - **unit:** `metric` oder `imperial`
+- **language:** Ihre ausgewählte Sprache (z. B. `de`, `en-US`)
+- **f1_schedule_cache:** speichert die F1-Kalenderdaten zwischen (24-Stunden-Cache)
 
 ## Open Source
 

--- a/public/privacy/PRIVACY.en-GB.md
+++ b/public/privacy/PRIVACY.en-GB.md
@@ -79,6 +79,8 @@ Preference settings are stored locally in your browser:
 
 - **theme:** `light` or `dark`
 - **unit:** `metric` or `imperial`
+- **language:** your selected locale (e.g., `en-GB`, `fr`)
+- **f1_schedule_cache:** caches the F1 schedule data (24-hour cache)
 
 This data remains on your device and is not sent to our servers.
 

--- a/public/privacy/PRIVACY.en-NZ.md
+++ b/public/privacy/PRIVACY.en-NZ.md
@@ -80,6 +80,7 @@ Preference settings are stored locally in your browser:
 - **theme:** `light` or `dark`
 - **unit:** `metric` or `imperial`
 - **language:** your selected locale (e.g., `en-NZ`, `fr`)
+- **f1_schedule_cache:** caches the F1 schedule data (24-hour cache)
 
 This data remains on your device and is not sent to our servers.
 

--- a/public/privacy/PRIVACY.en-US.md
+++ b/public/privacy/PRIVACY.en-US.md
@@ -79,6 +79,8 @@ Preference settings are stored locally in your browser:
 
 - **theme:** `light` or `dark`
 - **unit:** `metric` or `imperial`
+- **language:** your selected locale (e.g., `en-GB`, `fr`)
+- **f1_schedule_cache:** caches the F1 schedule data (24-hour cache)
 
 This data remains on your device and is not sent to our servers.
 

--- a/public/privacy/PRIVACY.es.md
+++ b/public/privacy/PRIVACY.es.md
@@ -79,6 +79,8 @@ El navegador guarda preferencias locales:
 
 - **theme:** `light` o `dark`
 - **unit:** `metric` o `imperial`
+- **language:** su idioma seleccionado (ej. `es`, `en-US`)
+- **f1_schedule_cache:** guarda en caché los datos del calendario de F1 (caché de 24 horas)
 
 Estos datos permanecen en tu dispositivo.
 

--- a/public/privacy/PRIVACY.fr.md
+++ b/public/privacy/PRIVACY.fr.md
@@ -79,6 +79,8 @@ Les preferences sont stockees localement dans le navigateur :
 
 - **theme:** `light` ou `dark`
 - **unit:** `metric` ou `imperial`
+- **language:** votre langue sélectionnée (ex: `fr`, `en-US`)
+- **f1_schedule_cache:** met en cache les données du calendrier de la F1 (cache de 24 heures)
 
 ## Open source
 

--- a/public/privacy/PRIVACY.hu.md
+++ b/public/privacy/PRIVACY.hu.md
@@ -79,6 +79,8 @@ A beállításokat a böngészője helyileg tárolja:
 
 - **theme (téma):** `light` (világos) vagy `dark` (sötét)
 - **unit (mértékegység):** `metric` (metrikus) vagy `imperial` (birodalmi)
+- **language (nyelv):** a kiválasztott nyelv (pl. `hu`, `en-US`)
+- **f1_schedule_cache:** gyorsítótárazza az F1 naptáradatokat (24 órás gyorsítótár)
 
 Ezek az adatok az Ön eszközén maradnak, és nem kerülnek elküldésre a szervereinkre.
 

--- a/public/privacy/PRIVACY.it.md
+++ b/public/privacy/PRIVACY.it.md
@@ -79,6 +79,8 @@ Preferenze salvate localmente nel browser:
 
 - **theme:** `light` o `dark`
 - **unit:** `metric` o `imperial`
+- **language:** la lingua selezionata (es. `it`, `en-US`)
+- **f1_schedule_cache:** memorizza i dati del calendario F1 (cache di 24 ore)
 
 ## Open source
 

--- a/public/privacy/PRIVACY.ja.md
+++ b/public/privacy/PRIVACY.ja.md
@@ -79,6 +79,8 @@ Circuit Weather は、Formula 1 サーキット向けのリアルタイム天気
 
 - **theme:** `light` または `dark`
 - **unit:** `metric` または `imperial`
+- **language:** 選択した言語 (例: `ja`, `en-US`)
+- **f1_schedule_cache:** F1のスケジュールデータをキャッシュします (24時間キャッシュ)
 
 これらのデータは端末内にのみ保存されます。
 

--- a/public/privacy/PRIVACY.pt-BR.md
+++ b/public/privacy/PRIVACY.pt-BR.md
@@ -79,6 +79,8 @@ Preferencias guardadas localmente no navegador:
 
 - **theme:** `light` ou `dark`
 - **unit:** `metric` ou `imperial`
+- **language:** o seu idioma selecionado (ex. `pt-BR`, `en-US`)
+- **f1_schedule_cache:** faz cache dos dados do calendário da F1 (cache de 24 horas)
 
 ## Open source
 

--- a/public/privacy/PRIVACY.zh-CN.md
+++ b/public/privacy/PRIVACY.zh-CN.md
@@ -79,6 +79,8 @@ Circuit Weather 是一个开源网站应用，用于显示 Formula 1 赛道的�
 
 - **theme:** `light` 或 `dark`
 - **unit:** `metric` 或 `imperial`
+- **language:** 您选择的语言 (如 `zh-CN`, `en-US`)
+- **f1_schedule_cache:** 缓存 F1 赛程数据 (24小时缓存)
 
 这些数据仅保存在你的设备上。
 


### PR DESCRIPTION
💡 **Problem:** The localized privacy policy files in `public/privacy/` had drifted from the base implementation, omitting documentation for the `language` and `f1_schedule_cache` local storage keys. This violates transparency and compliance rules regarding user data.
🎯 **Fix:** Updated all 11 translated `PRIVACY.*.md` files to explicitly list and describe the `language` and `f1_schedule_cache` local storage keys.
🧪 **Verification:** Executed `pnpm run test:coverage` to ensure no functionality regressions. Checked all updated markdown files to ensure the injected definitions fit syntactically.
🔎 **Scope:** ONLY documentation changes inside `public/privacy/` and `.jules/archivist.md` are included.

---
*PR created automatically by Jules for task [6410813964420453163](https://jules.google.com/task/6410813964420453163) started by @2fst4u*