### PR TITLE
🎨 Palette: Improve focus contrast for select dropdowns

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - Added skip-to-content link
 **Learning:** Adding a visually hidden skip link for keyboard navigation requires a unique CSS class (e.g., `.skip-link`) because the global `:focus-visible` styles don't inherently support repositioning elements off-screen and then on-screen during focus. Custom styling is required for this specific accessibility pattern, even though general focus styles are handled globally.
 **Action:** When adding bypass blocks or skip links, explicitly style them to be hidden visually (e.g., `position: absolute; top: -40px;`) and visible only on `:focus`, overriding the global focus ring if necessary.
+## 2026-04-28 - Focus-visible requires Tab emulation for verification
+**Learning:** When using Playwright to visually verify `:focus-visible` styles, programmatically focusing elements (e.g., `locator.focus()`) may not reliably trigger the pseudo-class. Genuine keyboard navigation must be simulated using `page.keyboard.press('Tab')` to accurately trigger and capture the keyboard focus state.
+**Action:** When writing Playwright verification scripts for keyboard accessibility features, rely on sequential `Tab` presses to reach the target element rather than direct DOM `.focus()` methods.

--- a/public/styles.css
+++ b/public/styles.css
@@ -286,7 +286,11 @@ body {
 .select:focus {
     outline: none;
     border-color: var(--color-primary);
-    box-shadow: 0 0 0 2px rgba(225, 6, 0, 0.15);
+}
+
+.select:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
 }
 
 .select:disabled {


### PR DESCRIPTION
🎨 Palette: Improve focus contrast for select dropdowns

💡 What: Removed the low-contrast (15% opacity) red box-shadow from the `.select:focus` state and implemented a robust `.select:focus-visible` rule using the global primary color outline.
🎯 Why: The custom box-shadow was nearly invisible to keyboard users, failing WCAG focus indicator contrast requirements. By tying the strong outline to `:focus-visible`, mouse users aren't penalized with aggressive outlines after clicking, while keyboard users receive clear tactile feedback.
📸 Before/After: Before, tabbing to the dropdown produced a faint pink blur. After, it produces a sharp, 2px solid primary red ring offset by 2px, matching the global focus style.
♿ Accessibility: Significantly improves keyboard navigation visibility for visually impaired users.

---
*PR created automatically by Jules for task [14390214258293042253](https://jules.google.com/task/14390214258293042253) started by @2fst4u*