### PR TITLE
Add TODO comments for planned improvements

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -18,6 +18,9 @@ import { i18n } from './i18n/index.js';
 /**
  * Main application orchestrator for Circuit Weather.
  */
+// TODO: Refactor — this orchestrator is large (~1100 lines). Consider extracting
+// cohesive responsibilities (session/forecast handling, selection + routing glue,
+// live-weather refresh loops) into smaller collaborators to ease testing.
 export class CircuitWeatherApp {
     constructor() {
         this.mapManager = new MapManager();
@@ -849,6 +852,11 @@ export class CircuitWeatherApp {
             return;
         }
 
+        // TODO: Known Limitation #4 — this fires an Open-Meteo request on every
+        // circuit change and can hit 429 rate limits under load. The `new Date()`
+        // argument changes the WeatherClient cache key each call, so current-weather
+        // responses are never reused. Debounce rapid circuit changes and round the
+        // timestamp (e.g. to the current minute/hour) so the cache can serve repeats.
         const [lat, lng] = this.currentCircuitCenter;
         const weather = await this.weatherClient.getForecast(lat, lng, new Date());
         this.mapWeatherWidget.update(weather);
@@ -1081,6 +1089,9 @@ export class CircuitWeatherApp {
     }
 
     async handleRoute({ series, round, session }) {
+        // TODO: Feature — only 'f1' is supported today although the UI is built
+        // around a series dropdown. F2/F3 share circuits and the Jolpica API, so
+        // generalise selection/routing here (and the F1API client) to add them.
         if (series !== 'f1') return;
 
         if (round) {

--- a/public/src/i18n/index.js
+++ b/public/src/i18n/index.js
@@ -13,6 +13,10 @@ import { ja } from './locales/ja.js';
 import { ptBR } from './locales/pt-BR.js';
 import { zhCN } from './locales/zh-CN.js';
 
+// TODO: Localisation roadmap (see AGENTS.md) — keep translations complete and
+// consistent against en.js as the source of truth, and add widely used languages
+// over time. The i18n-locales-completeness test guards key parity; prioritise
+// quality and consistency when extending coverage.
 const TRANSLATIONS = {
     en,
     'en-GB': enGB,

--- a/public/src/map/MapWeatherWidget.js
+++ b/public/src/map/MapWeatherWidget.js
@@ -4,6 +4,10 @@ import { i18n } from '../i18n/index.js';
  * Custom Control for showing weather data on the map.
  * Compatible with both Leaflet and Mapbox GL JS interfaces.
  */
+// TODO: Feature — wind overlay. The forecast already includes wind speed and
+// direction (see WeatherClient.getWindDirection), but it is only shown as a number.
+// Render a directional arrow / vector here (and optionally a map layer) so wind is
+// visualised for race strategy.
 class MapWeatherWidgetClass {
     constructor() {
         // Scout: Upgraded generic div to semantic section to improve document outline and explicitly signal this standalone widget region to search engines.

--- a/public/src/map/WeatherRadar.js
+++ b/public/src/map/WeatherRadar.js
@@ -1,6 +1,14 @@
 import { CONFIG } from '../config.js';
 import { i18n } from '../i18n/index.js';
 
+// TODO: Refactor — this class is large (~1200 lines) and mixes several concerns:
+// frame management, playback animation, polling/reconciliation, and the error/toast
+// UI. Consider splitting these into separate units (the existing test files already
+// hint at these seams: frames, playback, polling, reconcile, toast-timer).
+//
+// TODO: Feature — rain alerts. We already retain ~2h of radar frames; derive an
+// "approaching precipitation" signal relative to the selected circuit centre and
+// surface a "rain incoming" indicator for race strategy.
 export class WeatherRadar {
     constructor(map) {
         this.map = map;


### PR DESCRIPTION
## Summary

Annotates the codebase with `TODO` comments capturing improvement and feature ideas, without making any behavioural changes. Each TODO is placed at the most relevant spot so it surfaces when that code is next touched.

| Area | Location | Note |
| ---- | -------- | ---- |
| Current-weather rate limiting (Known Limitation #4) | `CircuitWeatherApp.updateLiveWeatherForCircuit` | `new Date()` defeats the `WeatherClient` cache; debounce + round the timestamp |
| Refactor large orchestrator (~1100 lines) | `CircuitWeatherApp` class | Extract session/forecast, selection/routing, refresh-loop concerns |
| Refactor large radar module (~1200 lines) | `WeatherRadar` class | Split frames / playback / polling / reconcile / toast UI |
| Rain alerts feature | `WeatherRadar` | Derive an "approaching precipitation" signal from existing 2h frame history |
| Wind overlay feature | `MapWeatherWidget` | Wind data is fetched but only shown as a number; render a directional arrow/vector |
| Multi-series support | `CircuitWeatherApp.handleRoute` | UI has a series dropdown but only `f1` is wired; F2/F3 share circuits + API |
| Localisation roadmap | `i18n/index.js` | Keep locales complete/consistent against `en.js`; add languages over time |

## Test plan
- [x] No code paths changed (comment-only diff), so existing behaviour and coverage are unaffected
- [ ] `pnpm test` passes in CI

https://claude.ai/code/session_01Un3RuK7bDVG9o4FLSrwF3s

---
_Generated by [Claude Code](https://claude.ai/code/session_01Un3RuK7bDVG9o4FLSrwF3s)_