### PR TITLE
📚 Archivist: Clarify cache durations in privacy policy

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -228,3 +228,6 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 
 **Learning:** When using Node.js scripts to inject text into markdown files (like `PRIVACY.*.md`), using template literals with indentation can inadvertently inject whitespace, breaking markdown formatting by converting text into code blocks. Also, relying on complex `RegExp` for trailing lines with various localized characters can fail (e.g., throwing `SyntaxError: Invalid regular expression... Nothing to repeat`) if the regex string is not properly escaped for all possible localized punctuation.
 **Action:** Always left-align script contents and template literals in heredocs (e.g., `cat << 'EOF' > script.cjs`). Use exact string replacements or highly simplified regexes (like `targetAfter: 'Leaflet'`) to bypass character encoding and regex escaping errors in localized files.
+## 2024-05-09 - Missing Caching Durations in Privacy Policy
+**Learning:** The privacy policy only documented caching durations for one out of five proxied data sources, leaving the data retention times for the others ambiguous despite them being explicitly defined in the worker cache headers.
+**Action:** Always verify that documentation of data retention and caching covers all relevant services consistently.

--- a/public/PRIVACY.md
+++ b/public/PRIVACY.md
@@ -77,11 +77,11 @@ To improve performance and reliability, we load standard libraries and assets fr
 
 The following services provide the raw data that we process and cache via Cloudflare. Your device does not connect to them directly for data API calls.
 
-- **Jolpica F1:** Historical and current F1 schedule data.
-- **GitHub (bacinger/f1-circuits):** Stores static track layout files (GeoJSON).
+- **Jolpica F1:** Historical and current F1 schedule data (1-hour edge cache).
+- **GitHub (bacinger/f1-circuits):** Stores static track layout files (GeoJSON) (24-hour edge cache).
 - **RainViewer:** Weather radar tiles (2-hour edge cache) and metadata (1-minute cache).
-- **Leaflet (via Unpkg):** Map interaction library assets (proxied for security).
-- **Mapbox (via Mapbox CDN):** Map interaction library assets (proxied for security).
+- **Leaflet (via Unpkg):** Map interaction library assets (proxied for security, 1-year immutable cache).
+- **Mapbox (via Mapbox CDN):** Map interaction library assets (proxied for security, 1-year immutable cache).
 
 ## Local Storage
 


### PR DESCRIPTION
💡 Problem: The privacy policy only documented caching durations for one out of five proxied data sources, leaving the data retention times for the others ambiguous despite them being explicitly defined in the worker cache headers and `AGENTS.md`.
🎯 Fix: Added explicit cache durations to the Jolpica F1, GitHub, Leaflet, and Mapbox entries in the "Data Sources (Proxied)" section to accurately reflect the caching reality implemented in the proxy worker. Also recorded this learning in the Archivist journal.
🔬 Verification: Checked `src/worker.js` and `AGENTS.md` to confirm the cache TTL values match the implemented code. Ran tests with `pnpm test`.
🔎 Scope: This PR contains ONLY documentation changes.

---
*PR created automatically by Jules for task [12863659537553031448](https://jules.google.com/task/12863659537553031448) started by @2fst4u*