### PR TITLE
📚 Archivist: Document Mapbox ToS caching compliance in worker

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -75,6 +75,12 @@ const VENDOR_ASSETS = new Map([
   }],
 
   // Mapbox GL JS Assets
+  // NOTE: We only proxy and cache the software libraries (JS/CSS) here for strict CSP compliance.
+  // This is completely acceptable under Mapbox's Terms of Service. Mapbox's strict anti-caching ToS
+  // only applies to "Licensed Map Content" (tiles, styles, geocoding API responses), which our app
+  // fetches directly client-side, bypassing this worker.
+  // Because these static files are heavily cached by Cloudflare, it will cause `api.mapbox.com` to show
+  // a very high cache rate in Cloudflare analytics. This is expected and is NOT a ToS violation.
   ['mapbox-gl.js', {
     upstream: 'https://api.mapbox.com/mapbox-gl-js/v3.0.1/mapbox-gl.js',
     contentTypes: ['application/javascript', 'text/javascript'],


### PR DESCRIPTION
**What:**
Added a documentation comment block to `src/worker.js` above the Mapbox GL JS proxy definitions (`VENDOR_ASSETS`).

**Why:**
To prevent confusion regarding Mapbox's strict Terms of Service against caching "Licensed Map Content". The Cloudflare dashboard shows a high cache rate for `api.mapbox.com` because the worker proxies the open-source software libraries (`mapbox-gl.js` / `mapbox-gl.css`), which is entirely permitted. The actual map data (tiles/styles) bypasses the worker.

**Value:**
Clarifies compliance and prevents future developers from unnecessarily removing the proxy (which is needed for strict CSP compliance) out of fear of a ToS violation.

---
*PR created automatically by Jules for task [1905200962068100453](https://jules.google.com/task/1905200962068100453) started by @2fst4u*