### PR TITLE
🎨 Palette: Link language toggle button to menu via aria-controls

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -246,7 +246,7 @@
             <!-- Scout: Upgraded generic div to semantic footer for better structure -->
             <footer class="sidebar-footer">
                 <div class="language-selector">
-                    <button id="languageToggle" class="link-button" aria-haspopup="true" aria-expanded="false" data-i18n="common.selectLanguage">Language</button>
+                    <button id="languageToggle" class="link-button" aria-haspopup="menu" aria-controls="languageMenu" aria-expanded="false" data-i18n="common.selectLanguage">Language</button>
                     <div id="languageMenu" class="language-menu" role="menu"></div>
                 </div>
                 <span>•</span>


### PR DESCRIPTION
**💡 What:** Updated the `aria-haspopup` attribute from `"true"` to `"menu"` and added `aria-controls="languageMenu"` to the `<button id="languageToggle">` element in `public/index.html`.
**🎯 Why:** This change explicitly establishes the semantic relationship between the toggle button and the dropdown menu it controls (`<div id="languageMenu">`), providing screen readers with the necessary context to understand and interact with the widget correctly.
**📸 Before/After:** N/A (Visuals remain unaffected as this is a purely semantic/accessibility update).
**♿ Accessibility:** Improves screen reader comprehension of the language selection dropdown by properly associating the trigger button with the target menu content, fulfilling WCAG guidelines for complex widgets.

---
*PR created automatically by Jules for task [4918225384013848170](https://jules.google.com/task/4918225384013848170) started by @2fst4u*