### PR TITLE
🌍 Globe: Extract translation for GitHub link title

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -256,7 +256,7 @@
                 <span>•</span>
                 <!-- Scout: Added title attribute to external link to provide search engines with more context about the destination -->
                 <a href="https://github.com/circuit-weather/circuit-weather" target="_blank" rel="noopener noreferrer"
-                    class="external-link" title="View Source Code on GitHub">
+                    class="external-link" title="View Source Code on GitHub" data-i18n-attr="title:common.github">
                     GitHub
                     <svg class="icon-external" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor"
                         stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/public/src/i18n/locales/de.js
+++ b/public/src/i18n/locales/de.js
@@ -1,5 +1,5 @@
 export const de = {
-    common: { loading: 'Wird geladen...', retry: 'Erneut versuchen', retrying: 'Versuche erneut...', selectLanguage: 'Sprache', openMenu: 'Menu offnen', closeMenu: 'Menu schliessen', skipToContent: 'Zum Hauptinhalt springen' },
+    common: { github: 'Quellcode auf GitHub ansehen', loading: 'Wird geladen...', retry: 'Erneut versuchen', retrying: 'Versuche erneut...', selectLanguage: 'Sprache', openMenu: 'Menu offnen', closeMenu: 'Menu schliessen', skipToContent: 'Zum Hauptinhalt springen' },
     theme: { toggle: 'Hell/Dunkelmodus umschalten', switchToLight: 'Zu hellem Modus wechseln', switchToDark: 'Zu dunklem Modus wechseln' },
     loading: { schedule: 'Lade Rennkalender...', session: 'Lade Sessiondaten...' },
     controls: {

--- a/public/src/i18n/locales/en.js
+++ b/public/src/i18n/locales/en.js
@@ -1,5 +1,5 @@
 export const en = {
-    common: {
+    common: { github: 'View Source Code on GitHub',
         loading: 'Loading...',
         retry: 'Retry',
         retrying: 'Retrying...',

--- a/public/src/i18n/locales/es.js
+++ b/public/src/i18n/locales/es.js
@@ -1,5 +1,5 @@
 export const es = {
-    common: { loading: 'Cargando...', retry: 'Reintentar', retrying: 'Reintentando...', selectLanguage: 'Idioma', openMenu: 'Abrir menu', closeMenu: 'Cerrar menu', skipToContent: 'Saltar al contenido principal' },
+    common: { github: 'Ver código fuente en GitHub', loading: 'Cargando...', retry: 'Reintentar', retrying: 'Reintentando...', selectLanguage: 'Idioma', openMenu: 'Abrir menu', closeMenu: 'Cerrar menu', skipToContent: 'Saltar al contenido principal' },
     theme: { toggle: 'Cambiar modo claro/oscuro', switchToLight: 'Cambiar a modo claro', switchToDark: 'Cambiar a modo oscuro' },
     loading: { schedule: 'Cargando calendario de carreras...', session: 'Cargando datos de la sesion...' },
     controls: {

--- a/public/src/i18n/locales/fr.js
+++ b/public/src/i18n/locales/fr.js
@@ -1,5 +1,5 @@
 export const fr = {
-    common: { loading: 'Chargement...', retry: 'Reessayer', retrying: 'Nouvelle tentative...', selectLanguage: 'Langue', openMenu: 'Ouvrir le menu', closeMenu: 'Fermer le menu', skipToContent: 'Passer au contenu principal' },
+    common: { github: 'Voir le code source sur GitHub', loading: 'Chargement...', retry: 'Reessayer', retrying: 'Nouvelle tentative...', selectLanguage: 'Langue', openMenu: 'Ouvrir le menu', closeMenu: 'Fermer le menu', skipToContent: 'Passer au contenu principal' },
     theme: { toggle: 'Basculer mode clair/sombre', switchToLight: 'Passer en mode clair', switchToDark: 'Passer en mode sombre' },
     loading: { schedule: 'Chargement du calendrier des courses...', session: 'Chargement des donnees de session...' },
     controls: {

--- a/public/src/i18n/locales/hu.js
+++ b/public/src/i18n/locales/hu.js
@@ -1,5 +1,5 @@
 export const hu = {
-    common: {
+    common: { github: 'Forráskód megtekintése a GitHubon',
         loading: 'Betöltés...',
         retry: 'Újrapróbálkozás',
         retrying: 'Újrapróbálkozás folyamatban...',

--- a/public/src/i18n/locales/it.js
+++ b/public/src/i18n/locales/it.js
@@ -1,5 +1,5 @@
 export const it = {
-    common: { loading: 'Caricamento...', retry: 'Riprova', retrying: 'Nuovo tentativo...', selectLanguage: 'Lingua', openMenu: 'Apri menu', closeMenu: 'Chiudi menu', skipToContent: 'Vai al contenuto principale' },
+    common: { github: 'Visualizza il codice sorgente su GitHub', loading: 'Caricamento...', retry: 'Riprova', retrying: 'Nuovo tentativo...', selectLanguage: 'Lingua', openMenu: 'Apri menu', closeMenu: 'Chiudi menu', skipToContent: 'Vai al contenuto principale' },
     theme: { toggle: 'Attiva tema chiaro/scuro', switchToLight: 'Passa al tema chiaro', switchToDark: 'Passa al tema scuro' },
     loading: { schedule: 'Caricamento calendario gare...', session: 'Caricamento dati sessione...' },
     controls: {

--- a/public/src/i18n/locales/ja.js
+++ b/public/src/i18n/locales/ja.js
@@ -1,5 +1,5 @@
 export const ja = {
-    common: { loading: '読み込み中...', retry: '再試行', retrying: '再試行中...', selectLanguage: '言語', openMenu: 'メニューを開く', closeMenu: 'メニューを閉じる', skipToContent: 'メインコンテンツへスキップ' },
+    common: { github: 'GitHubでソースコードを表示', loading: '読み込み中...', retry: '再試行', retrying: '再試行中...', selectLanguage: '言語', openMenu: 'メニューを開く', closeMenu: 'メニューを閉じる', skipToContent: 'メインコンテンツへスキップ' },
     theme: { toggle: 'ライト/ダークモードを切り替え', switchToLight: 'ライトモードに切り替え', switchToDark: 'ダークモードに切り替え' },
     loading: { schedule: 'レーススケジュールを読み込み中...', session: 'セッションデータを読み込み中...' },
     controls: {

--- a/public/src/i18n/locales/pt-BR.js
+++ b/public/src/i18n/locales/pt-BR.js
@@ -1,5 +1,5 @@
 export const ptBR = {
-    common: { loading: 'A carregar...', retry: 'Tentar novamente', retrying: 'A tentar novamente...', selectLanguage: 'Idioma', openMenu: 'Abrir menu', closeMenu: 'Fechar menu', skipToContent: 'Pular para o conteúdo principal' },
+    common: { github: 'Ver código-fonte no GitHub', loading: 'A carregar...', retry: 'Tentar novamente', retrying: 'A tentar novamente...', selectLanguage: 'Idioma', openMenu: 'Abrir menu', closeMenu: 'Fechar menu', skipToContent: 'Pular para o conteúdo principal' },
     theme: { toggle: 'Alternar modo claro/escuro', switchToLight: 'Mudar para modo claro', switchToDark: 'Mudar para modo escuro' },
     loading: { schedule: 'A carregar calendario de corridas...', session: 'A carregar dados da sessao...' },
     controls: {

--- a/public/src/i18n/locales/zh-CN.js
+++ b/public/src/i18n/locales/zh-CN.js
@@ -1,5 +1,5 @@
 export const zhCN = {
-    common: { loading: '加载中...', retry: '重试', retrying: '正在重试...', selectLanguage: '语言', openMenu: '打开菜单', closeMenu: '关闭菜单', skipToContent: '跳转到主要内容' },
+    common: { github: '在 GitHub 上查看源代码', loading: '加载中...', retry: '重试', retrying: '正在重试...', selectLanguage: '语言', openMenu: '打开菜单', closeMenu: '关闭菜单', skipToContent: '跳转到主要内容' },
     theme: { toggle: '切换明亮/深色模式', switchToLight: '切换到明亮模式', switchToDark: '切换到深色模式' },
     loading: { schedule: '正在加载比赛赛历...', session: '正在加载赛段数据...' },
     controls: {


### PR DESCRIPTION
💡 What: Extracted the hardcoded string "View Source Code on GitHub" from the external link title in `public/index.html` and added the `common.github` translation key to all target locale files.
🎯 Why: The title attribute was hardcoded in English, meaning non-English speaking users and assistive technologies would hear an untranslated phrase. Extracting it ensures the link's tooltip and context are fully localized.
🌐 Nuance: Maintained "GitHub" as an untranslated term across all locales, as it is a widely recognized brand name that native speakers commonly use in English.

---
*PR created automatically by Jules for task [14097105878707385136](https://jules.google.com/task/14097105878707385136) started by @2fst4u*