### PR TITLE
🌍 Globe: Extract translation for map zoom controls

### DIFF
--- a/public/src/i18n/locales/de.js
+++ b/public/src/i18n/locales/de.js
@@ -27,7 +27,7 @@ export const de = {
         retryingFailedTiles: 'Versuche {{count}} fehlgeschlagene Kachel{{suffix}} erneut...', radarStatus: 'Radarstatus: {{status}}',
     },
     countdown: { startsIn: 'Startet in', day: 'Tag', dayPlural: 'Tage', hour: 'Stunde', hourPlural: 'Stunden', minute: 'Minute', minutePlural: 'Minuten', second: 'Sekunde', secondPlural: 'Sekunden' },
-    map: { recenterOnCircuit: 'Auf Strecke zentrieren' },
+    map: { recenterOnCircuit: 'Auf Strecke zentrieren', zoomIn: 'Vergrößern', zoomOut: 'Verkleinern' },
     privacy: {
         link: 'Datenschutz',
         title: 'Datenschutzerklarung',

--- a/public/src/i18n/locales/en.js
+++ b/public/src/i18n/locales/en.js
@@ -85,6 +85,8 @@ export const en = {
     },
     map: {
         recenterOnCircuit: 'Recentre on circuit',
+        zoomIn: 'Zoom in',
+        zoomOut: 'Zoom out',
     },
     privacy: {
         link: 'Privacy',

--- a/public/src/i18n/locales/es.js
+++ b/public/src/i18n/locales/es.js
@@ -30,7 +30,7 @@ export const es = {
     countdown: {
         startsIn: 'Empieza en', day: 'dia', dayPlural: 'dias', hour: 'hora', hourPlural: 'horas', minute: 'minuto', minutePlural: 'minutos', second: 'segundo', secondPlural: 'segundos',
     },
-    map: { recenterOnCircuit: 'Recentrar en circuito' },
+    map: { recenterOnCircuit: 'Recentrar en circuito', zoomIn: 'Acercar', zoomOut: 'Alejar' },
     privacy: {
         link: 'Privacidad',
         title: 'Politica de privacidad',

--- a/public/src/i18n/locales/fr.js
+++ b/public/src/i18n/locales/fr.js
@@ -28,7 +28,7 @@ export const fr = {
         retryingFailedTiles: 'Nouvelle tentative pour {{count}} tuile{{suffix}} en echec...', radarStatus: 'Statut radar : {{status}}',
     },
     countdown: { startsIn: 'Debute dans', day: 'jour', dayPlural: 'jours', hour: 'heure', hourPlural: 'heures', minute: 'minute', minutePlural: 'minutes', second: 'seconde', secondPlural: 'secondes' },
-    map: { recenterOnCircuit: 'Recentrer sur le circuit' },
+    map: { recenterOnCircuit: 'Recentrer sur le circuit', zoomIn: 'Zoomer', zoomOut: 'Dézoomer' },
     privacy: {
         link: 'Confidentialite',
         title: 'Politique de confidentialite',

--- a/public/src/i18n/locales/hu.js
+++ b/public/src/i18n/locales/hu.js
@@ -84,6 +84,8 @@ export const hu = {
     },
     map: {
         recenterOnCircuit: 'Központosítás a pályára',
+        zoomIn: 'Nagyítás',
+        zoomOut: 'Kicsinyítés',
     },
     privacy: {
         link: 'Adatvédelem',

--- a/public/src/i18n/locales/it.js
+++ b/public/src/i18n/locales/it.js
@@ -28,7 +28,7 @@ export const it = {
         retryingFailedTiles: 'Nuovo tentativo per {{count}} tile non riuscita{{suffix}}...', radarStatus: 'Stato radar: {{status}}',
     },
     countdown: { startsIn: 'Inizia tra', day: 'giorno', dayPlural: 'giorni', hour: 'ora', hourPlural: 'ore', minute: 'minuto', minutePlural: 'minuti', second: 'secondo', secondPlural: 'secondi' },
-    map: { recenterOnCircuit: 'Ricentra sul circuito' },
+    map: { recenterOnCircuit: 'Ricentra sul circuito', zoomIn: 'Ingrandire', zoomOut: 'Rimpicciolire' },
     privacy: {
         link: 'Privacy',
         title: 'Informativa sulla privacy',

--- a/public/src/i18n/locales/ja.js
+++ b/public/src/i18n/locales/ja.js
@@ -26,7 +26,7 @@ export const ja = {
         rateLimitExceeded: 'リクエスト上限を超えました。しばらく待機します。', retryingFailedTiles: '失敗したタイル {{count}} 件を再試行中...', radarStatus: 'レーダー状態: {{status}}',
     },
     countdown: { startsIn: '開始まで', day: '日', dayPlural: '日', hour: '時間', hourPlural: '時間', minute: '分', minutePlural: '分', second: '秒', secondPlural: '秒' },
-    map: { recenterOnCircuit: 'サーキットに再センタリング' },
+    map: { recenterOnCircuit: 'サーキットに再センタリング', zoomIn: '拡大', zoomOut: '縮小' },
     privacy: {
         link: 'プライバシー',
         title: 'プライバシーポリシー',

--- a/public/src/i18n/locales/pt-BR.js
+++ b/public/src/i18n/locales/pt-BR.js
@@ -28,7 +28,7 @@ export const ptBR = {
         retryingFailedTiles: 'A tentar novamente {{count}} bloco{{suffix}} com falha...', radarStatus: 'Estado do radar: {{status}}',
     },
     countdown: { startsIn: 'Comeca em', day: 'dia', dayPlural: 'dias', hour: 'hora', hourPlural: 'horas', minute: 'minuto', minutePlural: 'minutos', second: 'segundo', secondPlural: 'segundos' },
-    map: { recenterOnCircuit: 'Recentrar no circuito' },
+    map: { recenterOnCircuit: 'Recentrar no circuito', zoomIn: 'Aproximar', zoomOut: 'Afastar' },
     privacy: {
         link: 'Privacidade',
         title: 'Politica de privacidade',

--- a/public/src/i18n/locales/zh-CN.js
+++ b/public/src/i18n/locales/zh-CN.js
@@ -26,7 +26,7 @@ export const zhCN = {
         rateLimitExceeded: '请求过于频繁，已暂时暂停。', retryingFailedTiles: '正在重试 {{count}} 个失败瓦片...', radarStatus: '雷达状态: {{status}}',
     },
     countdown: { startsIn: '开始倒计时', day: '天', dayPlural: '天', hour: '小时', hourPlural: '小时', minute: '分钟', minutePlural: '分钟', second: '秒', secondPlural: '秒' },
-    map: { recenterOnCircuit: '回到赛道中心' },
+    map: { recenterOnCircuit: '回到赛道中心', zoomIn: '放大', zoomOut: '缩小' },
     privacy: {
         link: '隐私',
         title: '隐私政策',

--- a/public/src/map/MapManager.js
+++ b/public/src/map/MapManager.js
@@ -138,15 +138,15 @@ export class MapManager {
     const zoomIn = document.createElement('button');
     zoomIn.className = 'leaflet-control-zoom-in';
     zoomIn.setAttribute('type', 'button');
-    zoomIn.setAttribute('aria-label', '+');
-    zoomIn.setAttribute('title', 'Zoom in');
+    zoomIn.setAttribute('aria-label', i18n.t('map.zoomIn'));
+    zoomIn.setAttribute('title', i18n.t('map.zoomIn'));
     zoomIn.textContent = '+';
 
     const zoomOut = document.createElement('button');
     zoomOut.className = 'leaflet-control-zoom-out';
     zoomOut.setAttribute('type', 'button');
-    zoomOut.setAttribute('aria-label', '−');
-    zoomOut.setAttribute('title', 'Zoom out');
+    zoomOut.setAttribute('aria-label', i18n.t('map.zoomOut'));
+    zoomOut.setAttribute('title', i18n.t('map.zoomOut'));
     zoomOut.textContent = '−';
 
     zoomIn.addEventListener('click', () => this.map.zoomIn());


### PR DESCRIPTION
💡 What: Replaced hardcoded 'Zoom in' and 'Zoom out' strings with `i18n.t('map.zoomIn')` and `i18n.t('map.zoomOut')` in `public/src/map/MapManager.js`. Populated the translations into `en.js` and all other localized `.js` dictionary files (e.g., `ja.js`, `es.js`, `de.js`).
🎯 Why: The aria-labels and tooltips for the custom mapbox zoom controls were hardcoded to English. This broke the native feel for non-English users and reduced accessibility because screen readers would announce English tooltips over localized content.
🌐 Nuance: Maintained the visual `+` and `−` symbols within the buttons while strictly translating the hidden descriptive labels to improve screen reader experience and hover tooltips for all locales.

---
*PR created automatically by Jules for task [7892187486283127745](https://jules.google.com/task/7892187486283127745) started by @2fst4u*