### PR TITLE
🔭 Scout: Add publisher Organization to JSON-LD schema

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -42,3 +42,7 @@
 
 **Learning:** When a generic container `<div>` is used to group an `<h2>` (or any `h1-h6`) with contextual paragraphs (like subheadings or metadata, e.g., Country, Circuit Name), crawlers may parse them as disjointed elements. Upgrading the wrapper to an `<hgroup>` explicitly signals to search engines that the paragraphs function as subheadings for the primary heading entity.
 **Action:** Always look for opportunities to upgrade `<div>` wrappers to `<hgroup>` when grouping headings with `<p>` tags, ensuring to apply `margin: 0` CSS resets since `<hgroup>` is a block-level element that may carry different browser default styles than a generic `div`.
+
+## 2025-05-14 - Expanding JSON-LD WebApplication Schema with Publisher Entity
+**Learning:** Expanding the existing `WebApplication` JSON-LD schema to explicitly include a `publisher` `Organization` entity (linking to the project repository via `sameAs`) is a highly effective, invisible SEO win. It establishes explicit brand identity and authoritativeness for Google Knowledge Graph integration.
+**Action:** When acting as Scout, identify existing generic JSON-LD schemas and look for opportunities to nest organizational or author entities to provide search engines with richer semantic context.

--- a/public/index.html
+++ b/public/index.html
@@ -68,7 +68,16 @@
                 "price": "0",
                 "priceCurrency": "USD"
             },
-            "featureList": "Live Weather Radar, Session Countdown, Track Maps, Hourly Forecasts"
+            "featureList": "Live Weather Radar, Session Countdown, Track Maps, Hourly Forecasts",
+            "publisher": {
+                "@type": "Organization",
+                "name": "Circuit Weather",
+                "url": "https://circuit-weather.racing",
+                "logo": "https://circuit-weather.racing/icon-512.png",
+                "sameAs": [
+                    "https://github.com/circuit-weather/circuit-weather"
+                ]
+            }
         }
     </script>
 


### PR DESCRIPTION
💡 What: Expanded the existing `WebApplication` JSON-LD schema to include a `publisher` `Organization` entity, explicitly linking to the official GitHub repository via the `sameAs` property.
🎯 Why: Search engines use the `publisher` and `sameAs` properties to build Knowledge Graph connections, establishing trust, identity, and authoritativeness for the application.
📊 Value: Enhances Entity SEO by explicitly connecting the web application to its organizational identity and source code repository, increasing the likelihood of rich brand panels in SERPs.
🔬 Measurement: Run the page source through the Schema Markup Validator or Google Rich Results Test to verify the nested `publisher` entity is parsed correctly without warnings.

---
*PR created automatically by Jules for task [3007148181023791497](https://jules.google.com/task/3007148181023791497) started by @2fst4u*