### PR TITLE
🎨 Palette: Improve accessibility of language menu with correct ARIA roles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,6 @@
 ## 2024-05-04 - Sidebar Links Focus Visibility
 **Learning:** External links and link-buttons used in the sidebar footer (Language, Privacy, GitHub) were visually indistinguishable from non-focused states when navigated via keyboard, despite having hover states. Relying only on hover states degrades accessibility for non-pointer users.
 **Action:** When adding or reviewing interactive footer links, ensure they include `:focus-visible` CSS rules that match the application's primary focus ring pattern (e.g., `outline: 2px solid var(--color-primary); outline-offset: 2px;`) to meet WCAG focus visibility requirements without compromising mouse user experience.
+## 2024-05-18 - Single-choice Menu Accessibility
+**Learning:** For single-choice options within a dropdown menu (like a language selector), using `role="menuitem"` combined with `aria-current` is invalid ARIA. `aria-current` is specifically meant for navigation contexts.
+**Action:** When creating menus with selectable options, use `role="menuitemradio"` (or `menuitemcheckbox`) and manage state with `aria-checked` to properly communicate selection to screen readers.

--- a/public/src/ui/LanguageManager.js
+++ b/public/src/ui/LanguageManager.js
@@ -34,7 +34,7 @@ export class LanguageManager {
             button.dataset.locale = locale;
             button.textContent = name;
             button.type = 'button';
-            button.setAttribute('role', 'menuitem');
+            button.setAttribute('role', 'menuitemradio');
 
             button.addEventListener('click', () => {
                 i18n.setLocale(locale);
@@ -147,7 +147,7 @@ export class LanguageManager {
         this.menu.querySelectorAll('.language-item').forEach(item => {
             const isActive = item.dataset.locale === currentLocale;
             item.classList.toggle('active', isActive);
-            item.setAttribute('aria-current', isActive ? 'true' : 'false');
+            item.setAttribute('aria-checked', isActive ? 'true' : 'false');
         });
     }
 }

--- a/tests/language-manager.test.js
+++ b/tests/language-manager.test.js
@@ -218,10 +218,10 @@ describe('LanguageManager', () => {
         manager.updateActiveLanguage();
 
         expect(item1.classList.toggle).toHaveBeenCalledWith('active', false);
-        expect(item1.setAttribute).toHaveBeenCalledWith('aria-current', 'false');
+        expect(item1.setAttribute).toHaveBeenCalledWith('aria-checked', 'false');
 
         expect(item2.classList.toggle).toHaveBeenCalledWith('active', true);
-        expect(item2.setAttribute).toHaveBeenCalledWith('aria-current', 'true');
+        expect(item2.setAttribute).toHaveBeenCalledWith('aria-checked', 'true');
     });
 
     it('responds to i18n:change event', () => {


### PR DESCRIPTION
💡 What: Upgraded the language selection dropdown to use `role="menuitemradio"` and `aria-checked` instead of generic `menuitem` and `aria-current`.
🎯 Why: `aria-current` is invalid for menu items and is designed for navigation links. By using the standard ARIA radio pattern, screen readers correctly announce the single-choice selection state of the active language.
📸 Before/After: Visuals unchanged; semantics upgraded.
♿ Accessibility: Resolves invalid ARIA state and significantly improves screen reader comprehension of the active language selection.

---
*PR created automatically by Jules for task [2280155356333341264](https://jules.google.com/task/2280155356333341264) started by @2fst4u*