### PR TITLE
🧹 Sweep: Remove unused forecast-content CSS class

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -186,7 +186,7 @@
                 <!-- Weather Forecast -->
                 <section class="forecast-section" id="forecastSection" aria-labelledby="forecastHeading" style="display: none;">
                     <h2 id="forecastHeading" data-i18n="forecast.heading">Session Forecast</h2>
-                    <div class="forecast-content" id="forecastContent">
+                    <div id="forecastContent">
                         <!-- Content injected by JS -->
                         <!-- Scout: Upgraded generic div wrappers to semantic article and section for explicit document outline parsing -->
                         <article class="weather-dashboard">


### PR DESCRIPTION
💡 What: Removed the unused `forecast-content` CSS class from the `<div id="forecastContent">` element in `public/index.html`.
🎯 Why: It was an orphaned CSS class; no corresponding CSS styles were defined for this class anywhere in the codebase (verified via global search).
🔬 Verification: Checked with `grep -rn "\.forecast-content" public/styles.css` and a global codebase search to confirm zero usage. Verified that tests run and pass without issues.

---
*PR created automatically by Jules for task [14864337355062266362](https://jules.google.com/task/14864337355062266362) started by @2fst4u*