### PR TITLE
🌍 Globe: Extract translation for session empty state aria-label

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -222,7 +222,7 @@
 
                 <!-- Session Empty State -->
                 <!-- Scout: Upgraded generic div to semantic section for consistent landmarks and improved document structure. -->
-                <section id="sessionEmptyState" class="empty-state" style="display: none;" aria-live="polite" aria-label="Select session prompt">
+                <section id="sessionEmptyState" class="empty-state" style="display: none;" aria-live="polite" aria-label="Select a session to view forecast" data-i18n-attr="aria-label:forecast.emptyStateAria">
                     <svg class="empty-state-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none"
                         stroke="currentColor" stroke-width="1.5">
                         <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>

--- a/public/src/i18n/locales/de.js
+++ b/public/src/i18n/locales/de.js
@@ -11,7 +11,7 @@ export const de = {
     forecast: {
         heading: 'Session-Prognose', hourlyForecast: 'Stundenprognose', availableFrom: 'Prognose verfugbar ab {{date}}', availableSoon: 'Prognose bald verfugbar',
         availableCloser: 'Prognose naher an der Session verfugbar', unavailable: 'Prognose konnte nicht geladen werden',
-        failedTryAgain: 'Prognose konnte nicht geladen werden. Bitte erneut versuchen.', selectSessionPrompt: 'Wahlen Sie eine Session, um die Prognose zu sehen',
+        failedTryAgain: 'Prognose konnte nicht geladen werden. Bitte erneut versuchen.', selectSessionPrompt: 'Wahlen Sie eine Session, um die Prognose zu sehen', emptyStateAria: 'Wählen Sie eine Session, um die Prognose zu sehen',
     },
     weather: {
         currentConditions: 'Aktuelle Bedingungen',

--- a/public/src/i18n/locales/en.js
+++ b/public/src/i18n/locales/en.js
@@ -37,7 +37,7 @@ export const en = {
         availableCloser: 'Forecast available closer to session',
         unavailable: 'Unable to load forecast data',
         failedTryAgain: 'Failed to load forecast data. Please try again.',
-        selectSessionPrompt: 'Select a session to view forecast',
+        selectSessionPrompt: 'Select a session to view forecast', emptyStateAria: 'Select a session to view the forecast',
     },
     weather: {
         currentConditions: 'Current Conditions',

--- a/public/src/i18n/locales/es.js
+++ b/public/src/i18n/locales/es.js
@@ -12,7 +12,7 @@ export const es = {
         heading: 'Pronostico de sesion', hourlyForecast: 'Pronostico por hora',
         availableFrom: 'Pronostico disponible desde {{date}}', availableSoon: 'Pronostico disponible pronto',
         availableCloser: 'Pronostico disponible mas cerca de la sesion', unavailable: 'No se pudo cargar el pronostico',
-        failedTryAgain: 'No se pudo cargar el pronostico. Intentalo de nuevo.', selectSessionPrompt: 'Selecciona una sesion para ver el pronostico',
+        failedTryAgain: 'No se pudo cargar el pronostico. Intentalo de nuevo.', selectSessionPrompt: 'Selecciona una sesion para ver el pronostico', emptyStateAria: 'Selecciona una sesión para ver el pronóstico',
     },
     weather: {
         currentConditions: 'Condiciones actuales',

--- a/public/src/i18n/locales/fr.js
+++ b/public/src/i18n/locales/fr.js
@@ -12,7 +12,7 @@ export const fr = {
         heading: 'Previsions de session', hourlyForecast: 'Previsions horaires', availableFrom: 'Previsions disponibles a partir de {{date}}',
         availableSoon: 'Previsions disponibles bientot', availableCloser: 'Previsions disponibles plus pres de la session',
         unavailable: 'Impossible de charger les previsions', failedTryAgain: 'Echec du chargement des previsions. Veuillez reessayer.',
-        selectSessionPrompt: 'Selectionnez une session pour voir les previsions',
+        selectSessionPrompt: 'Selectionnez une session pour voir les previsions', emptyStateAria: 'Sélectionnez une session pour voir les prévisions',
     },
     weather: {
         currentConditions: 'Conditions actuelles',

--- a/public/src/i18n/locales/hu.js
+++ b/public/src/i18n/locales/hu.js
@@ -37,7 +37,7 @@ export const hu = {
         availableCloser: 'Előrejelzés az eseményhez közeledve lesz elérhető',
         unavailable: 'Nem sikerült betölteni az előrejelzést',
         failedTryAgain: 'Nem sikerült betölteni az előrejelzést. Kérjük, próbálja újra.',
-        selectSessionPrompt: 'Válasszon egy eseményt az előrejelzés megtekintéséhez',
+        selectSessionPrompt: 'Válasszon egy eseményt az előrejelzés megtekintéséhez', emptyStateAria: 'Válasszon egy eseményt az előrejelzés megtekintéséhez',
     },
     weather: {
         currentConditions: 'Jelenlegi körülmények',

--- a/public/src/i18n/locales/it.js
+++ b/public/src/i18n/locales/it.js
@@ -12,7 +12,7 @@ export const it = {
         heading: 'Previsioni sessione', hourlyForecast: 'Previsioni orarie', availableFrom: 'Previsioni disponibili da {{date}}',
         availableSoon: 'Previsioni disponibili a breve', availableCloser: 'Previsioni disponibili piu vicino alla sessione',
         unavailable: 'Impossibile caricare le previsioni', failedTryAgain: 'Impossibile caricare le previsioni. Riprova.',
-        selectSessionPrompt: 'Seleziona una sessione per vedere le previsioni',
+        selectSessionPrompt: 'Seleziona una sessione per vedere le previsioni', emptyStateAria: 'Seleziona una sessione per vedere le previsioni',
     },
     weather: {
         currentConditions: 'Condizioni attuali',

--- a/public/src/i18n/locales/ja.js
+++ b/public/src/i18n/locales/ja.js
@@ -11,7 +11,7 @@ export const ja = {
     forecast: {
         heading: 'セッション予報', hourlyForecast: '時間別予報', availableFrom: '{{date}} から予報を表示できます', availableSoon: 'まもなく予報を表示できます',
         availableCloser: 'セッション開始が近づくと予報を表示できます', unavailable: '予報を読み込めませんでした',
-        failedTryAgain: '予報の読み込みに失敗しました。もう一度お試しください。', selectSessionPrompt: '予報を見るにはセッションを選択してください',
+        failedTryAgain: '予報の読み込みに失敗しました。もう一度お試しください。', selectSessionPrompt: '予報を見るにはセッションを選択してください', emptyStateAria: '予報を見るにはセッションを選択してください',
     },
     weather: {
         currentConditions: '現在の状況',

--- a/public/src/i18n/locales/pt-BR.js
+++ b/public/src/i18n/locales/pt-BR.js
@@ -12,7 +12,7 @@ export const ptBR = {
         heading: 'Previsao da sessao', hourlyForecast: 'Previsao horaria', availableFrom: 'Previsao disponivel a partir de {{date}}',
         availableSoon: 'Previsao disponivel em breve', availableCloser: 'Previsao disponivel mais perto da sessao',
         unavailable: 'Nao foi possivel carregar a previsao', failedTryAgain: 'Falha ao carregar a previsao. Tente novamente.',
-        selectSessionPrompt: 'Selecione uma sessao para ver a previsao',
+        selectSessionPrompt: 'Selecione uma sessao para ver a previsao', emptyStateAria: 'Selecione uma sessão para ver a previsão',
     },
     weather: {
         currentConditions: 'Condições atuais',

--- a/public/src/i18n/locales/zh-CN.js
+++ b/public/src/i18n/locales/zh-CN.js
@@ -11,7 +11,7 @@ export const zhCN = {
     forecast: {
         heading: '赛段天气预报', hourlyForecast: '逐小时预报', availableFrom: '{{date}} 起可查看预报', availableSoon: '预报即将可用',
         availableCloser: '临近赛段开始时可查看预报', unavailable: '无法加载预报',
-        failedTryAgain: '加载预报失败。请重试。', selectSessionPrompt: '请选择赛段以查看预报',
+        failedTryAgain: '加载预报失败。请重试。', selectSessionPrompt: '请选择赛段以查看预报', emptyStateAria: '请选择赛段以查看预报',
     },
     weather: {
         currentConditions: '当前状况',


### PR DESCRIPTION
💡 What: Extracted the hardcoded `aria-label` string for the session empty state to use a new `forecast.emptyStateAria` translation key. Added translations for this new key to all supported dictionaries.
🎯 Why: The `aria-label` text ("Select session prompt") was previously hardcoded in the HTML, meaning screen readers would only announce it in English regardless of the user's selected language, and it was awkwardly phrased.
🌐 Nuance: We updated the prompt wording to be more descriptive ("Select a session to view the forecast") to provide better context to screen reader users instead of just relying on the visual layout.

---
*PR created automatically by Jules for task [12440388654063381797](https://jules.google.com/task/12440388654063381797) started by @2fst4u*