### PR TITLE
🌍 Globe: Extract translation for error timer seconds

### DIFF
--- a/.jules/globe.md
+++ b/.jules/globe.md
@@ -1,3 +1,6 @@
 ## 2024-05-02 - Degree Symbol in HTML Replacement
 **Learning:** When using `replace_with_git_merge_diff` to extract hardcoded strings in HTML containing special characters (like the degree symbol `°`), terminal output (like `cat`) might render them in a specific way that differs from the raw source code or how it appears in the browser. The `SEARCH` block must strictly match the characters exactly as they appear in the file.
 **Action:** Always verify the exact character representation using a file reader or outputting a very tight `sed` or `head`/`tail` bound on the target lines before attempting a merge diff.
+## 2024-05-11 - Error Toast Countdown String Extracted
+**Learning:** Hardcoded short suffixes like `s` in `${remaining}s` bypass localization.
+**Action:** Always extract single-character or very short suffixes, taking care to adapt appropriately for languages like Japanese ('秒') or Hungarian ('mp').

--- a/public/src/i18n/locales/de.js
+++ b/public/src/i18n/locales/de.js
@@ -27,7 +27,7 @@ export const de = {
         serviceError: 'Dienstfehler', highTraffic: 'Hohe Auslastung', rateLimitExceeded: 'Ratenlimit uberschritten. Kurz pausiert.',
         retryingFailedTiles: 'Versuche {{count}} fehlgeschlagene Kachel{{suffix}} erneut...', radarStatus: 'Radarstatus: {{status}}',
     },
