### PR TITLE
🔭 Scout: Upgrade sponsorship widget container to semantic aside

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -34,3 +34,7 @@
 
 **Learning:** Upgrading generic root container tags (like changing `document.createElement('div')` to `'section'`) for better semantic meaning directly breaks rigid Vitest spies, such as `expect(document.createElement).toHaveBeenCalledWith('div')`.
 **Action:** When upgrading or modifying the root HTML tags of UI components, always `grep` for and update corresponding strict DOM creation assertions in the Vitest test files to prevent test suite regressions.
+## 2025-05-10 - Semantic Tags for Third-Party Widgets
+
+**Learning:** Replacing generic wrapper `<div>` elements around third-party scripts (like "Buy me a coffee" sponsorship buttons) with semantic `<aside>` elements explicitly signals to search engine crawlers that the content is secondary or tangentially related, properly pulling it out of the primary document outline without breaking the third-party widget's rendering.
+**Action:** Always consider the structural implication of wrapper tags for external embeds. Use `<aside>` for sponsorships or ads, but ensure existing CSS class names (e.g., `.bmc-container`) are preserved exactly so visual styling remains intact.

--- a/public/index.html
+++ b/public/index.html
@@ -234,7 +234,8 @@
                 </section>
             </nav>
 
-            <div class="bmc-container">
+            <!-- Scout: Upgraded generic bmc-container div to semantic aside to clearly designate sponsorship/secondary content to search engines -->
+            <aside class="bmc-container" aria-label="Sponsor">
                 <script type="text/javascript" src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js"
                     integrity="sha384-OibPdNn05smfqAFi21q8C4YkzZLEjwXs7kTtiqrJwOv7PtZefVaGPzKgX4rJfvWv" crossorigin="anonymous"
                     data-name="bmc-button" data-slug="2fst4u" data-color="#FF5F5F" data-emoji="" data-font="Poppins"
@@ -242,7 +243,7 @@
                     data-coffee-color="#FFDD00"
                     integrity="sha384-OibPdNn05smfqAFi21q8C4YkzZLEjwXs7kTtiqrJwOv7PtZefVaGPzKgX4rJfvWv"
                     crossorigin="anonymous"></script>
-            </div>
+            </aside>
 
             <!-- Scout: Upgraded generic div to semantic footer for better structure -->
             <footer class="sidebar-footer">


### PR DESCRIPTION
**💡 What:** Upgraded the generic `<div class="bmc-container">` wrapper around the "Buy me a coffee" sponsorship script to a semantic `<aside class="bmc-container" aria-label="Sponsor">` tag, and added an HTML comment explaining the change.
**🎯 Why:** Crawlers benefit from explicit structural landmarks. Replacing a `<div>` with an `<aside>` pulls this secondary content out of the main document outline, helping search engines focus on the page's primary weather data while correctly categorizing the sponsorship widget.
**📊 Value:** Improves document hierarchy parsing for search engines, making the primary content more prominent and correctly siloing secondary calls-to-action.
**🔬 Measurement:** Inspect the DOM output in `public/index.html` to confirm that the `.bmc-container` element is now rendered as an `<aside>` tag and includes the `aria-label="Sponsor"` attribute.

---
*PR created automatically by Jules for task [3287558186058904298](https://jules.google.com/task/3287558186058904298) started by @2fst4u*