### PR TITLE
Comment out claude-code-review.yml to disable workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,44 +1,43 @@
-name: Claude Code Review
-
-on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
-
-jobs:
-  claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: read
-      id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-
+# name: Claude Code Review
+#
+# on:
+#   pull_request:
+#     types: [opened, synchronize, ready_for_review, reopened]
+#     # Optional: Only run on specific file changes
+#     # paths:
+#     #   - "src/**/*.ts"
+#     #   - "src/**/*.tsx"
+#     #   - "src/**/*.js"
+#     #   - "src/**/*.jsx"
+#
+# jobs:
+#   claude-review:
+#     # Optional: Filter by PR author
+#     # if: |
+#     #   github.event.pull_request.user.login == 'external-contributor' ||
+#     #   github.event.pull_request.user.login == 'new-developer' ||
+#     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+#
+#     runs-on: ubuntu-latest
+#     permissions:
+#       contents: read
+#       pull-requests: write
+#       issues: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout repository
+#         uses: actions/checkout@v4
+#         with:
+#           fetch-depth: 1
+#
+#       - name: Run Claude Code Review
+#         id: claude-review
+#         uses: anthropics/claude-code-action@v1
+#         with:
+#           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+#           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+#           plugins: 'code-review@claude-code-plugins'
+#           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+#           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+#           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
Comments out the entire `claude-code-review.yml` workflow file to disable it without deleting it, preserving the configuration for future use.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeBmV4vC4cTJ7C9thSPg5a)_