### PR TITLE
🌍 Globe: Refine translation for radar retrying tiles

### DIFF
--- a/.jules/globe.md
+++ b/.jules/globe.md
@@ -4,3 +4,6 @@
 ## 2024-05-11 - Error Toast Countdown String Extracted
 **Learning:** Hardcoded short suffixes like `s` in `${remaining}s` bypass localization.
 **Action:** Always extract single-character or very short suffixes, taking care to adapt appropriately for languages like Japanese ('秒') or Hungarian ('mp').
+## 2024-05-19 - Hardcoded Suffix Logic Causes Pluralization Bugs
+**Learning:** Using an English-centric hardcoded suffix placeholder like `{{suffix}}` (e.g. `suffix: count > 1 ? 's' : ''`) for pluralization causes severe grammatical errors in target languages. For example, German requires "Kacheln" instead of "Kachels", and Italian requires "riuscite" instead of "riuscitass".
+**Action:** Never use string concatenation or single-character suffix injections to handle plurals. Always create explicit singular and plural translation keys (e.g., `retryingFailedTiles` and `retryingFailedTilesPlural`) in the base dictionary and duplicate them in languages without plural forms if necessary.

--- a/public/src/i18n/locales/de.js
+++ b/public/src/i18n/locales/de.js
@@ -25,7 +25,7 @@ export const de = {
         afterSession: '{{duration}} nach der Session', forecast: 'Prognose', live: 'Live', liveAria: 'Live-Radar',
         minutesAgo: 'Vor {{count}} Min', minutesAgoPlural: 'Vor {{count}} Min', connectionInstability: 'Verbindungsinstabilitat',
         serviceError: 'Dienstfehler', highTraffic: 'Hohe Auslastung', rateLimitExceeded: 'Ratenlimit uberschritten. Kurz pausiert.',
-        retryingFailedTiles: 'Versuche {{count}} fehlgeschlagene Kachel{{suffix}} erneut...', radarStatus: 'Radarstatus: {{status}}',
+        retryingFailedTiles: 'Versuche {{count}} fehlgeschlagene Kachel erneut...', retryingFailedTilesPlural: 'Versuche {{count}} fehlgeschlagene Kacheln erneut...', radarStatus: 'Radarstatus: {{status}}',
     },
     countdown: { startsIn: 'Startet in', day: 'Tag', dayPlural: 'Tage', hour: 'Stunde', hourPlural: 'Stunden', minute: 'Minute', minutePlural: 'Minuten', second: 'Sekunde', secondPlural: 'Sekunden' , secondShort: 's', dayShort: 'T', hourShort: 'Std'},
     map: { recenterOnCircuit: 'Auf Strecke zentrieren', zoomIn: 'Vergrößern', zoomOut: 'Verkleinern' },

--- a/public/src/i18n/locales/es.js
+++ b/public/src/i18n/locales/es.js
@@ -26,7 +26,7 @@ export const es = {
         afterSession: '{{duration}} despues de la sesion', forecast: 'Pronostico', live: 'En vivo', liveAria: 'Radar en vivo',
         minutesAgo: 'Hace {{count}} min', minutesAgoPlural: 'Hace {{count}} mins', connectionInstability: 'Inestabilidad de conexion',
         serviceError: 'Error del servicio', highTraffic: 'Alto trafico', rateLimitExceeded: 'Limite de peticiones excedido. Pausa momentanea.',
-        retryingFailedTiles: 'Reintentando {{count}} tesela{{suffix}} fallida{{suffix}}...', radarStatus: 'Estado del radar: {{status}}',
+        retryingFailedTiles: 'Reintentando {{count}} tesela fallida...', retryingFailedTilesPlural: 'Reintentando {{count}} teselas fallidas...', radarStatus: 'Estado del radar: {{status}}',
     },
     countdown: {
         startsIn: 'Empieza en', day: 'dia', dayPlural: 'dias', hour: 'hora', hourPlural: 'horas', minute: 'minuto', minutePlural: 'minutos', second: 'segundo', secondPlural: 'segundos', secondShort: 's', dayShort: 'd', hourShort: 'h'},

