### PR TITLE
🌍 Globe: Add translation for skipToContent in hu.js

### DIFF
--- a/public/src/i18n/locales/hu.js
+++ b/public/src/i18n/locales/hu.js
@@ -6,6 +6,7 @@ export const hu = {
         selectLanguage: 'Nyelv',
         openMenu: 'Menü megnyitása',
         closeMenu: 'Menü bezárása',
+        skipToContent: 'Ugrás a fő tartalomra',
     },
     loading: {
         schedule: 'Versenynaptár betöltése...',


### PR DESCRIPTION
💡 **What:** Added the missing `common.skipToContent` localization key to the Hungarian (`hu.js`) language file.
🎯 **Why:** The key was missing entirely from the Hungarian locale file while it existed in the base English file and all other target languages, resulting in an incomplete localization dictionary.
🌐 **Nuance:** Translated to "Ugrás a fő tartalomra" ensuring an accurate and culturally appropriate representation of "Skip to main content".

---
*PR created automatically by Jules for task [1636068112361158884](https://jules.google.com/task/1636068112361158884) started by @2fst4u*