### PR TITLE
🌍 Globe: Extract translation for weather forecast labels

### DIFF
--- a/.jules/globe.md
+++ b/.jules/globe.md
@@ -1,3 +1,3 @@
-## 2024-04-24 - HTML data-i18n-attr for dynamically updated attributes
-**Learning:** Even if an element's attribute (like an `aria-label` or `title`) is dynamically updated by a JavaScript component after load (e.g. `WeatherRadar.js` updating playback speeds), the initial HTML markup must still use `data-i18n-attr` to localize the initial state. This ensures screen readers and crawlers see localized strings before the JS executes.
-**Action:** When extracting hardcoded strings from HTML, check if they represent an initial state for a dynamically updated attribute. If so, create a dedicated base translation key for that initial state and use `data-i18n-attr` to bind it.
+## 2024-05-02 - Degree Symbol in HTML Replacement
+**Learning:** When using `replace_with_git_merge_diff` to extract hardcoded strings in HTML containing special characters (like the degree symbol `°`), terminal output (like `cat`) might render them in a specific way that differs from the raw source code or how it appears in the browser. The `SEARCH` block must strictly match the characters exactly as they appear in the file.
+**Action:** Always verify the exact character representation using a file reader or outputting a very tight `sed` or `head`/`tail` bound on the target lines before attempting a merge diff.

--- a/public/index.html
+++ b/public/index.html
@@ -194,15 +194,15 @@
                             <!-- Scout: Upgraded generic div/span wrappers to semantic description list (dl/dt/dd) to explicitly associate weather labels with their values for crawlers and assistive tech. -->
                             <dl class="weather-current">
                                 <div class="weather-metric">
-                                    <dt class="weather-label">Temp</dt>
+                                    <dt class="weather-label" data-i18n="weather.temp">Temp</dt>
                                     <dd class="weather-value" id="weatherTemp">--°</dd>
                                 </div>
                                 <div class="weather-metric">
-                                    <dt class="weather-label">Rain</dt>
+                                    <dt class="weather-label" data-i18n="weather.rain">Rain</dt>
                                     <dd class="weather-value" id="weatherRain">--%</dd>
                                 </div>
                                 <div class="weather-metric">
-                                    <dt class="weather-label">Wind</dt>
+                                    <dt class="weather-label" data-i18n="weather.wind">Wind</dt>
                                     <dd class="weather-value" id="weatherWind">--</dd>
                                     <dd class="weather-sub" id="weatherWindDir">--</dd>
                                 </div>

--- a/public/src/i18n/locales/de.js
+++ b/public/src/i18n/locales/de.js
@@ -15,7 +15,7 @@ export const de = {
     },
     weather: {
         currentConditions: 'Aktuelle Bedingungen',
-        temp: 'Temp', rain: 'Regen', wind: 'Wind', windDirection: 'Windrichtung: {{direction}} ({{degrees}} Grad)',
+        temp: 'Temp.', rain: 'Regen', wind: 'Wind', windDirection: 'Windrichtung: {{direction}} ({{degrees}} Grad)',
         timelineAria: '{{time}}. {{description}}. Temperatur {{temp}} Grad. Regenwahrscheinlichkeit {{rain}}%. Wind {{wind}} {{windUnit}}.',
         currentCircuitWeather: 'Aktuelles Streckenwetter', temperature: 'Temperatur', rainChance: 'Regenchance', humidity: 'Luftfeuchtigkeit', windSpeed: 'Windgeschwindigkeit',
     },

