### PR TITLE
🔭 Scout: Add robots meta tag for large image previews

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -17,3 +17,8 @@
 
 **Learning:** Memory explicitly states that native `<a href="...">` anchor tags should not use `role="button"` as it overrides their semantic identity, causing crawlers to treat them as widgets rather than navigational paths.
 **Action:** Always scan for and remove `role="button"` from native `<a>` tags with `href` attributes, but ensure existing CSS classes (like `.link-button`) are retained so visual layout remains completely unaffected.
+
+## 2025-04-26 - max-image-preview SEO directive
+
+**Learning:** Adding the `<meta name="robots" content="max-image-preview:large">` directive is a highly effective, invisible SEO optimization that enables Google Discover and search results to use large, high-quality image previews, drastically improving Click-Through Rates (CTR).
+**Action:** When acting as Scout, actively seek out opportunities to add or augment the `robots` meta tag with `max-image-preview:large`, `max-snippet:-1`, and `max-video-preview:-1` on content-heavy pages.

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,9 @@
         content="Stay ahead of the rain with Circuit Weather. Real-time weather radar, live forecasts, and session countdowns for every Formula 1 Grand Prix circuit worldwide.">
     <meta name="keywords" content="F1, Formula 1, weather, radar, circuit, race, precipitation, Grand Prix, weather forecast">
 
+    <!-- Scout: Added explicit robots directives to enable large image previews in Google Discover and rich snippets, improving CTR. -->
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
+
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://circuit-weather.racing">


### PR DESCRIPTION
### 💡 What
Added the `<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">` tag to the document `<head>`.

### 🎯 Why
By default, search engines may limit snippet lengths and use standard-sized thumbnails for indexing. Explicitly declaring `max-image-preview:large` and removing snippet length restrictions instructs Google and other search engines to utilize high-quality rich previews for the application.

### 📊 Value
This completely invisible enhancement significantly improves the visual footprint in Search Engine Results Pages (SERP) and unlocks eligibility for Google Discover's large image cards, drastically boosting potential Click-Through Rate (CTR).

### 🔬 Measurement
Verify the DOM output directly: run `grep '<meta name="robots"' public/index.html`. The robots directives will be present in the head section. Tested locally with `pnpm test` to ensure zero regressions or broken tests.

---
*PR created automatically by Jules for task [17021822894561055811](https://jules.google.com/task/17021822894561055811) started by @2fst4u*