--- a/public/src/i18n/locales/fr.js
+++ b/public/src/i18n/locales/fr.js
@@ -26,7 +26,7 @@ export const fr = {
         afterSession: '{{duration}} apres la session', forecast: 'Previsions', live: 'En direct', liveAria: 'Radar en direct',
         minutesAgo: 'Il y a {{count}} min', minutesAgoPlural: 'Il y a {{count}} mins', connectionInstability: 'Connexion instable',
         serviceError: 'Erreur du service', highTraffic: 'Trafic eleve', rateLimitExceeded: 'Limite de requetes depassee. Pause momentanee.',
-        retryingFailedTiles: 'Nouvelle tentative pour {{count}} tuile{{suffix}} en echec...', radarStatus: 'Statut radar : {{status}}',
+        retryingFailedTiles: 'Nouvelle tentative pour {{count}} tuile en echec...', retryingFailedTilesPlural: 'Nouvelle tentative pour {{count}} tuiles en echec...', radarStatus: 'Statut radar : {{status}}',
     },
     countdown: { startsIn: 'Debute dans', day: 'jour', dayPlural: 'jours', hour: 'heure', hourPlural: 'heures', minute: 'minute', minutePlural: 'minutes', second: 'seconde', secondPlural: 'secondes' , secondShort: 's', dayShort: 'j', hourShort: 'h'},
     map: { recenterOnCircuit: 'Recentrer sur le circuit', zoomIn: 'Zoomer', zoomOut: 'Dézoomer' },

