### PR TITLE
Reduce Open-Meteo requests for live circuit weather

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -39,6 +39,7 @@ export class CircuitWeatherApp {
         this.selectedSession = null;
         this.router = new Router(params => this.handleRoute(params));
         this.mobileQuery = window.matchMedia('(max-width: 768px)');
+        this.liveWeatherDebounceTimer = null;
 
         this.ui = {};
         this.handleLanguageChange = this.handleLanguageChange.bind(this);
@@ -696,8 +697,9 @@ export class CircuitWeatherApp {
             this.ui.sessionEmptyState.style.display = 'flex';
         }
 
-        // Fetch current "Live" weather for the widgets
-        this.updateLiveWeatherForCircuit();
+        // Fetch current "Live" weather for the widgets (debounced so rapid round
+        // switching does not fire an Open-Meteo request per change).
+        this.scheduleLiveWeatherUpdate();
 
         this.updateMobileVisibility();
 
@@ -846,19 +848,31 @@ export class CircuitWeatherApp {
         }
     }
 
+    scheduleLiveWeatherUpdate() {
+        if (this.liveWeatherDebounceTimer) {
+            clearTimeout(this.liveWeatherDebounceTimer);
+        }
+        this.liveWeatherDebounceTimer = setTimeout(() => {
+            this.liveWeatherDebounceTimer = null;
+            this.updateLiveWeatherForCircuit();
+        }, CONFIG.LIVE_WEATHER_DEBOUNCE_MS);
+    }
+
     async updateLiveWeatherForCircuit() {
         // Only fetch weather if a circuit is selected
         if (!this.currentCircuitCenter) {
             return;
         }
 
-        // TODO: Known Limitation #4 — this fires an Open-Meteo request on every
-        // circuit change and can hit 429 rate limits under load. The `new Date()`
-        // argument changes the WeatherClient cache key each call, so current-weather
-        // responses are never reused. Debounce rapid circuit changes and round the
-        // timestamp (e.g. to the current minute/hour) so the cache can serve repeats.
         const [lat, lng] = this.currentCircuitCenter;
-        const weather = await this.weatherClient.getForecast(lat, lng, new Date());
+        // Bucket "now" to the refresh window so repeated fetches for the same circuit
+        // (re-selection, theme re-renders, switching away and back) reuse the
+        // WeatherClient cache instead of hitting Open-Meteo each time (Known
+        // Limitation #4 — avoids 429s). A fresh `new Date()` would change the cache
+        // key on every call, defeating the cache.
+        const bucketMs = CONFIG.WEATHER_REFRESH_INTERVAL_MS;
+        const bucketedNow = new Date(Math.floor(Date.now() / bucketMs) * bucketMs);
+        const weather = await this.weatherClient.getForecast(lat, lng, bucketedNow);
         this.mapWeatherWidget.update(weather);
     }
 

