### PR TITLE
🔭 Scout: Inject datetime attributes into radar timeline <time> elements

### DIFF
--- a/public/src/map/WeatherRadar.js
+++ b/public/src/map/WeatherRadar.js
@@ -952,6 +952,8 @@ export class WeatherRadar {
         const timeStr = this.timeFormatter.format(date);
 
         this.ui.time.textContent = timeStr;
+        // Scout: Added datetime attribute to <time> element for semantic SEO value and machine-readability
+        this.ui.time.setAttribute('datetime', date.toISOString());
 
         let relativeText = '';
         let accessibleText = ''; // Palette A11y: New variable for screen reader text
@@ -1027,11 +1029,21 @@ export class WeatherRadar {
         }
 
         if (this.ui.timeStart && this.ui.timeEnd && this.frames.length > 0) {
-            this.ui.timeStart.textContent = this.timeFormatter.format(new Date(this.frames[0].time * 1000));
-            this.ui.timeEnd.textContent = this.timeFormatter.format(new Date(this.frames[this.frames.length - 1].time * 1000));
+            const startDate = new Date(this.frames[0].time * 1000);
+            const endDate = new Date(this.frames[this.frames.length - 1].time * 1000);
+
+            this.ui.timeStart.textContent = this.timeFormatter.format(startDate);
+            // Scout: Added datetime attribute to <time> element for semantic SEO value and machine-readability
+            this.ui.timeStart.setAttribute('datetime', startDate.toISOString());
+
+            this.ui.timeEnd.textContent = this.timeFormatter.format(endDate);
+            // Scout: Added datetime attribute to <time> element for semantic SEO value and machine-readability
+            this.ui.timeEnd.setAttribute('datetime', endDate.toISOString());
         } else if (this.ui.timeStart && this.ui.timeEnd) {
             this.ui.timeStart.textContent = '--:--';
+            this.ui.timeStart.removeAttribute('datetime');
             this.ui.timeEnd.textContent = '--:--';
+            this.ui.timeEnd.removeAttribute('datetime');
         }
     }
 


### PR DESCRIPTION
**💡 What:** 
Added dynamically generated ISO 8601 `datetime` attributes to the semantic `<time>` elements in the radar timeline (`WeatherRadar.js`). 

**🎯 Why:** 
The `<time>` elements previously only updated their visual `textContent`. Providing a strict ISO timestamp via the `datetime` attribute provides search engines, crawlers, and assistive technologies with unambiguous temporal data that avoids localization/formatting ambiguity.

**📊 Value:** 
Improves semantic HTML data richness. When crawlers parse the radar component, they can now explicitly extract exact timing boundaries and intervals, which helps correctly index the live/dynamic nature of the application content.

**🔬 Measurement:** 
Open the application, start the radar playback, and inspect the `<time>` elements inside `.radar-time-info`. They will now contain valid attributes such as `<time datetime="2025-02-14T10:00:00.000Z">...`.

---
*PR created automatically by Jules for task [10741232380337185772](https://jules.google.com/task/10741232380337185772) started by @2fst4u*