### PR TITLE
🧪 Spec: Add createMapboxLayer proxy method tests in WeatherRadar

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -21,3 +21,6 @@
 ## 2026-05-20 - Brittle Generic DOM Assertions
 **Learning:** Asserting on native DOM creation methods like `documentMock.createDocumentFragment()` without verifying where those fragments end up creates falsely passing tests that don't verify underlying behavior.
 **Action:** Replace generic native DOM spy assertions with behavioral assertions, such as verifying `.appendChild()` on the specific target element.
+## 2024-05-25 - Mocking Mapbox Proxy Methods
+**Learning:** In Map-related unit tests (e.g., `WeatherRadar`), the component infers a Mapbox map instance (versus Leaflet) by checking `!this.map.hasLayer`. To test Mapbox-specific logic correctly, mock map objects must explicitly omit the `hasLayer` function. The proxy object returned by `createMapboxLayer` has its own simulated `on`/`off` events and a `redraw` mechanism manipulating Mapbox specific `addSource`/`setTiles` that need dedicated test blocks since they diverge significantly from Leaflet's standard `TileLayer`.
+**Action:** Created dedicated test block for Mapbox proxy methods by passing a mocked map omitting `hasLayer` and explicitly simulated `mockMap.once` callbacks to trigger the registered proxy load events.

--- a/tests/weather-radar.test.js
+++ b/tests/weather-radar.test.js
@@ -172,6 +172,78 @@ describe('WeatherRadar Timer Logic', () => {
     });
 });
 
+describe('createMapboxLayer Proxy Methods', () => {
+    let radar;
+    let mockMap;
+
+    beforeEach(() => {
+        mockMap = {
+            getSource: vi.fn(),
+            getLayer: vi.fn(),
+            addSource: vi.fn(),
+            addLayer: vi.fn(),
+            setPaintProperty: vi.fn(),
+            once: vi.fn()
+        };
+        // Mock mapbox by explicitly omitting hasLayer per .jules/spec.md
+        radar = new WeatherRadar(mockMap);
+    });
+
+    it('should register and unregister events using on/off', () => {
+        const frame = { url: 'http://test.url', time: 1000, path: '/test' };
+        const layerProxy = radar.createMapboxLayer(frame, 0);
+
+        const mockCallback = vi.fn();
+        layerProxy.on('load', mockCallback);
+
+        // Assert behavior: the callback should be invoked when the idle event fires after layer is added
+        layerProxy.addTo(mockMap);
+
+        // Simulate mapbox idle event firing
+        const idleCallback = mockMap.once.mock.calls.find(call => call[0] === 'idle')[1];
+        idleCallback();
+
+        expect(mockCallback).toHaveBeenCalled();
+
+        // Test off behavior
+        layerProxy.off('load');
+        const mockCallback2 = vi.fn();
+
+        // Mock map.once again to reset
+        mockMap.once.mockClear();
+        layerProxy.addTo(mockMap);
+
+        // Simulate mapbox idle event firing again
+        const idleCallback2 = mockMap.once.mock.calls.find(call => call[0] === 'idle')[1];
+        idleCallback2();
+
+        // Verify the original callback was unregistered and not called again
+        expect(mockCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should redraw by setting tiles if source exists', () => {
+        const frame = { url: 'http://test.url/tile.png', time: 1000, path: '/test' };
+        const layerProxy = radar.createMapboxLayer(frame, 0);
+
+        const mockSource = { setTiles: vi.fn() };
+        mockMap.getSource.mockReturnValue(mockSource);
+
+        layerProxy.redraw();
+
+        expect(mockMap.getSource).toHaveBeenCalledWith('radar-source-0');
+        expect(mockSource.setTiles).toHaveBeenCalledWith(['http://test.url/tile.png']);
+    });
+
+    it('should not throw on redraw if source does not exist', () => {
+        const frame = { url: 'http://test.url/tile.png', time: 1000, path: '/test' };
+        const layerProxy = radar.createMapboxLayer(frame, 0);
+
+        mockMap.getSource.mockReturnValue(null);
+
+        expect(() => layerProxy.redraw()).not.toThrow();
+    });
+});
+
 describe('waitForTilesToLoad', () => {
     let radar;
     let mockMap;


### PR DESCRIPTION
*   💡 **What**: Added unit tests for `on`, `off`, and `redraw` mapbox proxy methods inside `WeatherRadar.js`.
*   🎯 **Why**: The mapbox `createMapboxLayer` function uses a proxy object to match Leaflet's API but its internal methods for managing events and re-triggering mapbox source tiles (`setTiles`) were uncovered. This secures the fallback and proxy mechanism for mapbox layer integrations.
*   📈 **Maturity Impact**: Fortified the test suite by bringing the `WeatherRadar.js` branch coverage up to standard by testing mapbox-specific proxy edge cases.

---
*PR created automatically by Jules for task [7077506907330201703](https://jules.google.com/task/7077506907330201703) started by @2fst4u*