### PR TITLE
🌍 Globe: Extract translation for Formula 1 series control

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -142,8 +142,8 @@
                     <div class="control-group">
                         <label for="seriesSelect" data-i18n="controls.series">Series</label>
                         <select id="seriesSelect" class="select" disabled
-                            title="Only Formula 1 is currently supported">
-                            <option value="f1">Formula 1</option>
+                            title="Only Formula 1 is currently supported" data-i18n-attr="title:controls.onlyF1Supported">
+                            <option value="f1" data-i18n="controls.f1">Formula 1</option>
                         </select>
                     </div>
                     <div class="control-group">

--- a/public/src/i18n/locales/de.js
+++ b/public/src/i18n/locales/de.js
@@ -3,6 +3,7 @@ export const de = {
     theme: { toggle: 'Hell/Dunkelmodus umschalten', switchToLight: 'Zu hellem Modus wechseln', switchToDark: 'Zu dunklem Modus wechseln' },
     loading: { schedule: 'Lade Rennkalender...', session: 'Lade Sessiondaten...' },
     controls: {
+        onlyF1Supported: 'Derzeit wird nur die Formel 1 unterstutzt', f1: 'Formel 1',
         series: 'Serie', round: 'Runde', session: 'Session', units: 'Einheiten',
         selectRound: 'Runde auswahlen...', selectRoundFirst: 'Wahlen Sie zuerst eine Runde', selectSession: 'Session auswahlen...',
         metricLabel: 'Kilometer', imperialLabel: 'Meilen',

--- a/public/src/i18n/locales/en.js
+++ b/public/src/i18n/locales/en.js
@@ -18,6 +18,7 @@ export const en = {
         switchToDark: 'Switch to dark mode',
     },
     controls: {
+        onlyF1Supported: 'Only Formula 1 is currently supported', f1: 'Formula 1',
         series: 'Series',
         round: 'Round',
         session: 'Session',

--- a/public/src/i18n/locales/es.js
+++ b/public/src/i18n/locales/es.js
@@ -3,6 +3,7 @@ export const es = {
     theme: { toggle: 'Cambiar modo claro/oscuro', switchToLight: 'Cambiar a modo claro', switchToDark: 'Cambiar a modo oscuro' },
     loading: { schedule: 'Cargando calendario de carreras...', session: 'Cargando datos de la sesion...' },
     controls: {
+        onlyF1Supported: 'Actualmente solo se admite Formula 1', f1: 'Formula 1',
         series: 'Serie', round: 'Ronda', session: 'Sesion', units: 'Unidades',
         selectRound: 'Selecciona ronda...', selectRoundFirst: 'Selecciona una ronda primero', selectSession: 'Selecciona sesion...',
         metricLabel: 'Kilometros', imperialLabel: 'Millas',

--- a/public/src/i18n/locales/fr.js
+++ b/public/src/i18n/locales/fr.js
@@ -3,6 +3,7 @@ export const fr = {
     theme: { toggle: 'Basculer mode clair/sombre', switchToLight: 'Passer en mode clair', switchToDark: 'Passer en mode sombre' },
     loading: { schedule: 'Chargement du calendrier des courses...', session: 'Chargement des donnees de session...' },
     controls: {
+        onlyF1Supported: 'Seule la Formule 1 est actuellement prise en charge', f1: 'Formule 1',
         series: 'Serie', round: 'Manche', session: 'Session', units: 'Unites',
         selectRound: 'Selectionner une manche...', selectRoundFirst: 'Selectionnez d\'abord une manche', selectSession: 'Selectionner une session...',
         metricLabel: 'Kilometres', imperialLabel: 'Miles',

--- a/public/src/i18n/locales/hu.js
+++ b/public/src/i18n/locales/hu.js
@@ -18,6 +18,7 @@ export const hu = {
         switchToDark: 'Váltás sötét módra',
     },
     controls: {
+        onlyF1Supported: 'Jelenleg csak a Forma-1 támogatott', f1: 'Forma-1',
         series: 'Sorozat',
         round: 'Forduló',
         session: 'Esemény',

--- a/public/src/i18n/locales/it.js
+++ b/public/src/i18n/locales/it.js
@@ -3,6 +3,7 @@ export const it = {
     theme: { toggle: 'Attiva tema chiaro/scuro', switchToLight: 'Passa al tema chiaro', switchToDark: 'Passa al tema scuro' },
     loading: { schedule: 'Caricamento calendario gare...', session: 'Caricamento dati sessione...' },
     controls: {
+        onlyF1Supported: 'Attualmente e supportata solo la Formula 1', f1: 'Formula 1',
         series: 'Serie', round: 'Round', session: 'Sessione', units: 'Unita',
         selectRound: 'Seleziona round...', selectRoundFirst: 'Seleziona prima un round', selectSession: 'Seleziona sessione...',
         metricLabel: 'Chilometri', imperialLabel: 'Miglia',

--- a/public/src/i18n/locales/ja.js
+++ b/public/src/i18n/locales/ja.js
@@ -3,6 +3,7 @@ export const ja = {
     theme: { toggle: 'ライト/ダークモードを切り替え', switchToLight: 'ライトモードに切り替え', switchToDark: 'ダークモードに切り替え' },
     loading: { schedule: 'レーススケジュールを読み込み中...', session: 'セッションデータを読み込み中...' },
     controls: {
+        onlyF1Supported: '現在はF1のみサポートされています', f1: 'F1',
         series: 'シリーズ', round: 'ラウンド', session: 'セッション', units: '単位',
         selectRound: 'ラウンドを選択...', selectRoundFirst: '先にラウンドを選択してください', selectSession: 'セッションを選択...',
         metricLabel: 'キロメートル', imperialLabel: 'マイル',

--- a/public/src/i18n/locales/pt-BR.js
+++ b/public/src/i18n/locales/pt-BR.js
@@ -3,6 +3,7 @@ export const ptBR = {
     theme: { toggle: 'Alternar modo claro/escuro', switchToLight: 'Mudar para modo claro', switchToDark: 'Mudar para modo escuro' },
     loading: { schedule: 'A carregar calendario de corridas...', session: 'A carregar dados da sessao...' },
     controls: {
+        onlyF1Supported: 'Atualmente, apenas a Formula 1 e suportada', f1: 'Formula 1',
         series: 'Serie', round: 'Ronda', session: 'Sessao', units: 'Unidades',
         selectRound: 'Selecionar ronda...', selectRoundFirst: 'Selecione primeiro uma ronda', selectSession: 'Selecionar sessao...',
         metricLabel: 'Quilometros', imperialLabel: 'Milhas',

--- a/public/src/i18n/locales/zh-CN.js
+++ b/public/src/i18n/locales/zh-CN.js
@@ -3,6 +3,7 @@ export const zhCN = {
     theme: { toggle: '切换明亮/深色模式', switchToLight: '切换到明亮模式', switchToDark: '切换到深色模式' },
     loading: { schedule: '正在加载比赛赛历...', session: '正在加载赛段数据...' },
     controls: {
+        onlyF1Supported: '目前仅支持 F1', f1: 'F1',
         series: '系列赛', round: '分站', session: '赛段', units: '单位',
         selectRound: '选择分站...', selectRoundFirst: '请先选择分站', selectSession: '选择赛段...',
         metricLabel: '公里', imperialLabel: '英里',


### PR DESCRIPTION
**💡 What:** Extracted the hardcoded string `<option value="f1">Formula 1</option>` and `title="Only Formula 1 is currently supported"` from the series select control in `public/index.html` into the `controls` dictionary across all supported locales.

**🎯 Why:** To fully internationalize the UI so that users interacting with the series selection control see translations in their native language instead of English.

**🌐 Nuance:** Kept the abbreviation "F1" in the Japanese and Simplified Chinese locales, as it is the universally accepted and more natural term in those languages. Maintained the existing case structure and orthography (including missing accents) found in the other base locale files.

---
*PR created automatically by Jules for task [17679390059370320478](https://jules.google.com/task/17679390059370320478) started by @2fst4u*