### PR TITLE
🌍 Globe: Extract translation for external link screen reader text

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -263,7 +263,7 @@
                         <polyline points="15 3 21 3 21 9"></polyline>
                         <line x1="10" y1="14" x2="21" y2="3"></line>
                     </svg>
-                    <span class="sr-only">(opens in a new tab)</span>
+                    <span class="sr-only" data-i18n="privacy.opensInNewTab">(opens in a new tab)</span>
                 </a>
             </footer>
         </aside>

--- a/public/src/i18n/locales/de.js
+++ b/public/src/i18n/locales/de.js
@@ -34,7 +34,7 @@ export const de = {
         title: 'Datenschutzerklarung',
         closePolicy: 'Datenschutzerklarung schliessen',
         contentAria: 'Inhalt der Datenschutzerklarung',
-        opensInNewTab: 'wird in einem neuen Tab geoffnet',
+        opensInNewTab: '(wird in einem neuen Tab geoffnet)',
         loadFailed: 'Datenschutzerklarung konnte nicht geladen werden. Bitte spater erneut versuchen.',
     },
     errors: {

--- a/public/src/i18n/locales/en.js
+++ b/public/src/i18n/locales/en.js
@@ -94,7 +94,7 @@ export const en = {
         title: 'Privacy Policy',
         closePolicy: 'Close privacy policy',
         contentAria: 'Privacy Policy content',
-        opensInNewTab: 'opens in a new tab',
+        opensInNewTab: '(opens in a new tab)',
         loadFailed: 'Failed to load privacy policy. Please try again later.',
     },
     errors: {

--- a/public/src/i18n/locales/es.js
+++ b/public/src/i18n/locales/es.js
@@ -36,7 +36,7 @@ export const es = {
         title: 'Politica de privacidad',
         closePolicy: 'Cerrar politica de privacidad',
         contentAria: 'Contenido de la politica de privacidad',
-        opensInNewTab: 'se abre en una pestana nueva',
+        opensInNewTab: '(se abre en una pestana nueva)',
         loadFailed: 'No se pudo cargar la politica de privacidad. Intentalo de nuevo mas tarde.',
     },
     errors: {

--- a/public/src/i18n/locales/fr.js
+++ b/public/src/i18n/locales/fr.js
@@ -35,7 +35,7 @@ export const fr = {
         title: 'Politique de confidentialite',
         closePolicy: 'Fermer la politique de confidentialite',
         contentAria: 'Contenu de la politique de confidentialite',
-        opensInNewTab: 'ouvre dans un nouvel onglet',
+        opensInNewTab: '(ouvre dans un nouvel onglet)',
         loadFailed: 'Impossible de charger la politique de confidentialite. Veuillez reessayer plus tard.',
     },
     errors: {

--- a/public/src/i18n/locales/hu.js
+++ b/public/src/i18n/locales/hu.js
@@ -93,7 +93,7 @@ export const hu = {
         title: 'Adatvédelmi irányelvek',
         closePolicy: 'Adatvédelmi irányelvek bezárása',
         contentAria: 'Adatvédelmi irányelvek tartalma',
-        opensInNewTab: 'új lapon nyílik meg',
+        opensInNewTab: '(új lapon nyílik meg)',
         loadFailed: 'Nem sikerült betölteni az adatvédelmi irányelveket. Kérjük, próbálja újra később.',
     },
     errors: {

--- a/public/src/i18n/locales/it.js
+++ b/public/src/i18n/locales/it.js
@@ -35,7 +35,7 @@ export const it = {
         title: 'Informativa sulla privacy',
         closePolicy: 'Chiudi informativa sulla privacy',
         contentAria: 'Contenuto informativa sulla privacy',
-        opensInNewTab: 'si apre in una nuova scheda',
+        opensInNewTab: '(si apre in una nuova scheda)',
         loadFailed: 'Impossibile caricare la privacy policy. Riprova piu tardi.',
     },
     errors: {

--- a/public/src/i18n/locales/ja.js
+++ b/public/src/i18n/locales/ja.js
@@ -33,7 +33,7 @@ export const ja = {
         title: 'プライバシーポリシー',
         closePolicy: 'プライバシーポリシーを閉じる',
         contentAria: 'プライバシーポリシーの内容',
-        opensInNewTab: '新しいタブで開きます',
+        opensInNewTab: '(新しいタブで開きます)',
         loadFailed: 'プライバシーポリシーを読み込めませんでした。後でもう一度お試しください。',
     },
     errors: {

--- a/public/src/i18n/locales/pt-BR.js
+++ b/public/src/i18n/locales/pt-BR.js
@@ -35,7 +35,7 @@ export const ptBR = {
         title: 'Politica de privacidade',
         closePolicy: 'Fechar politica de privacidade',
         contentAria: 'Conteudo da politica de privacidade',
-        opensInNewTab: 'abre em novo separador',
+        opensInNewTab: '(abre em novo separador)',
         loadFailed: 'Falha ao carregar a politica de privacidade. Tente novamente mais tarde.',
     },
     errors: {

--- a/public/src/i18n/locales/zh-CN.js
+++ b/public/src/i18n/locales/zh-CN.js
@@ -33,7 +33,7 @@ export const zhCN = {
         title: '隐私政策',
         closePolicy: '关闭隐私政策',
         contentAria: '隐私政策内容',
-        opensInNewTab: '将在新标签页打开',
+        opensInNewTab: '(将在新标签页打开)',
         loadFailed: '无法加载隐私政策。请稍后重试。',
     },
     errors: {


### PR DESCRIPTION
🌍 Globe: Extract translation for external link screen reader text

**What**: Extracted the hardcoded `(opens in a new tab)` screen reader text from the GitHub external link in `public/index.html` by wrapping it with `data-i18n="privacy.opensInNewTab"`. Also adjusted the translation key in all translation files to include the parenthesis to ensure proper semantic extraction.
**Why**: The screen reader text was hardcoded in English, which degraded the accessibility experience for non-English users.
**Nuance**: By formatting the translation files (e.g. `(opens in a new tab)`) rather than hardcoding the parenthesis in HTML, we ensure that full-width parenthesis or specific punctuation formatting can be provided by the localized dictionary, maintaining proper grammar and spacing.

---
*PR created automatically by Jules for task [1281892212759048340](https://jules.google.com/task/1281892212759048340) started by @2fst4u*