### PR TITLE
Update Claude workflow prompt to include blocking comment instruction

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,7 +41,7 @@ jobs:
             actions: read
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          prompt: "Implement the issue and open a pull request when done."
+          prompt: "Implement the issue and open a pull request when done. If you cannot proceed (e.g. prerequisites are not yet complete, or the scope is unclear), post a comment on the issue explaining what is blocking you."
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## Summary

- Updated the `prompt` in `.github/workflows/claude.yml` to instruct Claude to post a comment on the issue explaining what is blocking it when it cannot proceed (e.g. prerequisites not yet complete or unclear scope).

## Changes

**Before:**
```
Implement the issue and open a pull request when done.
```

**After:**
```
Implement the issue and open a pull request when done. If you cannot proceed (e.g. prerequisites are not yet complete, or the scope is unclear), post a comment on the issue explaining what is blocking you.
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGSa3Vnr979cGdj1asaXE4)_