--- a/public/src/config.js
+++ b/public/src/config.js
@@ -33,6 +33,7 @@ export const CONFIG = {
     RACE_DAY_END_HOUR: 23, // Fallback to end of day if session time is missing
     WEATHER_REFRESH_INTERVAL_MS: 300000, // 5 minutes
     SESSION_FORECAST_REFRESH_INTERVAL_MS: 900000, // 15 minutes
+    LIVE_WEATHER_DEBOUNCE_MS: 400, // Collapse rapid circuit changes into one Open-Meteo request
     TILE_LOAD_TIMEOUT_MS: 3000, // 3 seconds
     MIN_POLL_DELAY_MS: 30000, // 30 seconds
     WEATHER_CACHE_MAX_ENTRIES: 50,

--- a/tests/circuit-weather-app.test.js
+++ b/tests/circuit-weather-app.test.js
@@ -222,6 +222,15 @@ describe('CircuitWeatherApp Pure Methods', () => {
         app.mapWeatherWidget = new MapWeatherWidget();
     });
 
+    afterEach(() => {
+        // Clear any pending live-weather debounce timer so real timers don't leak
+        // between tests that exercise selectRound/handleRoute.
+        if (app && app.liveWeatherDebounceTimer) {
+            clearTimeout(app.liveWeatherDebounceTimer);
+            app.liveWeatherDebounceTimer = null;
+        }
+    });
+
     // ---------------------------------------------------------------
     // getRaceEndTime
     // ---------------------------------------------------------------
@@ -1038,6 +1047,36 @@ describe('CircuitWeatherApp Pure Methods', () => {
 
             expect(app.weatherClient.getForecast).not.toHaveBeenCalled();
             expect(app.mapWeatherWidget.update).not.toHaveBeenCalled();
+        });
+
+        it('scheduleLiveWeatherUpdate debounces rapid calls into a single update', () => {
+            // updateLiveWeatherForCircuit is mocked in beforeEach
+            app.scheduleLiveWeatherUpdate();
+            app.scheduleLiveWeatherUpdate();
+            app.scheduleLiveWeatherUpdate();
+
+            expect(app.updateLiveWeatherForCircuit).not.toHaveBeenCalled();
+
+            vi.advanceTimersByTime(400);
+
+            expect(app.updateLiveWeatherForCircuit).toHaveBeenCalledTimes(1);
+        });
+
+        it('updateLiveWeatherForCircuit buckets the timestamp so repeats reuse the cache', async () => {
+            app.updateLiveWeatherForCircuit = CircuitWeatherApp.prototype.updateLiveWeatherForCircuit.bind(app);
+            app.currentCircuitCenter = [26.0, 50.0];
+
+            // Two calls within the same 5-minute window must use an identical,
+            // floored timestamp so the WeatherClient cache key is stable.
+            vi.setSystemTime(new Date('2026-05-24T12:01:30Z'));
+            await app.updateLiveWeatherForCircuit();
+            vi.setSystemTime(new Date('2026-05-24T12:03:45Z'));
+            await app.updateLiveWeatherForCircuit();
+
+            const firstTime = app.weatherClient.getForecast.mock.calls[0][2];
+            const secondTime = app.weatherClient.getForecast.mock.calls[1][2];
+            expect(firstTime.getTime()).toBe(new Date('2026-05-24T12:00:00Z').getTime());
+            expect(secondTime.getTime()).toBe(firstTime.getTime());
         });
     });
 


### PR DESCRIPTION
## Summary

Implements the live-weather rate-limit TODO (Known Limitation #4). The live-weather widget previously fired an Open-Meteo request on **every** circuit change, with two sources of waste:

1. It passed a fresh `new Date()` to `WeatherClient.getForecast`, which is part of the cache key — so the same circuit's current weather was **never** served from cache (re-selection, theme re-renders, switching away and back all re-fetched).
2. Rapid round switching fired one request per change, risking per-IP 429s.

### Changes
- **Bucket the timestamp** — `updateLiveWeatherForCircuit` now floors `now` to the 5-minute refresh window (`WEATHER_REFRESH_INTERVAL_MS`), so repeated fetches for the same circuit within the window share a cache key and reuse the cached response. Data still refreshes on the intended 5-minute cadence (each interval tick lands in a new bucket).
- **Debounce circuit-change updates** — `selectRound` now calls a new `scheduleLiveWeatherUpdate()` (400ms trailing debounce, `LIVE_WEATHER_DEBOUNCE_MS`), so scrubbing through rounds collapses into a single request for the final selection. The 5-minute refresh interval still fetches directly.

No visible behaviour change: the widget reads `weather.current`, which Open-Meteo always returns as live conditions regardless of the (bucketed) timestamp passed.

## Test plan
- [x] `pnpm test` — 733 tests pass (added 2: debounce collapsing + timestamp bucketing)
- [x] `pnpm run test:coverage` — thresholds met (99.58% statements overall)
- [ ] Manual: switch rapidly between rounds and confirm a single live-weather fetch fires for the final selection; switch back to a recent circuit within 5 min and confirm it serves from cache (no new Open-Meteo call)

https://claude.ai/code/session_01Un3RuK7bDVG9o4FLSrwF3s

---
_Generated by [Claude Code](https://claude.ai/code/session_01Un3RuK7bDVG9o4FLSrwF3s)_