### PR TITLE
🔭 Scout: Upgrade map countdown session div to semantic p tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -362,7 +362,8 @@
                 <!-- Scout: Upgraded generic div to semantic h2 to provide a proper heading for the section landmark, improving document outline and discoverability. -->
                 <h2 class="map-countdown-label" id="mapCountdownLabel" data-i18n="countdown.startsIn">Starts in</h2>
                 <time class="map-countdown-timer" id="mapCountdownTimer" role="timer">--:--:--</time>
-                <div class="map-countdown-session" id="mapCountdownSession"></div>
+                <!-- Scout: Upgraded generic div to semantic p to provide better structural meaning to textual content for crawlers parsing the countdown section -->
+                <p class="map-countdown-session" id="mapCountdownSession"></p>
             </section>
 
             <!-- Mobile UI Overlay Stack -->

--- a/public/styles.css
+++ b/public/styles.css
@@ -1560,6 +1560,7 @@ body {
 }
 
 .map-countdown-session {
+    margin: 0;
     font-size: 0.7rem;
     color: var(--color-text-secondary);
     white-space: nowrap;


### PR DESCRIPTION
💡 What: Upgraded the generic `<div>` used for the map countdown session description into a semantic `<p>` tag, and applied a CSS margin reset to prevent layout shifts.
🎯 Why: The generic `<div>` did not convey semantic meaning. Using a `<p>` tag explicitly communicates to search engines that this element contains textual paragraph data associated with the section's heading (`<h2>`).
📊 Value: Improves document outline parsing and structural meaning for crawlers parsing the countdown container.
🔬 Measurement: Verify the DOM output in `public/index.html` to see the `<p id="mapCountdownSession">` tag instead of the former `<div>` tag, and ensure no layout regressions occur due to the applied `margin: 0;` CSS reset.

---
*PR created automatically by Jules for task [2939331285120238570](https://jules.google.com/task/2939331285120238570) started by @2fst4u*