### PR TITLE
🧪 Spec: Add CORS edge case tests for worker tile errors

### DIFF
--- a/tests/worker-tile-errors.test.js
+++ b/tests/worker-tile-errors.test.js
@@ -97,6 +97,58 @@ describe('Worker Logic - Tile Errors', () => {
     expect(data.error.status).toBe(500);
   });
 
+  it('sets CORS headers on error response when valid Origin is provided', async () => {
+    mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({ error: 'Rate Limit' }), {
+      status: 429,
+      headers: {
+        'Content-Type': 'application/json',
+        'Retry-After': '120'
+      }
+    }));
+
+    const req = createRequest('/api/tiles/v2/radar/1/2/3/512/1/1_1.png', {
+      headers: { Origin: 'http://localhost:8787' }
+    });
+    const res = await worker.fetch(req, global.env, global.ctx);
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:8787');
+    expect(res.headers.get('Vary')).toBe('Origin');
+  });
+
+  it('removes CORS headers on error response when invalid Origin is provided', async () => {
+    mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({ error: 'Rate Limit' }), {
+      status: 429,
+      headers: {
+        'Content-Type': 'application/json',
+        'Retry-After': '120'
+      }
+    }));
+
+    const req = createRequest('/api/tiles/v2/radar/1/2/3/512/1/1_1.png', {
+      headers: { Origin: 'https://evil.com' }
+    });
+    const res = await worker.fetch(req, global.env, global.ctx);
+
+    expect(res.status).toBe(429);
+    expect(res.headers.has('Access-Control-Allow-Origin')).toBe(false);
+  });
+
+  it('removes CORS headers on error response via cacheAndReturnError when invalid Origin is provided', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('Upstream Server Error', {
+      status: 500,
+      headers: { 'Content-Type': 'text/html' }
+    }));
+
+    const req = createRequest('/api/tiles/v2/radar/1/2/3/512/1/1_1.png', {
+      headers: { Origin: 'https://evil.com' }
+    });
+    const res = await worker.fetch(req, global.env, global.ctx);
+
+    expect(res.status).toBe(500);
+    expect(res.headers.has('Access-Control-Allow-Origin')).toBe(false);
+  });
+
   it('handles network exception for tiles', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockFetch.mockRejectedValueOnce(new Error('Network error'));

--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -639,6 +639,23 @@ describe("Worker Logic", () => {
       expect(mockCache.put).toHaveBeenCalled();
     });
 
+    it("removes CORS headers for safe 404 tile response when invalid Origin is provided", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response("<html>Not Found</html>", {
+          status: 404,
+          headers: { "Content-Type": "text/html" },
+        }),
+      );
+
+      const req = createRequest("/api/tiles/v2/radar/missing.png", {
+        headers: { Origin: "https://evil.com" }
+      });
+      const res = await worker.fetch(req, global.env, global.ctx);
+
+      expect(res.status).toBe(404);
+      expect(res.headers.has("Access-Control-Allow-Origin")).toBe(false);
+    });
+
     it("sets CORS headers for safe 404 tile response when valid Origin is provided", async () => {
       mockFetch.mockResolvedValueOnce(
         new Response("<html>Not Found</html>", {


### PR DESCRIPTION
💡 What: Added test assertions in `worker-tile-errors.test.js` and `worker.test.js` to ensure the strict `getAllowedOrigin` CORS logic accurately removes headers (`Access-Control-Allow-Origin`) for invalid cross-origin requests returning safe 4xx/5xx proxy error responses.
🎯 Why: This fortifies our boundary coverage where cached upstream errors (404s, 429s, 500s) still route through the secure CORS-stripping phase, guarding against inadvertent cross-origin leakage on safe error cache responses.

---
*PR created automatically by Jules for task [13718936693314843426](https://jules.google.com/task/13718936693314843426) started by @2fst4u*