### PR TITLE
🧪 Spec: Add MutationObserver test for CircuitWeatherApp

### DIFF
--- a/tests/circuit-weather-app.test.js
+++ b/tests/circuit-weather-app.test.js
@@ -1508,6 +1508,62 @@ describe('CircuitWeatherApp Pure Methods', () => {
             global.ResizeObserver = origRo;
             global.MutationObserver = origMo;
         });
+
+        it('observes dynamically added map controls using MutationObserver', () => {
+            let moCb = null;
+            const origMo = global.MutationObserver;
+            global.MutationObserver = vi.fn(function(cb) {
+                moCb = cb;
+                this.observe = vi.fn();
+                this.disconnect = vi.fn();
+            });
+
+            let resizeCb = null;
+            const origRo = global.ResizeObserver;
+            let mockObserve = vi.fn();
+            global.ResizeObserver = vi.fn(function(cb) {
+                resizeCb = cb;
+                this.observe = mockObserve;
+                this.disconnect = vi.fn();
+            });
+
+            let rafCb = null;
+            const origRaf = global.requestAnimationFrame;
+            global.requestAnimationFrame = vi.fn(cb => {
+                rafCb = cb;
+                return 123;
+            });
+
+            app.updateLayoutOffsets = vi.fn();
+
+            // Mock Node globally as it's used in CircuitWeatherApp.js
+            const origNode = global.Node;
+            global.Node = { ELEMENT_NODE: 1 };
+
+            app.initResizeObserver();
+
+            // Simulate mutation adding a relevant node
+            const mockNode = {
+                nodeType: 1, // Node.ELEMENT_NODE
+                matches: vi.fn(sel => sel === '.mapboxgl-ctrl-bottom-left'),
+                querySelector: vi.fn()
+            };
+
+            moCb([{ addedNodes: [mockNode] }]);
+
+            expect(mockObserve).toHaveBeenCalledWith(mockNode);
+            expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+
+            // Restore globals
+            global.MutationObserver = origMo;
+            global.ResizeObserver = origRo;
+            global.requestAnimationFrame = origRaf;
+            if (origNode !== undefined) {
+                global.Node = origNode;
+            } else {
+                delete global.Node;
+            }
+        });
     });
 
     describe('Mobile Visibility', () => {


### PR DESCRIPTION
💡 What: Added a new unit test for `initResizeObserver` logic using a safe `global.Node` mock.
🎯 Why: Fortify critical UI layout logic to ensure dynamically injected map controls trigger layout offset updates.
📈 Maturity Impact: N/A, coverage remained within standard (> 98%).

---
*PR created automatically by Jules for task [241849003323995658](https://jules.google.com/task/241849003323995658) started by @2fst4u*