-    countdown: { startsIn: 'Startet in', day: 'Tag', dayPlural: 'Tage', hour: 'Stunde', hourPlural: 'Stunden', minute: 'Minute', minutePlural: 'Minuten', second: 'Sekunde', secondPlural: 'Sekunden' , dayShort: 'T', hourShort: 'Std'},
+    countdown: { startsIn: 'Startet in', day: 'Tag', dayPlural: 'Tage', hour: 'Stunde', hourPlural: 'Stunden', minute: 'Minute', minutePlural: 'Minuten', second: 'Sekunde', secondPlural: 'Sekunden' , secondShort: 's', dayShort: 'T', hourShort: 'Std'},
     map: { recenterOnCircuit: 'Auf Strecke zentrieren', zoomIn: 'Vergrößern', zoomOut: 'Verkleinern' },
     privacy: {
         link: 'Datenschutz',

--- a/public/src/i18n/locales/en.js
+++ b/public/src/i18n/locales/en.js
@@ -83,7 +83,7 @@ export const en = {
         minute: 'minute',
         minutePlural: 'minutes',
         second: 'second',
-        secondPlural: 'seconds', dayShort: 'd', hourShort: 'h'},
+        secondPlural: 'seconds', secondShort: 's', dayShort: 'd', hourShort: 'h'},
     map: {
         recenterOnCircuit: 'Recentre on circuit',
         zoomIn: 'Zoom in',

--- a/public/src/i18n/locales/es.js
+++ b/public/src/i18n/locales/es.js
@@ -29,7 +29,7 @@ export const es = {
         retryingFailedTiles: 'Reintentando {{count}} tesela{{suffix}} fallida{{suffix}}...', radarStatus: 'Estado del radar: {{status}}',
     },
     countdown: {
-        startsIn: 'Empieza en', day: 'dia', dayPlural: 'dias', hour: 'hora', hourPlural: 'horas', minute: 'minuto', minutePlural: 'minutos', second: 'segundo', secondPlural: 'segundos', dayShort: 'd', hourShort: 'h'},
+        startsIn: 'Empieza en', day: 'dia', dayPlural: 'dias', hour: 'hora', hourPlural: 'horas', minute: 'minuto', minutePlural: 'minutos', second: 'segundo', secondPlural: 'segundos', secondShort: 's', dayShort: 'd', hourShort: 'h'},
     map: { recenterOnCircuit: 'Recentrar en circuito', zoomIn: 'Acercar', zoomOut: 'Alejar' },
     privacy: {
         link: 'Privacidad',

--- a/public/src/i18n/locales/fr.js
+++ b/public/src/i18n/locales/fr.js
@@ -28,7 +28,7 @@ export const fr = {
         serviceError: 'Erreur du service', highTraffic: 'Trafic eleve', rateLimitExceeded: 'Limite de requetes depassee. Pause momentanee.',
         retryingFailedTiles: 'Nouvelle tentative pour {{count}} tuile{{suffix}} en echec...', radarStatus: 'Statut radar : {{status}}',
     },
-    countdown: { startsIn: 'Debute dans', day: 'jour', dayPlural: 'jours', hour: 'heure', hourPlural: 'heures', minute: 'minute', minutePlural: 'minutes', second: 'seconde', secondPlural: 'secondes' , dayShort: 'j', hourShort: 'h'},
+    countdown: { startsIn: 'Debute dans', day: 'jour', dayPlural: 'jours', hour: 'heure', hourPlural: 'heures', minute: 'minute', minutePlural: 'minutes', second: 'seconde', secondPlural: 'secondes' , secondShort: 's', dayShort: 'j', hourShort: 'h'},
     map: { recenterOnCircuit: 'Recentrer sur le circuit', zoomIn: 'Zoomer', zoomOut: 'Dézoomer' },
     privacy: {
         link: 'Confidentialite',

--- a/public/src/i18n/locales/hu.js
+++ b/public/src/i18n/locales/hu.js
@@ -82,7 +82,7 @@ export const hu = {
         minute: 'perc',
         minutePlural: 'perc',
         second: 'másodperc',
-        secondPlural: 'másodperc', dayShort: 'n', hourShort: 'ó'},
+        secondPlural: 'másodperc', secondShort: 'mp', dayShort: 'n', hourShort: 'ó'},
     map: {
         recenterOnCircuit: 'Központosítás a pályára',
         zoomIn: 'Nagyítás',

--- a/public/src/i18n/locales/it.js
+++ b/public/src/i18n/locales/it.js
@@ -28,7 +28,7 @@ export const it = {
         serviceError: 'Errore servizio', highTraffic: 'Traffico elevato', rateLimitExceeded: 'Limite richieste superato. Pausa momentanea.',
         retryingFailedTiles: 'Nuovo tentativo per {{count}} tile non riuscita{{suffix}}...', radarStatus: 'Stato radar: {{status}}',
     },
-    countdown: { startsIn: 'Inizia tra', day: 'giorno', dayPlural: 'giorni', hour: 'ora', hourPlural: 'ore', minute: 'minuto', minutePlural: 'minuti', second: 'secondo', secondPlural: 'secondi' , dayShort: 'g', hourShort: 'h'},
+    countdown: { startsIn: 'Inizia tra', day: 'giorno', dayPlural: 'giorni', hour: 'ora', hourPlural: 'ore', minute: 'minuto', minutePlural: 'minuti', second: 'secondo', secondPlural: 'secondi' , secondShort: 's', dayShort: 'g', hourShort: 'h'},
     map: { recenterOnCircuit: 'Ricentra sul circuito', zoomIn: 'Ingrandire', zoomOut: 'Rimpicciolire' },
     privacy: {
         link: 'Privacy',

--- a/public/src/i18n/locales/ja.js
+++ b/public/src/i18n/locales/ja.js
@@ -26,7 +26,7 @@ export const ja = {
         connectionInstability: '接続が不安定です', serviceError: 'サービスエラー', highTraffic: 'アクセス集中',
         rateLimitExceeded: 'リクエスト上限を超えました。しばらく待機します。', retryingFailedTiles: '失敗したタイル {{count}} 件を再試行中...', radarStatus: 'レーダー状態: {{status}}',
     },
-    countdown: { startsIn: '開始まで', day: '日', dayPlural: '日', hour: '時間', hourPlural: '時間', minute: '分', minutePlural: '分', second: '秒', secondPlural: '秒' , dayShort: '日', hourShort: '時間' },
+    countdown: { startsIn: '開始まで', day: '日', dayPlural: '日', hour: '時間', hourPlural: '時間', minute: '分', minutePlural: '分', second: '秒', secondPlural: '秒' , secondShort: '秒', dayShort: '日', hourShort: '時間' },
     map: { recenterOnCircuit: 'サーキットに再センタリング', zoomIn: '拡大', zoomOut: '縮小' },
     privacy: {
         link: 'プライバシー',

--- a/public/src/i18n/locales/pt-BR.js
+++ b/public/src/i18n/locales/pt-BR.js
@@ -28,7 +28,7 @@ export const ptBR = {
         serviceError: 'Erro de servico', highTraffic: 'Trafego elevado', rateLimitExceeded: 'Limite de pedidos excedido. Pausa momentanea.',
         retryingFailedTiles: 'A tentar novamente {{count}} bloco{{suffix}} com falha...', radarStatus: 'Estado do radar: {{status}}',
     },
-    countdown: { startsIn: 'Comeca em', day: 'dia', dayPlural: 'dias', hour: 'hora', hourPlural: 'horas', minute: 'minuto', minutePlural: 'minutos', second: 'segundo', secondPlural: 'segundos' , dayShort: 'd', hourShort: 'h'},
+    countdown: { startsIn: 'Comeca em', day: 'dia', dayPlural: 'dias', hour: 'hora', hourPlural: 'horas', minute: 'minuto', minutePlural: 'minutos', second: 'segundo', secondPlural: 'segundos' , secondShort: 's', dayShort: 'd', hourShort: 'h'},
     map: { recenterOnCircuit: 'Recentrar no circuito', zoomIn: 'Aproximar', zoomOut: 'Afastar' },
     privacy: {
         link: 'Privacidade',

--- a/public/src/i18n/locales/zh-CN.js
+++ b/public/src/i18n/locales/zh-CN.js
@@ -26,7 +26,7 @@ export const zhCN = {
         connectionInstability: '连接不稳定', serviceError: '服务错误', highTraffic: '访问量高',
         rateLimitExceeded: '请求过于频繁，已暂时暂停。', retryingFailedTiles: '正在重试 {{count}} 个失败瓦片...', radarStatus: '雷达状态: {{status}}',
     },
-    countdown: { startsIn: '开始倒计时', day: '天', dayPlural: '天', hour: '小时', hourPlural: '小时', minute: '分钟', minutePlural: '分钟', second: '秒', secondPlural: '秒' , dayShort: '天', hourShort: '小时' },
+    countdown: { startsIn: '开始倒计时', day: '天', dayPlural: '天', hour: '小时', hourPlural: '小时', minute: '分钟', minutePlural: '分钟', second: '秒', secondPlural: '秒' , secondShort: '秒', dayShort: '天', hourShort: '小时' },
     map: { recenterOnCircuit: '回到赛道中心', zoomIn: '放大', zoomOut: '缩小' },
     privacy: {
         link: '隐私',

--- a/public/src/map/WeatherRadar.js
+++ b/public/src/map/WeatherRadar.js
@@ -644,7 +644,7 @@ export class WeatherRadar {
 
             const remaining = Math.ceil((endTime - Date.now()) / 1000);
             if (remaining > 0) {
-                this.ui.errorTimer.textContent = `${remaining}s`;
+                this.ui.errorTimer.textContent = `${remaining}${i18n.t('countdown.secondShort')}`;
                 this.toastAnimationFrame = requestAnimationFrame(updateTimer);
             } else {
                 this.ui.errorTimer.textContent = '';


### PR DESCRIPTION
💡 What: Extracted the hardcoded "s" (seconds abbreviation) from the WeatherRadar error toast timer into the i18n dictionaries as `countdown.secondShort`, and applied appropriate translations across all locale files.
🎯 Why: The short "s" suffix was hardcoded directly in the JavaScript view logic (`${remaining}s`), meaning it would bypass localization and appear awkwardly for locales where the standard abbreviation differs or uses different spacing.
🌐 Nuance: Kept 's' for locales where the SI unit abbreviation 's' for seconds is standard (e.g., French, German, Spanish), while ensuring it can be adapted or spaced properly for languages like Japanese ('秒') or Hungarian ('mp').

---
*PR created automatically by Jules for task [7516977629690348047](https://jules.google.com/task/7516977629690348047) started by @2fst4u*