### PR TITLE
🎨 Palette: Add focus-visible states to map controls

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -710,6 +710,15 @@ body {
     background: var(--color-surface-elevated) !important;
 }
 
+.leaflet-control-zoom a:focus-visible,
+.leaflet-control-zoom-in:focus-visible,
+.leaflet-control-zoom-out:focus-visible,
+.leaflet-control-zoom-recentre:focus-visible {
+    outline: 2px solid var(--color-primary) !important;
+    outline-offset: 2px;
+    z-index: 10;
+}
+
 /* Range Circle Labels */
 .range-label {
     background: transparent !important;


### PR DESCRIPTION
💡 What: Added explicit `:focus-visible` styling (`outline: 2px solid var(--color-primary); z-index: 10;`) to the Leaflet map controls (zoom in, zoom out, recentre).
🎯 Why: Previously, the map control buttons only had hover and active states, meaning keyboard users tabbing through the interface had no visual indication of which map control was currently focused.
📸 Before/After: Visual focus rings now appear strictly when navigating via keyboard.
♿ Accessibility: Directly satisfies WCAG 2.4.7 (Focus Visible), ensuring interactive map controls are clearly discernible for keyboard navigation.

---
*PR created automatically by Jules for task [5184981045017492932](https://jules.google.com/task/5184981045017492932) started by @2fst4u*