### PR TITLE
🎨 Palette: Add aria-hidden to decorative SVGs

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -163,7 +163,7 @@ export class CircuitWeatherApp {
                     btn.disabled = true;
                     btn.setAttribute('aria-disabled', 'true');
                     // Palette UX: Add loading spinner to async submit button
-                    btn.innerHTML = `<svg style="width: 1rem; height: 1rem; margin-right: 0.5rem; animation: spin 1s linear infinite;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 2v4m0 12v4M4.93 4.93l2.83 2.83m8.48 8.48l2.83 2.83M2 12h4m12 0h4M4.93 19.07l2.83-2.83m8.48-8.48l2.83-2.83"></path></svg>${escapeHtml(i18n.t('common.retrying'))}`;
+                    btn.innerHTML = `<svg aria-hidden="true" style="width: 1rem; height: 1rem; margin-right: 0.5rem; animation: spin 1s linear infinite;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 2v4m0 12v4M4.93 4.93l2.83 2.83m8.48 8.48l2.83 2.83M2 12h4m12 0h4M4.93 19.07l2.83-2.83m8.48-8.48l2.83-2.83"></path></svg>${escapeHtml(i18n.t('common.retrying'))}`;
                     btn.setAttribute('aria-label', i18n.t('errors.retryingConnection'));
                     window.location.reload();
                 });

--- a/public/src/map/RecentreControl.js
+++ b/public/src/map/RecentreControl.js
@@ -32,7 +32,7 @@ export class RecentreControl {
         this.button.setAttribute('aria-label', recenterLabel);
         this.button.setAttribute('aria-keyshortcuts', 'c');
         this.button.innerHTML = `
-            <svg class="recentre-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="width: 20px; height: 20px;">
+            <svg class="recentre-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="width: 20px; height: 20px;">
                 <circle cx="12" cy="12" r="3"/>
                 <path d="M12 2v4M12 18v4M2 12h4M18 12h4"/>
             </svg>


### PR DESCRIPTION
- **What:** Added `aria-hidden="true"` to the decorative SVG icons in the map recentre button (`RecentreControl.js`) and the retry connection button (`CircuitWeatherApp.js`).
- **Why:** The buttons already have appropriate descriptive `aria-label` text. Hiding the decorative SVG icons prevents screen readers from redundantly trying to announce the SVG elements.
- **Before/After:** The SVGs now have the `aria-hidden="true"` attribute whereas previously they did not.
- **Accessibility:** Improves screen reader experience by hiding decorative graphical elements inside labeled buttons, preventing noisy or redundant announcements.

---
*PR created automatically by Jules for task [9792548350544829151](https://jules.google.com/task/9792548350544829151) started by @2fst4u*