### PR TITLE
🎨 Palette: Add focus-visible styles to footer links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2026-05-03 - Redundant labels for screen readers
 **Learning:** Adding an internal visually hidden span (e.g., `<span class="sr-only">`) inside an interactive element like a button that already has an explicit `aria-label` causes screen readers to redundantly announce the label twice.
 **Action:** Always avoid using an internal `.sr-only` span for text if the parent interactive element already provides the exact same information via an `aria-label` attribute.
+## 2024-05-04 - Sidebar Links Focus Visibility
+**Learning:** External links and link-buttons used in the sidebar footer (Language, Privacy, GitHub) were visually indistinguishable from non-focused states when navigated via keyboard, despite having hover states. Relying only on hover states degrades accessibility for non-pointer users.
+**Action:** When adding or reviewing interactive footer links, ensure they include `:focus-visible` CSS rules that match the application's primary focus ring pattern (e.g., `outline: 2px solid var(--color-primary); outline-offset: 2px;`) to meet WCAG focus visibility requirements without compromising mouse user experience.

--- a/public/styles.css
+++ b/public/styles.css
@@ -599,6 +599,11 @@ body {
     color: var(--color-primary);
 }
 
+.link-button:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}
+
 .sidebar-footer span {
     color: var(--color-border);
 }
@@ -1833,6 +1838,11 @@ button:disabled,
     display: inline-flex;
     align-items: center;
     gap: 4px;
+}
+
+.external-link:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
 }
 
 .icon-external {


### PR DESCRIPTION
- 💡 **What**: Added `:focus-visible` CSS rules for `.link-button` and `.external-link` classes in `public/styles.css`.
- 🎯 **Why**: Improves keyboard navigation accessibility. Currently, the Language, Privacy, and GitHub links in the sidebar footer lack clear visual indicators when focused via keyboard.
- 📸 **Before/After**: Keyboard focus on footer links is now clearly visible with a primary-colored outline.
- ♿ **Accessibility**: Ensures interactive elements have a visible focus ring, adhering to WCAG focus visibility requirements without compromising the pointer/mouse user experience.

---
*PR created automatically by Jules for task [11412659268052706470](https://jules.google.com/task/11412659268052706470) started by @2fst4u*