### PR TITLE
🔭 Scout: Upgrade generic wrappers to semantic <hgroup> to strengthen heading associations

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -38,3 +38,7 @@
 
 **Learning:** Replacing generic wrapper `<div>` elements around third-party scripts (like "Buy me a coffee" sponsorship buttons) with semantic `<aside>` elements explicitly signals to search engine crawlers that the content is secondary or tangentially related, properly pulling it out of the primary document outline without breaking the third-party widget's rendering.
 **Action:** Always consider the structural implication of wrapper tags for external embeds. Use `<aside>` for sponsorships or ads, but ensure existing CSS class names (e.g., `.bmc-container`) are preserved exactly so visual styling remains intact.
+## 2025-05-13 - Semantic grouping of titles and metadata
+
+**Learning:** When a generic container `<div>` is used to group an `<h2>` (or any `h1-h6`) with contextual paragraphs (like subheadings or metadata, e.g., Country, Circuit Name), crawlers may parse them as disjointed elements. Upgrading the wrapper to an `<hgroup>` explicitly signals to search engines that the paragraphs function as subheadings for the primary heading entity.
+**Action:** Always look for opportunities to upgrade `<div>` wrappers to `<hgroup>` when grouping headings with `<p>` tags, ensuring to apply `margin: 0` CSS resets since `<hgroup>` is a block-level element that may carry different browser default styles than a generic `div`.

--- a/public/index.html
+++ b/public/index.html
@@ -172,14 +172,15 @@
                 <section class="race-info-banner" id="raceInfoBanner" aria-labelledby="raceInfoName" style="display: none;">
                     <!-- Scout: Added a generic fallback alt text for SEO and accessibility before JS populates the country name -->
                     <img id="countryFlag" class="race-info-flag" alt="Country flag">
-                    <div class="race-info-details">
+                    <!-- Scout: Upgraded generic div wrapper to semantic hgroup to explicitly associate the subheadings/metadata with the primary h2 element for crawlers. -->
+                    <hgroup class="race-info-details">
                         <!-- Scout: Upgraded generic div to semantic p to provide better structural meaning to textual content for crawlers -->
                         <p class="race-info-country" id="raceInfoCountry"></p>
                 <!-- Scout: Upgraded generic div to semantic h2 for better heading hierarchy and discoverability -->
                 <h2 class="race-info-name" id="raceInfoName"></h2>
                         <!-- Scout: Upgraded generic div to semantic p to provide better structural meaning to textual content for crawlers -->
                         <p class="race-info-circuit" id="raceInfoCircuit"></p>
-                    </div>
+                    </hgroup>
                 </section>
 
 
@@ -362,12 +363,13 @@
                 <section class="mobile-race-info" id="mobileRaceInfo" aria-labelledby="mobileRaceInfoName" style="display: none;">
                     <!-- Scout: Added a generic fallback alt text for SEO and accessibility before JS populates the country name -->
                     <img id="mobileCountryFlag" class="mobile-race-info-flag" alt="Country flag">
-                    <div class="mobile-race-info-text">
+                    <!-- Scout: Upgraded generic div wrapper to semantic hgroup to explicitly associate the subheadings/metadata with the primary h2 element for crawlers. -->
+                    <hgroup class="mobile-race-info-text">
                 <!-- Scout: Upgraded generic span to semantic h2 for consistent heading hierarchy across viewports -->
                 <h2 id="mobileRaceInfoName"></h2>
                         <!-- Scout: Upgraded generic span to semantic p to provide better structural meaning to textual content for crawlers -->
                         <p id="mobileRaceInfoCircuit"></p>
-                    </div>
+                    </hgroup>
                 </section>
             </div>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1395,6 +1395,7 @@ body {
 .race-info-details {
     flex: 1;
     min-width: 0;
+    margin: 0;
 }
 
 .race-info-country {
@@ -1498,6 +1499,7 @@ body {
         display: flex;
         flex-direction: column;
         gap: 1px;
+        margin: 0;
     }
 
     .mobile-race-info-text h2 {


### PR DESCRIPTION
💡 What: Upgraded generic `<div>` wrappers (`.race-info-details` and `.mobile-race-info-text`) to semantic `<hgroup>` tags.
🎯 Why: Groups the `<h2>` race name directly with its contextual `<p>` tags (country, circuit name), explicitly signaling to search engines that these paragraphs function as subheadings/metadata for the race entity.
📊 Value: Strengthens document outline and explicit entity context mapping for crawlers.
🔬 Measurement: Verify the DOM outputs `<hgroup>` around the headers without any visual layout or spacing regressions.

---
*PR created automatically by Jules for task [10174212766601269813](https://jules.google.com/task/10174212766601269813) started by @2fst4u*