### PR TITLE
🔭 Scout: Upgrade generic dashboard and timeline divs to semantic region landmarks

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -22,3 +22,7 @@
 
 **Learning:** Adding the `<meta name="robots" content="max-image-preview:large">` directive is a highly effective, invisible SEO optimization that enables Google Discover and search results to use large, high-quality image previews, drastically improving Click-Through Rates (CTR).
 **Action:** When acting as Scout, actively seek out opportunities to add or augment the `robots` meta tag with `max-image-preview:large`, `max-snippet:-1`, and `max-video-preview:-1` on content-heavy pages.
+## 2025-05-01 - Cloudflare API Workers Cannot Do Edge HTML SEO Rewrites
+
+**Learning:** The application uses Cloudflare Pages/Workers (`wrangler.toml`) where `src/worker.js` is configured to only intercept API routes (`run_worker_first = ["/api/*"]`). It cannot be used for Edge HTML rewriting (e.g., dynamically injecting specific Open Graph meta tags for Facebook crawlers) because the main SPA HTML is served directly as a static asset.
+**Action:** When attempting to improve static metadata that requires crawler visibility without executing JS (like `og:image`), do not attempt to write Edge handlers in `src/worker.js`.

--- a/public/index.html
+++ b/public/index.html
@@ -187,7 +187,8 @@
                     <h2 id="forecastHeading" data-i18n="forecast.heading">Session Forecast</h2>
                     <div class="forecast-content" id="forecastContent">
                         <!-- Content injected by JS -->
-                        <div class="weather-dashboard">
+                        <!-- Scout: Upgraded generic div wrappers to semantic article and section for explicit document outline parsing -->
+                        <article class="weather-dashboard">
                             <!-- Scout: Upgraded generic div/span wrappers to semantic description list (dl/dt/dd) to explicitly associate weather labels with their values for crawlers and assistive tech. -->
                             <dl class="weather-current">
                                 <div class="weather-metric">
@@ -204,13 +205,13 @@
                                     <dd class="weather-sub" id="weatherWindDir">--</dd>
                                 </div>
                             </dl>
-                            <div class="weather-timeline" id="weatherTimeline" tabindex="0" role="region"
+                            <section class="weather-timeline" id="weatherTimeline" tabindex="0"
                                 aria-label="Hourly forecast" data-i18n-attr="aria-label:forecast.hourlyForecast">
                                 <ol class="weather-timeline-list">
                                     <!-- Timeline items injected here -->
                                 </ol>
-                            </div>
-                        </div>
+                            </section>
+                        </article>
                     </div>
                     <div id="forecastUnavailable" style="display: none;" aria-live="polite">
                         <p class="forecast-unavailable" data-i18n="forecast.availableCloser">Forecast available closer to session</p>
@@ -443,7 +444,8 @@
 
     <!-- Template for skeleton loading state in forecast panel -->
     <template id="forecast-skeleton-template">
-        <div class="weather-dashboard" aria-hidden="true">
+        <!-- Scout: Upgraded generic div wrappers to semantic article and section for explicit document outline parsing -->
+        <article class="weather-dashboard" aria-hidden="true">
             <!-- Scout: Upgraded generic div/span wrappers to semantic description list (dl/dt/dd) to explicitly associate weather labels with their values for crawlers and assistive tech. -->
             <dl class="weather-current">
                 <div class="weather-metric">
@@ -460,7 +462,7 @@
                     <dd class="weather-sub skeleton"><span class="skeleton-text" style="width: 20px"></span></dd>
                 </div>
             </dl>
-            <div class="weather-timeline" id="weatherTimeline">
+            <section class="weather-timeline" id="weatherTimeline">
                 <ol class="weather-timeline-list">
                     <!-- Scout: Upgraded generic div wrapper to semantic time element in skeletons -->
                     <li class="weather-timeline-item">
@@ -479,8 +481,8 @@
                         <div class="weather-timeline-temp skeleton"><span class="skeleton-text" style="width: 30px"></span></div>
                     </li>
                 </ol>
-            </div>
-        </div>
+            </section>
+        </article>
     </template>
 
 </body>

--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -1054,21 +1054,22 @@ export class CircuitWeatherApp {
 
             // Scout: Upgraded generic unordered list (ul) to an ordered list (ol) to semantically indicate to search engines and screen readers that the hourly forecast is a chronological, time-ordered sequence of events.
             timelineHtml = `
-                <div class="weather-timeline" id="weatherTimeline" tabindex="0" role="region" data-i18n-attr="aria-label:forecast.hourlyForecast" aria-label="${escapeHtml(i18n.t('forecast.hourlyForecast'))}">
+                <section class="weather-timeline" id="weatherTimeline" tabindex="0" data-i18n-attr="aria-label:forecast.hourlyForecast" aria-label="${escapeHtml(i18n.t('forecast.hourlyForecast'))}">
                     <ol class="weather-timeline-list">
                         ${items}
                     </ol>
-                </div>
+                </section>
             `;
         }
 
         // Inject into content
         if (content) {
             content.innerHTML = `
-                <div class="weather-dashboard">
+                <!-- Scout: Upgraded generic div wrappers to semantic article and section for explicit document outline parsing -->
+                <article class="weather-dashboard">
                     ${currentHtml}
                     ${timelineHtml}
-                </div>
+                </article>
             `;
         }
     }


### PR DESCRIPTION
💡 What: Upgraded the generic `<div class="weather-dashboard">` to an `<article>` and the `<div class="weather-timeline" role="region">` to a `<section>` natively in both `public/index.html` and the dynamic builder in `CircuitWeatherApp.js`.
🎯 Why: "Div soup" hides the semantic structure of the page from search engine crawlers. Upgrading these wrappers provides an explicit document outline where the forecast timeline acts as a distinct, identifiable region landmark.
📊 Value: Search engines and assistive technologies can now confidently identify the weather timeline block as an independent temporal dataset, improving indexability and structural comprehension without altering CSS or application logic.
🔬 Measurement: Inspecting the DOM of any active session forecast will now show the `<article>` and `<section>` tags replacing the previous `<div>` wrappers.

---
*PR created automatically by Jules for task [6753556071611373852](https://jules.google.com/task/6753556071611373852) started by @2fst4u*