### PR TITLE
🔭 Scout: Upgrade MapWeatherWidget container to semantic section

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -30,3 +30,7 @@
 
 **Learning:** Upgrading generic HTML containers (`<div>`, `<span>`) to semantic text tags (like `<p>`) for better SEO document outline introduces default browser user-agent styles (specifically, block-level display and top/bottom margins). This can unexpectedly break the visual layout if the elements were originally designed without margins.
 **Action:** When replacing generic wrappers with semantic text tags, always inspect the corresponding CSS selectors and explicitly add CSS resets (e.g., `margin: 0`) to prevent visual regressions while maintaining semantic value for crawlers.
+## 2025-05-02 - Upgrading DOM elements requires test updates
+
+**Learning:** Upgrading generic root container tags (like changing `document.createElement('div')` to `'section'`) for better semantic meaning directly breaks rigid Vitest spies, such as `expect(document.createElement).toHaveBeenCalledWith('div')`.
+**Action:** When upgrading or modifying the root HTML tags of UI components, always `grep` for and update corresponding strict DOM creation assertions in the Vitest test files to prevent test suite regressions.

--- a/public/src/map/MapWeatherWidget.js
+++ b/public/src/map/MapWeatherWidget.js
@@ -6,7 +6,8 @@ import { i18n } from '../i18n/index.js';
  */
 class MapWeatherWidgetClass {
     constructor() {
-        this._div = document.createElement('div');
+        // Scout: Upgraded generic div to semantic section to improve document outline and explicitly signal this standalone widget region to search engines.
+        this._div = document.createElement('section');
         this._div.className = 'leaflet-control-weather mapboxgl-ctrl mapboxgl-ctrl-group';
         this._div.setAttribute('role', 'region');
         this._div.setAttribute('aria-label', i18n.t('weather.currentCircuitWeather'));

--- a/tests/map-weather-widget.test.js
+++ b/tests/map-weather-widget.test.js
@@ -80,7 +80,7 @@ describe('MapWeatherWidget', () => {
     });
 
     it('should initialize with correct DOM structure', () => {
-        expect(document.createElement).toHaveBeenCalledWith('div');
+        expect(document.createElement).toHaveBeenCalledWith('section');
         expect(widget._div).toBeDefined();
         expect(widget._div.setAttribute).toHaveBeenCalledWith('data-i18n-attr', 'aria-label:weather.currentCircuitWeather');
 


### PR DESCRIPTION
💡 What: Upgraded the generic `div` wrapper for the map weather widget to a semantic `<section>` element.
🎯 Why: The widget already acts as a distinct conceptual region (`role="region"`) with an accessible label, but using a generic `div` hides this explicit structure from crawlers reading the HTML tree natively.
📊 Value: Improves document outline and explicit DOM parsing for search engines, signaling that the widget is a standalone thematic section of the page.
🔬 Measurement: Verify the DOM output inside the map container now injects a `<section>` instead of a `<div>` for the `.leaflet-control-weather` class.

---
*PR created automatically by Jules for task [4534301885735691945](https://jules.google.com/task/4534301885735691945) started by @2fst4u*