--- a/public/src/i18n/locales/hu.js
+++ b/public/src/i18n/locales/hu.js
@@ -71,6 +71,7 @@ export const hu = {
         highTraffic: 'Nagy forgalom',
         rateLimitExceeded: 'A kérések korlátját túllépte. Rövid szünet.',
         retryingFailedTiles: '{{count}} sikertelen csempe újrapróbálása...',
+        retryingFailedTilesPlural: '{{count}} sikertelen csempe újrapróbálása...',
         radarStatus: 'Radar státusza: {{status}}',
     },
     countdown: {

--- a/public/src/i18n/locales/it.js
+++ b/public/src/i18n/locales/it.js
@@ -26,7 +26,7 @@ export const it = {
         afterSession: '{{duration}} dopo la sessione', forecast: 'Previsioni', live: 'Live', liveAria: 'Radar live',
         minutesAgo: '{{count}} min fa', minutesAgoPlural: '{{count}} min fa', connectionInstability: 'Connessione instabile',
         serviceError: 'Errore servizio', highTraffic: 'Traffico elevato', rateLimitExceeded: 'Limite richieste superato. Pausa momentanea.',
-        retryingFailedTiles: 'Nuovo tentativo per {{count}} tile non riuscita{{suffix}}...', radarStatus: 'Stato radar: {{status}}',
+        retryingFailedTiles: 'Nuovo tentativo per {{count}} tile non riuscita...', retryingFailedTilesPlural: 'Nuovo tentativo per {{count}} tile non riuscite...', radarStatus: 'Stato radar: {{status}}',
     },
     countdown: { startsIn: 'Inizia tra', day: 'giorno', dayPlural: 'giorni', hour: 'ora', hourPlural: 'ore', minute: 'minuto', minutePlural: 'minuti', second: 'secondo', secondPlural: 'secondi' , secondShort: 's', dayShort: 'g', hourShort: 'h'},
     map: { recenterOnCircuit: 'Ricentra sul circuito', zoomIn: 'Ingrandire', zoomOut: 'Rimpicciolire' },

--- a/public/src/i18n/locales/ja.js
+++ b/public/src/i18n/locales/ja.js
@@ -24,7 +24,7 @@ export const ja = {
         changePlaybackSpeed: '再生速度を変更', playbackSpeed: '再生速度: {{speed}}', sessionStart: 'セッション開始', beforeSession: 'セッション {{duration}} 前', afterSession: 'セッション {{duration}} 後',
         forecast: '予報', live: 'ライブ', liveAria: 'ライブレーダー', minutesAgo: '{{count}} 分前', minutesAgoPlural: '{{count}} 分前',
         connectionInstability: '接続が不安定です', serviceError: 'サービスエラー', highTraffic: 'アクセス集中',
-        rateLimitExceeded: 'リクエスト上限を超えました。しばらく待機します。', retryingFailedTiles: '失敗したタイル {{count}} 件を再試行中...', radarStatus: 'レーダー状態: {{status}}',
+        rateLimitExceeded: 'リクエスト上限を超えました。しばらく待機します。', retryingFailedTiles: '失敗したタイル {{count}} 件を再試行中...', retryingFailedTilesPlural: '失敗したタイル {{count}} 件を再試行中...', radarStatus: 'レーダー状態: {{status}}',
     },
     countdown: { startsIn: '開始まで', day: '日', dayPlural: '日', hour: '時間', hourPlural: '時間', minute: '分', minutePlural: '分', second: '秒', secondPlural: '秒' , secondShort: '秒', dayShort: '日', hourShort: '時間' },
     map: { recenterOnCircuit: 'サーキットに再センタリング', zoomIn: '拡大', zoomOut: '縮小' },

--- a/public/src/i18n/locales/pt-BR.js
+++ b/public/src/i18n/locales/pt-BR.js
@@ -26,7 +26,7 @@ export const ptBR = {
         afterSession: '{{duration}} depois da sessao', forecast: 'Previsao', live: 'Ao vivo', liveAria: 'Radar ao vivo',
         minutesAgo: '{{count}} min atras', minutesAgoPlural: '{{count}} mins atras', connectionInstability: 'Instabilidade de ligacao',
         serviceError: 'Erro de servico', highTraffic: 'Trafego elevado', rateLimitExceeded: 'Limite de pedidos excedido. Pausa momentanea.',
-        retryingFailedTiles: 'A tentar novamente {{count}} bloco{{suffix}} com falha...', radarStatus: 'Estado do radar: {{status}}',
+        retryingFailedTiles: 'A tentar novamente {{count}} bloco com falha...', retryingFailedTilesPlural: 'A tentar novamente {{count}} blocos com falha...', radarStatus: 'Estado do radar: {{status}}',
     },
     countdown: { startsIn: 'Comeca em', day: 'dia', dayPlural: 'dias', hour: 'hora', hourPlural: 'horas', minute: 'minuto', minutePlural: 'minutos', second: 'segundo', secondPlural: 'segundos' , secondShort: 's', dayShort: 'd', hourShort: 'h'},
     map: { recenterOnCircuit: 'Recentrar no circuito', zoomIn: 'Aproximar', zoomOut: 'Afastar' },

--- a/public/src/i18n/locales/zh-CN.js
+++ b/public/src/i18n/locales/zh-CN.js
@@ -24,7 +24,7 @@ export const zhCN = {
         changePlaybackSpeed: '更改播放速度', playbackSpeed: '播放速度: {{speed}}', sessionStart: '赛段开始', beforeSession: '距赛段开始前 {{duration}}', afterSession: '赛段开始后 {{duration}}',
         forecast: '预报', live: '实时', liveAria: '实时雷达', minutesAgo: '{{count}} 分钟前', minutesAgoPlural: '{{count}} 分钟前',
         connectionInstability: '连接不稳定', serviceError: '服务错误', highTraffic: '访问量高',
-        rateLimitExceeded: '请求过于频繁，已暂时暂停。', retryingFailedTiles: '正在重试 {{count}} 个失败瓦片...', radarStatus: '雷达状态: {{status}}',
+        rateLimitExceeded: '请求过于频繁，已暂时暂停。', retryingFailedTiles: '正在重试 {{count}} 个失败瓦片...', retryingFailedTilesPlural: '正在重试 {{count}} 个失败瓦片...', radarStatus: '雷达状态: {{status}}',
     },
     countdown: { startsIn: '开始倒计时', day: '天', dayPlural: '天', hour: '小时', hourPlural: '小时', minute: '分钟', minutePlural: '分钟', second: '秒', secondPlural: '秒' , secondShort: '秒', dayShort: '天', hourShort: '小时' },
     map: { recenterOnCircuit: '回到赛道中心', zoomIn: '放大', zoomOut: '缩小' },


### PR DESCRIPTION
💡 What: Replaced English-centric `{{suffix}}` logic with proper singular and plural translation keys (`retryingFailedTiles` and `retryingFailedTilesPlural`) across all locales.
🎯 Why: The hardcoded `s` suffix resulted in invalid grammar in multiple languages, such as rendering "riuscitass" in Italian and "Kachels" in German.
🌐 Nuance: Kept Hungarian, Japanese, and Chinese plural strings identical to singular since these languages do not pluralize nouns in this context (e.g. Hungarian uses singular after numbers).

---
*PR created automatically by Jules for task [12436803528021342578](https://jules.google.com/task/12436803528021342578) started by @2fst4u*