### PR TITLE
🧪 Spec: Add coverage for cacheAndReturnError valid CORS origin

### DIFF
--- a/tests/worker-api-cors.test.js
+++ b/tests/worker-api-cors.test.js
@@ -100,4 +100,24 @@ describe("Worker API Proxy CORS and Error Cases", () => {
     expect(errorSpy).toHaveBeenCalledWith("API Fetch Error:", expect.any(Error));
     errorSpy.mockRestore();
   });
+
+  it("applies strict CORS headers on error response via cacheAndReturnError when valid Origin is provided", async () => {
+    // Simulating an upstream error (e.g. invalid content type or 500) that triggers cacheAndReturnError in handleApiRequest
+    mockFetch.mockResolvedValueOnce(new Response("Internal Server Error", {
+      status: 500,
+      headers: { "Content-Type": "text/html" }
+    }));
+
+    const req = createRequest("/api/f1/current", {
+      Origin: "https://circuit-weather.racing"
+    });
+    const res = await worker.fetch(req, global.env, global.ctx);
+
+    expect(res.status).toBe(500);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://circuit-weather.racing");
+    expect(res.headers.get("Vary")).toBe("Origin");
+
+    // Ensure cacheAndReturnError cached it
+    expect(mockCache.put).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
💡 What: Added a test in `tests/worker-api-cors.test.js` to verify that `cacheAndReturnError` correctly applies `Access-Control-Allow-Origin` and `Vary` headers when a request includes a valid `Origin`.
🎯 Why: Lines 229-230 in `src/worker.js` were uncovered. Testing this logic ensures that upstream API errors correctly preserve CORS headers for valid origins, preventing misleading CORS errors in the browser when the real issue is an upstream failure.
📈 Maturity Impact: N/A - Kept strict existing coverage thresholds as read-only guardrails.

---
*PR created automatically by Jules for task [5661063899045382780](https://jules.google.com/task/5661063899045382780) started by @2fst4u*