### PR TITLE
🔭 Scout: Upgrade race info wrappers to semantic p tags

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -26,3 +26,7 @@
 
 **Learning:** The application uses Cloudflare Pages/Workers (`wrangler.toml`) where `src/worker.js` is configured to only intercept API routes (`run_worker_first = ["/api/*"]`). It cannot be used for Edge HTML rewriting (e.g., dynamically injecting specific Open Graph meta tags for Facebook crawlers) because the main SPA HTML is served directly as a static asset.
 **Action:** When attempting to improve static metadata that requires crawler visibility without executing JS (like `og:image`), do not attempt to write Edge handlers in `src/worker.js`.
+## 2025-05-02 - Semantic Tags and Default Browser Margins
+
+**Learning:** Upgrading generic HTML containers (`<div>`, `<span>`) to semantic text tags (like `<p>`) for better SEO document outline introduces default browser user-agent styles (specifically, block-level display and top/bottom margins). This can unexpectedly break the visual layout if the elements were originally designed without margins.
+**Action:** When replacing generic wrappers with semantic text tags, always inspect the corresponding CSS selectors and explicitly add CSS resets (e.g., `margin: 0`) to prevent visual regressions while maintaining semantic value for crawlers.

--- a/public/index.html
+++ b/public/index.html
@@ -174,10 +174,12 @@
                     <!-- Scout: Added a generic fallback alt text for SEO and accessibility before JS populates the country name -->
                     <img id="countryFlag" class="race-info-flag" alt="Country flag">
                     <div class="race-info-details">
-                        <div class="race-info-country" id="raceInfoCountry"></div>
+                        <!-- Scout: Upgraded generic div to semantic p to provide better structural meaning to textual content for crawlers -->
+                        <p class="race-info-country" id="raceInfoCountry"></p>
                 <!-- Scout: Upgraded generic div to semantic h2 for better heading hierarchy and discoverability -->
                 <h2 class="race-info-name" id="raceInfoName"></h2>
-                        <div class="race-info-circuit" id="raceInfoCircuit"></div>
+                        <!-- Scout: Upgraded generic div to semantic p to provide better structural meaning to textual content for crawlers -->
+                        <p class="race-info-circuit" id="raceInfoCircuit"></p>
                     </div>
                 </section>
 
@@ -363,7 +365,8 @@
                     <div class="mobile-race-info-text">
                 <!-- Scout: Upgraded generic span to semantic h2 for consistent heading hierarchy across viewports -->
                 <h2 id="mobileRaceInfoName"></h2>
-                        <span id="mobileRaceInfoCircuit"></span>
+                        <!-- Scout: Upgraded generic span to semantic p to provide better structural meaning to textual content for crawlers -->
+                        <p id="mobileRaceInfoCircuit"></p>
                     </div>
                 </section>
             </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1389,6 +1389,7 @@ body {
     text-transform: uppercase;
     letter-spacing: 0.05em;
     color: var(--color-text-secondary);
+    margin: 0;
 }
 
 .race-info-name {
@@ -1405,6 +1406,7 @@ body {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    margin: 0;
 }
 
 /* Mobile Race Info Overlay */
@@ -1494,12 +1496,13 @@ body {
         margin: 0;
     }
 
-    .mobile-race-info-text span:last-child {
+    .mobile-race-info-text p:last-child {
         font-size: 0.7rem;
         color: var(--color-text-secondary);
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        margin: 0;
     }
 }
 


### PR DESCRIPTION
💡 **What:** Upgraded the generic `<div>` and `<span>` wrappers used for displaying the race country and circuit names (`#raceInfoCountry`, `#raceInfoCircuit`, `#mobileRaceInfoCircuit`) to semantic `<p>` tags. CSS resets (`margin: 0`) were added to maintain the visual layout.
🎯 **Why:** Generic containers like `<div>` and `<span>` do not provide intrinsic meaning to the text they hold.
📊 **Value:** Using semantic `<p>` tags explicitly tells search engines and assistive technologies that the content represents distinct paragraphs of textual data, improving the parsing of the document outline and overall semantic structure for better discoverability.
🔬 **Measurement:** Inspect the DOM in the Race Info Banner or Mobile Race Info sections; the elements will now be `<p class="race-info-country">`, `<p class="race-info-circuit">`, and `<p id="mobileRaceInfoCircuit">`. Verify no visual changes occurred compared to production.

---
*PR created automatically by Jules for task [5550157604503812045](https://jules.google.com/task/5550157604503812045) started by @2fst4u*