### PR TITLE
🧪 Spec: Add MapManager coverage test

### DIFF
--- a/tests/map-manager.test.js
+++ b/tests/map-manager.test.js
@@ -632,3 +632,54 @@ describe("MapManager", () => {
     });
   });
 });
+
+
+
+describe("MapManager coverage test", () => {
+    let mapManager;
+    let mapboxMapMock;
+
+    beforeEach(() => {
+        mapboxMapMock = {
+            getStyle: vi.fn(),
+            getLayoutProperty: vi.fn(),
+            setLayoutProperty: vi.fn(),
+            on: vi.fn(),
+        };
+        mapManager = new MapManager();
+        mapManager.isMapbox = true;
+        mapManager.map = mapboxMapMock;
+    });
+
+    it('should ignore layers without text-field property', () => {
+        mapboxMapMock.getStyle.mockReturnValue({
+            layers: [{ id: 'layer1', type: 'symbol' }]
+        });
+        mapboxMapMock.getLayoutProperty.mockReturnValue(undefined);
+
+        mapManager.applyMapLanguage('fr');
+
+        expect(mapboxMapMock.setLayoutProperty).not.toHaveBeenCalled();
+    });
+
+    it('should ignore layers without name field in text-field expression', () => {
+        mapboxMapMock.getStyle.mockReturnValue({
+            layers: [{ id: 'layer1', type: 'symbol' }]
+        });
+        mapboxMapMock.getLayoutProperty.mockReturnValue(['get', 'highway']); // No "name" or 'name'
+
+        mapManager.applyMapLanguage('fr');
+
+        expect(mapboxMapMock.setLayoutProperty).not.toHaveBeenCalled();
+    });
+
+    it('should ignore layers that are not symbol type', () => {
+        mapboxMapMock.getStyle.mockReturnValue({
+            layers: [{ id: 'layer1', type: 'fill' }]
+        });
+
+        mapManager.applyMapLanguage('fr');
+
+        expect(mapboxMapMock.setLayoutProperty).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
💡 What: Added unit tests targeting edge cases in MapManager's label translation logic (layers without text-fields or name references or invalid layer types).
🎯 Why: To defend critical mapping logic from regressions and increase overall test suite robustness.
📈 Maturity Impact: N/A - existing branch coverage threshold was left as a read-only guardrail since it is already extremely healthy at 95%.

---
*PR created automatically by Jules for task [3466588503375306523](https://jules.google.com/task/3466588503375306523) started by @2fst4u*