### PR TITLE
🎨 Palette: Remove redundant sr-only span from sidebar toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-19 - Screen reader visibility of disabled inputs
 **Learning:** Screen readers might not consistently announce elements with only the `disabled` property. Adding `aria-disabled="true"` to inputs like `select` gives screen reader users explicit information that an element is present but currently inactive, which provides better context than skipping it entirely.
 **Action:** When adding or dynamically toggling the `disabled` property on form elements or buttons, also update the `aria-disabled` attribute to maintain synchronization for assistive technologies.
+## 2026-05-03 - Redundant labels for screen readers
+**Learning:** Adding an internal visually hidden span (e.g., `<span class="sr-only">`) inside an interactive element like a button that already has an explicit `aria-label` causes screen readers to redundantly announce the label twice.
+**Action:** Always avoid using an internal `.sr-only` span for text if the parent interactive element already provides the exact same information via an `aria-label` attribute.

--- a/public/index.html
+++ b/public/index.html
@@ -99,7 +99,6 @@
                 <button class="sidebar-toggle" id="sidebarToggle" aria-label="Open menu"
                     title="Open menu" aria-expanded="false" data-i18n-attr="aria-label:common.openMenu,title:common.openMenu"
                     aria-controls="sidebar">
-                    <span class="sr-only" data-i18n="common.openMenu">Open menu</span>
                     <svg class="icon-menu" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor"
                         stroke-width="2">
                         <line x1="3" y1="6" x2="21" y2="6"></line>


### PR DESCRIPTION
**What:** Removed the redundant visually hidden `<span>` inside the sidebar toggle button.
**Why:** The button already provides an `aria-label`, so including an additional `sr-only` span with the same text causes screen readers to announce the label twice, degrading the user experience.
**Before/After:** The visually hidden span was removed. No visual changes.
**Accessibility:** Improved screen reader experience by eliminating redundant announcements for the menu toggle button.

---
*PR created automatically by Jules for task [15179761439355730512](https://jules.google.com/task/15179761439355730512) started by @2fst4u*