### PR TITLE
🔭 Scout: Convert countdown timer to semantic <time> tag with ISO duration

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -50,3 +50,7 @@
 
 **Learning:** Enhancing the dynamic `SportsEvent` JSON-LD schema with an `organizer` entity explicitly links the localized event to a wider organization (e.g., Formula 1). Since this schema is dynamically constructed and injected as a JavaScript object before serialization in `CircuitWeatherApp.js`, any comments regarding its SEO value must be standard JavaScript comments (`//`), not HTML comments (`<!-- -->`), to avoid syntax errors before the string is injected into the DOM.
 **Action:** When adding SEO documentation comments directly inside JavaScript files (including when building JSON objects for JSON-LD), always use JavaScript comments. Only use HTML comments when modifying actual `.html` template files.
+## 2025-05-17 - Temporal Data and Duration Semantics
+
+**Learning:** When displaying durations (such as countdown timers), replacing generic `<div>` wrappers with the semantic `<time>` tag enhances semantic precision for search engines mapping event timelines. However, simply wrapping the duration in `<time>` is insufficient; search engines expect a valid, machine-readable `datetime` attribute.
+**Action:** When implementing a semantic `<time>` tag for durations, construct and inject a valid ISO 8601 duration string (e.g., `PT2H30M15S` or `P3DT5H`) into the `datetime` attribute. Ensure any corresponding test suites asserting DOM structures (e.g., `setAttribute` calls) are updated to reflect the new attribute injection logic.

--- a/public/index.html
+++ b/public/index.html
@@ -361,7 +361,7 @@
             <section class="map-countdown" id="mapCountdown" aria-labelledby="mapCountdownLabel" style="display: none;">
                 <!-- Scout: Upgraded generic div to semantic h2 to provide a proper heading for the section landmark, improving document outline and discoverability. -->
                 <h2 class="map-countdown-label" id="mapCountdownLabel" data-i18n="countdown.startsIn">Starts in</h2>
-                <div class="map-countdown-timer" id="mapCountdownTimer" role="timer">--:--:--</div>
+                <time class="map-countdown-timer" id="mapCountdownTimer" role="timer">--:--:--</time>
                 <div class="map-countdown-session" id="mapCountdownSession"></div>
             </section>
 

--- a/public/src/ui/CountdownTimer.js
+++ b/public/src/ui/CountdownTimer.js
@@ -56,9 +56,20 @@ export class CountdownTimer {
 
         const accessibleText = this.getAccessibleDuration(diff);
 
+        // Scout: Generate ISO 8601 duration format for the datetime attribute
+        let isoDuration = 'PT';
+        if (hours > 24) {
+            const days = Math.floor(hours / 24);
+            const remHours = hours % 24;
+            isoDuration = `P${days}DT${remHours}H`;
+        } else {
+            isoDuration += `${hours}H${mins}M${secs}S`;
+        }
+
         if (this.ui.timer) {
             this.ui.timer.textContent = timeText;
             this.ui.timer.setAttribute('aria-label', accessibleText);
+            this.ui.timer.setAttribute('datetime', isoDuration);
         }
         if (this.ui.session) this.ui.session.textContent = this.sessionName;
     }

--- a/tests/countdown-timer.test.js
+++ b/tests/countdown-timer.test.js
@@ -172,6 +172,20 @@ describe('CountdownTimer', () => {
             );
         });
 
+        it('sets datetime attribute with ISO 8601 duration format', () => {
+            // 2 hours, 30 minutes, 15 seconds
+            const diff = (2 * 3600 + 30 * 60 + 15) * 1000;
+            timer.targetTime = new Date(Date.now() + diff);
+            timer.update();
+            expect(timer.ui.timer.setAttribute).toHaveBeenCalledWith('datetime', 'PT2H30M15S');
+
+            // Over 24 hours (e.g. 3 days and 5 hours)
+            const diffDays = (3 * 24 + 5) * 3600000;
+            timer.targetTime = new Date(Date.now() + diffDays);
+            timer.update();
+            expect(timer.ui.timer.setAttribute).toHaveBeenCalledWith('datetime', 'P3DT5H');
+        });
+
     });
 
     describe('stop', () => {


### PR DESCRIPTION
💡 What: Upgraded the map countdown timer container from a generic `<div>` to a semantic `<time>` element and injected a dynamic ISO 8601 duration string into its `datetime` attribute.
🎯 Why: Search engines and crawlers cannot natively parse a plain text visual countdown (e.g., "02:30:15"). Converting this wrapper to a `<time>` tag and providing a standardized duration format enables explicit machine readability of the temporal data.
📊 Value: Enhances semantic precision for search engine parsers mapping out event timelines, avoiding unstructured time ambiguities and bolstering the overall temporal SEO footprint.
🔬 Measurement: Inspect the DOM for `#mapCountdownTimer` to verify it renders as a `<time>` element and inspect its `datetime` attribute for the ISO 8601 string (e.g., `datetime="PT2H30M15S"`).

---
*PR created automatically by Jules for task [16478067178037024132](https://jules.google.com/task/16478067178037024132) started by @2fst4u*