### PR TITLE
🎨 Palette: Add aria-pressed state to radar play/pause button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -318,7 +318,7 @@
             <!-- Scout: Upgraded generic div to semantic section for better structure and screen reader landmarks -->
             <section class="radar-controls" id="radarControls" aria-label="Radar Playback Controls" style="display: none;">
                 <button class="radar-play-btn" id="radarPlayBtn" aria-label="Play radar animation" title="Play (Space)" data-i18n-attr="aria-label:radar.play,title:radar.playTitle"
-                    aria-keyshortcuts="Space">
+                    aria-keyshortcuts="Space" aria-pressed="false">
                     <svg class="icon-play" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
                         <polygon points="5,3 19,12 5,21"></polygon>
                     </svg>

--- a/public/src/map/WeatherRadar.js
+++ b/public/src/map/WeatherRadar.js
@@ -1060,6 +1060,7 @@ export class WeatherRadar {
         this.isPlaying = true;
         if (this.ui.playBtn) {
             this.ui.playBtn.classList.add('playing');
+            this.ui.playBtn.setAttribute('aria-pressed', 'true');
             this.ui.playBtn.setAttribute('aria-label', i18n.t('radar.pause'));
             this.ui.playBtn.setAttribute('title', i18n.t('radar.pauseTitle'));
         }
@@ -1091,6 +1092,7 @@ export class WeatherRadar {
         this.isPlaying = false;
         if (this.ui.playBtn) {
             this.ui.playBtn.classList.remove('playing');
+            this.ui.playBtn.setAttribute('aria-pressed', 'false');
             this.ui.playBtn.setAttribute('aria-label', i18n.t('radar.play'));
             this.ui.playBtn.setAttribute('title', i18n.t('radar.playTitle'));
         }


### PR DESCRIPTION
* 💡 What: Added `aria-pressed` attribute to the radar play/pause toggle button.
* 🎯 Why: This helps screen reader users understand the current toggle state of the button directly via semantics, rather than relying solely on the changing `aria-label`.
* 📸 Before/After: N/A (non-visual change)
* ♿ Accessibility: Improved screen reader feedback for toggle states.

---
*PR created automatically by Jules for task [2735808123163347114](https://jules.google.com/task/2735808123163347114) started by @2fst4u*