### PR TITLE
🌍 Globe: Fix pluralization for retryingFailedTiles key

### DIFF
--- a/public/src/i18n/locales/en.js
+++ b/public/src/i18n/locales/en.js
@@ -71,7 +71,8 @@ export const en = {
         serviceError: 'Service Error',
         highTraffic: 'High Traffic',
         rateLimitExceeded: 'Rate limit exceeded. Pausing momentarily.',
-        retryingFailedTiles: 'Retrying {{count}} failed tile{{suffix}}...',
+        retryingFailedTiles: 'Retrying {{count}} failed tile...',
+        retryingFailedTilesPlural: 'Retrying {{count}} failed tiles...',
         radarStatus: 'Radar status: {{status}}',
     },
     countdown: {

--- a/public/src/map/WeatherRadar.js
+++ b/public/src/map/WeatherRadar.js
@@ -659,9 +659,8 @@ export class WeatherRadar {
     }
 
     retryingTilesMessage(count) {
-        return i18n.t('radar.retryingFailedTiles', {
+        return i18n.t(count > 1 ? 'radar.retryingFailedTilesPlural' : 'radar.retryingFailedTiles', {
             count,
-            suffix: count > 1 ? 's' : '',
         });
     }
 


### PR DESCRIPTION
* 💡 What: Replaced English-centric `{{suffix}}` logic with explicit singular and plural translation keys (`retryingFailedTiles` and `retryingFailedTilesPlural`) for the "Retrying {{count}} failed tile(s)..." string in `en.js` and `WeatherRadar.js`.
* 🎯 Why: Using string concatenation with an English suffix placeholder like `{{suffix}}` (e.g. `suffix: count > 1 ? 's' : ''`) for pluralization causes grammatical errors in target languages, as pluralizations do not always follow the simple "add an 's'" rule.
* 🌐 Nuance: Created explicit singular/plural dictionary keys to properly support grammatically correct plural forms in target languages, aligning with best practices for localization pluralization.

---
*PR created automatically by Jules for task [6943231874312687919](https://jules.google.com/task/6943231874312687919) started by @2fst4u*