### PR TITLE
🎨 Palette: Add aria-disabled attributes to disabled elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2026-04-28 - Focus-visible requires Tab emulation for verification
 **Learning:** When using Playwright to visually verify `:focus-visible` styles, programmatically focusing elements (e.g., `locator.focus()`) may not reliably trigger the pseudo-class. Genuine keyboard navigation must be simulated using `page.keyboard.press('Tab')` to accurately trigger and capture the keyboard focus state.
 **Action:** When writing Playwright verification scripts for keyboard accessibility features, rely on sequential `Tab` presses to reach the target element rather than direct DOM `.focus()` methods.
+## 2024-05-19 - Screen reader visibility of disabled inputs
+**Learning:** Screen readers might not consistently announce elements with only the `disabled` property. Adding `aria-disabled="true"` to inputs like `select` gives screen reader users explicit information that an element is present but currently inactive, which provides better context than skipping it entirely.
+**Action:** When adding or dynamically toggling the `disabled` property on form elements or buttons, also update the `aria-disabled` attribute to maintain synchronization for assistive technologies.

--- a/public/index.html
+++ b/public/index.html
@@ -141,7 +141,7 @@
                 <section class="control-section" aria-label="Race Selection">
                     <div class="control-group">
                         <label for="seriesSelect" data-i18n="controls.series">Series</label>
-                        <select id="seriesSelect" class="select" disabled
+                        <select id="seriesSelect" class="select" disabled aria-disabled="true"
                             title="Only Formula 1 is currently supported" data-i18n-attr="title:controls.onlyF1Supported">
                             <option value="f1" data-i18n="controls.f1">Formula 1</option>
                         </select>
@@ -154,7 +154,7 @@
                     </div>
                     <div class="control-group">
                         <label for="sessionSelect" data-i18n="controls.session">Session</label>
-                        <select id="sessionSelect" class="select" disabled title="Select a round first" data-i18n-attr="title:controls.selectRoundFirst">
+                        <select id="sessionSelect" class="select" disabled aria-disabled="true" title="Select a round first" data-i18n-attr="title:controls.selectRoundFirst">
                             <option value="" data-i18n="controls.selectRoundFirst">Select a round first</option>
                         </select>
                     </div>

--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -161,6 +161,7 @@ export class CircuitWeatherApp {
             if (btn) {
                 btn.addEventListener('click', () => {
                     btn.disabled = true;
+                    btn.setAttribute('aria-disabled', 'true');
                     // Palette UX: Add loading spinner to async submit button
                     btn.innerHTML = `<svg style="width: 1rem; height: 1rem; margin-right: 0.5rem; animation: spin 1s linear infinite;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 2v4m0 12v4M4.93 4.93l2.83 2.83m8.48 8.48l2.83 2.83M2 12h4m12 0h4M4.93 19.07l2.83-2.83m8.48-8.48l2.83-2.83"></path></svg>${escapeHtml(i18n.t('common.retrying'))}`;
                     btn.setAttribute('aria-label', i18n.t('errors.retryingConnection'));
@@ -395,6 +396,7 @@ export class CircuitWeatherApp {
                     // Palette UX: Reset session select when round is cleared
                     if (this.ui.sessionSelect) {
                         this.ui.sessionSelect.disabled = true;
+                        this.ui.sessionSelect.setAttribute('aria-disabled', 'true');
                         this.ui.sessionSelect.title = i18n.t('controls.selectRoundFirst');
                         this.ui.sessionSelect.innerHTML = `<option value="">${escapeHtml(i18n.t('controls.selectRoundFirst'))}</option>`;
                     }
@@ -735,6 +737,7 @@ export class CircuitWeatherApp {
         if (!select) return;
 
         select.disabled = false;
+        select.setAttribute('aria-disabled', 'false');
         select.removeAttribute('title');
         select.innerHTML = `<option value="">${escapeHtml(i18n.t('controls.selectSession'))}</option>`;
 


### PR DESCRIPTION
This PR enhances screen reader accessibility by supplementing native `disabled` properties with `aria-disabled="true"` on elements like the series/session dropdowns and the retry button.

💡 What:
Added explicit `aria-disabled="true"` to inherently disabled `select` elements in the HTML and synchronized the attribute alongside dynamic `disabled` states in the Javascript logic.

🎯 Why:
Native `disabled` properties often cause screen readers to completely skip the element, leaving users blind to its existence. Explicitly defining `aria-disabled` gives them necessary context about inactive controls.

♿ Accessibility:
Ensures screen reader consistency when interacting with form and button states.

---
*PR created automatically by Jules for task [11314462541243868344](https://jules.google.com/task/11314462541243868344) started by @2fst4u*