### PR TITLE
🌍 Globe: Add translation for windOverlay in Hungarian locale

### DIFF
--- a/public/src/i18n/locales/hu.js
+++ b/public/src/i18n/locales/hu.js
@@ -28,6 +28,7 @@ export const hu = {
         selectSession: 'Esemény kiválasztása...',
         metricLabel: 'Kilométer',
         imperialLabel: 'Mérföld',
+        windOverlay: 'Szélréteg',
     },
     forecast: {
         heading: 'Esemény előrejelzése',


### PR DESCRIPTION
💡 **What:** Added the `windOverlay` translation key to the Hungarian (`hu.js`) locale.
🎯 **Why:** The key was missing from `hu.js`, resulting in a localization gap where the application would fallback or fail to render the localized string for "Wind overlay".
🌐 **Nuance:** Translated to 'Szélréteg' to accurately represent the wind map overlay feature.

---
*PR created automatically by Jules for task [17492748294737932260](https://jules.google.com/task/17492748294737932260) started by @2fst4u*