--- a/public/src/i18n/locales/en.js
+++ b/public/src/i18n/locales/en.js
@@ -41,7 +41,7 @@ export const en = {
     },
     weather: {
         currentConditions: 'Current Conditions',
-        temp: 'Temp',
+        temp: 'Temp.',
         rain: 'Rain',
         wind: 'Wind',
         windDirection: 'Wind direction: {{direction}} ({{degrees}} degrees)',

--- a/public/src/i18n/locales/es.js
+++ b/public/src/i18n/locales/es.js
@@ -16,7 +16,7 @@ export const es = {
     },
     weather: {
         currentConditions: 'Condiciones actuales',
-        temp: 'Temp', rain: 'Lluvia', wind: 'Viento', windDirection: 'Direccion del viento: {{direction}} ({{degrees}} grados)',
+        temp: 'Temp.', rain: 'Lluvia', wind: 'Viento', windDirection: 'Direccion del viento: {{direction}} ({{degrees}} grados)',
         timelineAria: '{{time}}. {{description}}. Temperatura {{temp}} grados. Probabilidad de lluvia {{rain}}%. Viento {{wind}} {{windUnit}}.',
         currentCircuitWeather: 'Tiempo actual del circuito', temperature: 'Temperatura', rainChance: 'Prob. lluvia', humidity: 'Humedad', windSpeed: 'Velocidad del viento',
     },

--- a/public/src/i18n/locales/fr.js
+++ b/public/src/i18n/locales/fr.js
@@ -16,7 +16,7 @@ export const fr = {
     },
     weather: {
         currentConditions: 'Conditions actuelles',
-        temp: 'Temp', rain: 'Pluie', wind: 'Vent', windDirection: 'Direction du vent : {{direction}} ({{degrees}} degres)',
+        temp: 'Temp.', rain: 'Pluie', wind: 'Vent', windDirection: 'Direction du vent : {{direction}} ({{degrees}} degres)',
         timelineAria: '{{time}}. {{description}}. Temperature {{temp}} degres. Risque de pluie {{rain}}%. Vent {{wind}} {{windUnit}}.',
         currentCircuitWeather: 'Meteo actuelle du circuit', temperature: 'Temperature', rainChance: 'Risque de pluie', humidity: 'Humidite', windSpeed: 'Vitesse du vent',
     },

--- a/public/src/i18n/locales/it.js
+++ b/public/src/i18n/locales/it.js
@@ -16,7 +16,7 @@ export const it = {
     },
     weather: {
         currentConditions: 'Condizioni attuali',
-        temp: 'Temp', rain: 'Pioggia', wind: 'Vento', windDirection: 'Direzione vento: {{direction}} ({{degrees}} gradi)',
+        temp: 'Temp.', rain: 'Pioggia', wind: 'Vento', windDirection: 'Direzione vento: {{direction}} ({{degrees}} gradi)',
         timelineAria: '{{time}}. {{description}}. Temperatura {{temp}} gradi. Probabilita pioggia {{rain}}%. Vento {{wind}} {{windUnit}}.',
         currentCircuitWeather: 'Meteo attuale del circuito', temperature: 'Temperatura', rainChance: 'Prob. pioggia', humidity: 'Umidita', windSpeed: 'Velocita vento',
     },

--- a/public/src/i18n/locales/pt-BR.js
+++ b/public/src/i18n/locales/pt-BR.js
@@ -16,7 +16,7 @@ export const ptBR = {
     },
     weather: {
         currentConditions: 'Condições atuais',
-        temp: 'Temp', rain: 'Chuva', wind: 'Vento', windDirection: 'Direcao do vento: {{direction}} ({{degrees}} graus)',
+        temp: 'Temp.', rain: 'Chuva', wind: 'Vento', windDirection: 'Direcao do vento: {{direction}} ({{degrees}} graus)',
         timelineAria: '{{time}}. {{description}}. Temperatura {{temp}} graus. Probabilidade de chuva {{rain}}%. Vento {{wind}} {{windUnit}}.',
         currentCircuitWeather: 'Tempo atual do circuito', temperature: 'Temperatura', rainChance: 'Chance de chuva', humidity: 'Humidade', windSpeed: 'Velocidade do vento',
     },


### PR DESCRIPTION
💡 What: Extracted the hardcoded "Temp", "Rain", and "Wind" labels in the session forecast block and added them to the localization system using the existing `weather.temp`, `weather.rain`, and `weather.wind` keys. Also updated the `temp` key in English and target locales to include a period (`Temp.`) to properly denote the abbreviation.

🎯 Why: These labels were hardcoded in the HTML, causing the session forecast dashboard to always display them in English regardless of the user's selected language. The English dictionary also used "Temp", which is better formatted as an abbreviation "Temp."

🌐 Nuance: Maintained existing translation terms for Rain and Wind in target locales as they were already accurate. Updated the abbreviation formatting universally to ensure consistency across UI elements.

---
*PR created automatically by Jules for task [4285755635711777031](https://jules.google.com/task/4285755635711777031) started by @2fst4u*