### PR TITLE
🧪 Spec: Add Track Proxy Content-Type validation test

### DIFF
--- a/tests/worker-security-content-type.test.js
+++ b/tests/worker-security-content-type.test.js
@@ -157,6 +157,23 @@ describe('Worker Security: Strict Content-Type Validation', () => {
     });
   });
 
+  describe('Track Proxy (/api/track/*)', () => {
+    it('blocks deceptive type: text/html', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockFetch.mockResolvedValueOnce(new Response('<html></html>', {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' }
+      }));
+
+      const req = createRequest('/api/track/monaco');
+      const res = await worker.fetch(req, global.env, global.ctx);
+
+      expect(res.status).toBe(502);
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+  });
+
   describe('Vendor Assets Proxy (/api/assets/*)', () => {
     it('allows text/css; charset=utf-8', async () => {
         // Valid hash for leaflet.css


### PR DESCRIPTION
What: Added Content-Type validation test for the Track API proxy.
Why: The Track proxy's content-type validation logic was completely uncovered, leaving a potential gap in MIME sniffing protection testing. This ensures that the proxy behaves securely when returning 502 for unexpected upstream MIME types like `text/html`.

---
*PR created automatically by Jules for task [10481575568004162361](https://jules.google.com/task/10481575568004162361) started by @2fst4u*