### PR TITLE
🔭 Scout: Add organizer entity to SportsEvent schema

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -46,3 +46,7 @@
 ## 2025-05-14 - Expanding JSON-LD WebApplication Schema with Publisher Entity
 **Learning:** Expanding the existing `WebApplication` JSON-LD schema to explicitly include a `publisher` `Organization` entity (linking to the project repository via `sameAs`) is a highly effective, invisible SEO win. It establishes explicit brand identity and authoritativeness for Google Knowledge Graph integration.
 **Action:** When acting as Scout, identify existing generic JSON-LD schemas and look for opportunities to nest organizational or author entities to provide search engines with richer semantic context.
+## 2025-05-15 - Injecting Organizer into SportsEvent JSON-LD Schema
+
+**Learning:** Enhancing the dynamic `SportsEvent` JSON-LD schema with an `organizer` entity explicitly links the localized event to a wider organization (e.g., Formula 1). Since this schema is dynamically constructed and injected as a JavaScript object before serialization in `CircuitWeatherApp.js`, any comments regarding its SEO value must be standard JavaScript comments (`//`), not HTML comments (`<!-- -->`), to avoid syntax errors before the string is injected into the DOM.
+**Action:** When adding SEO documentation comments directly inside JavaScript files (including when building JSON objects for JSON-LD), always use JavaScript comments. Only use HTML comments when modifying actual `.html` template files.

--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -613,6 +613,12 @@ export class CircuitWeatherApp {
                 "eventStatus": "https://schema.org/EventScheduled",
                 "url": window.location.href,
                 "image": "https://circuit-weather.racing/icon-512.png",
+                // Scout: Added organizer entity to explicitly link the event to Formula 1 for knowledge graph integration.
+                "organizer": {
+                    "@type": "Organization",
+                    "name": "Formula 1",
+                    "url": "https://www.formula1.com"
+                },
                 "location": {
                     "@type": "Place",
                     "name": this.selectedRace.circuit ? this.selectedRace.circuit.circuitName : (this.selectedRace.location ? this.selectedRace.location.country : ""),

--- a/tests/seo.test.js
+++ b/tests/seo.test.js
@@ -227,6 +227,7 @@ describe('SEO Title Updates', () => {
         expect(schema.name).toBe('Bahrain Grand Prix - Qualifying');
         expect(schema.startDate).toBe('2024-03-01T14:00:00.000Z');
         expect(schema.location.address.addressCountry).toBe('Bahrain');
+        expect(schema.organizer.name).toBe('Formula 1');
     });
 
     it('should update existing JSON-LD schema when switching sessions', async () => {


### PR DESCRIPTION
**What:** Added the `organizer` property (type `Organization`) with 'Formula 1' details to the dynamically generated `SportsEvent` JSON-LD schema in `updatePageMetadata()`. Also updated the corresponding unit test to assert its presence.

**Why:** To explicitly link the dynamic F1 event entity to its official organizing body. This is an SEO best practice for structured data.

**Value:** Improves rich snippets in SERP and Google Knowledge Graph association by providing explicit authorship, event linkage, and domain authority attribution to the parsed events.

**Measurement:** Verify by running the application, selecting any round and session, and inspecting the generated `<script id="dynamic-json-ld">` tag in the DOM to ensure the `organizer` property is cleanly populated without breaking the valid JSON structure.

---
*PR created automatically by Jules for task [12028507560362743567](https://jules.google.com/task/12028507560362743567) started by @2fst4u*