### PR TITLE
Extract radar error/toast subsystem into RadarErrorToast

### DIFF
--- a/public/src/map/RadarErrorToast.js
+++ b/public/src/map/RadarErrorToast.js
@@ -1,0 +1,226 @@
+import { CONFIG } from '../config.js';
+import { i18n } from '../i18n/index.js';
+
+/**
+ * Owns the radar's tile-error tracking and the "connection instability /
+ * rate limit" toast. Extracted from WeatherRadar to keep that class focused.
+ *
+ * The only outward dependency is redrawing the radar's layers after a retry
+ * cooldown, which is injected via the `onRetry` callback so this class does
+ * not need to know about layers or the map.
+ */
+export class RadarErrorToast {
+    constructor(options = {}) {
+        this.onRetry = options.onRetry || (() => {});
+
+        this.failedTiles = new Set();
+        this.lastTileErrorTime = 0;
+        this.isCheckingStatus = false;
+        this.rateLimitResetTime = 0;
+        this.retryTimer = null;
+        this.activeErrorTitle = null;
+        this.toastAnimationFrame = null;
+        this.hideErrorTimer = null;
+
+        this.ui = {
+            errorToast: document.getElementById('errorToast'),
+            errorTitle: document.getElementById('errorTitle'),
+            errorMessage: document.getElementById('errorMessage'),
+            errorTimer: document.getElementById('errorTimer')
+        };
+    }
+
+    /** Reset error tracking (called on a full layer rebuild). */
+    reset() {
+        if (this.failedTiles) this.failedTiles.clear();
+        this.updateErrorUI();
+    }
+
+    /** A previously-failed tile loaded or unloaded; clear it from the error set. */
+    registerTileSuccess(tile) {
+        if (this.failedTiles.has(tile)) {
+            this.failedTiles.delete(tile);
+            this.updateErrorUI();
+        }
+    }
+
+    handleTileError(e) {
+        // Bolt Optimization: Track unique failed tiles to prevent double-counting
+        // during animation frames or rapid panning
+        this.failedTiles.add(e.tile);
+
+        // We cannot check the tile URL directly due to CORS blocks on the tile cache.
+        // Instead, we check the main RainViewer API. If IT is rate limited, we are definitely limited.
+        // If it is OK (200), then the tile error is likely a benign 404 (empty/ocean).
+
+        // Avoid spamming checks
+        if (this.isCheckingStatus) return;
+        this.isCheckingStatus = true;
+
+        // Use proxied API URL to avoid privacy leak (direct connection exposes IP)
+        // Worker now passes through 429 status for this check
+        const checkUrl = CONFIG.rainViewerApi;
+
+        fetch(checkUrl, { method: 'HEAD', signal: AbortSignal.timeout(5000) })
+            .then(response => {
+                this.isCheckingStatus = false;
+
+                if (response.status === 429) {
+                    // Critical: Rate Limit Hit (API is blocked, so tiles likely are too)
+                    this.triggerRateLimitCooldown();
+                } else if (response.ok) {
+                    // Ambiguous Case: API is fine (200), but tile failed.
+                    // We treat this as a transient failure that needs retry.
+                    // Count is already updated at top of method.
+                    this.triggerRateLimitCooldown(15000, i18n.t('radar.connectionInstability'), this.retryingTilesMessage(this.failedTiles.size));
+                } else {
+                    // Service Error
+                    const now = Date.now();
+                    if (now - this.lastTileErrorTime > 2000) {
+                        this.lastTileErrorTime = now;
+                        this.showErrorToast(i18n.t('radar.serviceError'), i18n.t('radar.radarStatus', { status: response.status }), 5);
+                    }
+                }
+            })
+            .catch(error => {
+                this.isCheckingStatus = false;
+                console.error('Network error during API status check:', error);
+
+                // Network error (likely offline)
+                // Count already updated at top.
+                this.updateErrorUI();
+            });
+    }
+
+    updateErrorUI() {
+        const count = this.failedTiles.size;
+        if (count > 0) {
+            // Cancel any pending hide timer since we have errors
+            if (this.hideErrorTimer) {
+                clearTimeout(this.hideErrorTimer);
+                this.hideErrorTimer = null;
+            }
+
+            // Persistent toast while errors exist
+            const message = this.retryingTilesMessage(count);
+
+            // Fix Timer Sync: Use actual remaining time if a retry cooldown is active
+            let duration = 60;
+            if (this.rateLimitResetTime > Date.now()) {
+                duration = Math.ceil((this.rateLimitResetTime - Date.now()) / 1000);
+                duration = Math.max(1, duration); // Ensure at least 1s
+            }
+
+            this.showErrorToast(
+                this.activeErrorTitle || i18n.t('radar.connectionInstability'),
+                message,
+                duration
+            );
+        } else {
+            // DEBOUNCE HIDE: Wait 1s before hiding to prevent "popping" during redraws
+            // If errors reappear within 1s (e.g. strict redraw), the toast stays visible.
+            if (!this.hideErrorTimer) {
+                this.hideErrorTimer = setTimeout(() => {
+                    this.hideErrorToast();
+                    this.hideErrorTimer = null;
+                }, 1000);
+            }
+        }
+    }
+
+    triggerRateLimitCooldown(waitTimeMs = 61000, title = i18n.t('radar.highTraffic'), message = i18n.t('radar.rateLimitExceeded')) {
+        if (this.rateLimitResetTime > Date.now()) return; // Already triggered
+
+        // Playback continues (removed pause) so valid tiles can load
+
+        this.rateLimitResetTime = Date.now() + waitTimeMs;
+        this.activeErrorTitle = title; // Track title for consistency
+
+        // Show persistent toast
+        this.showErrorToast(title, message, Math.ceil(waitTimeMs / 1000));
+
+        // Schedule Retry
+        if (this.retryTimer) clearTimeout(this.retryTimer);
+        this.retryTimer = setTimeout(() => {
+            this.retryTiles();
+        }, waitTimeMs);
+    }
+
+    retryTiles() {
+        this.rateLimitResetTime = 0;
+        this.activeErrorTitle = null;
+
+        // Manual Clean: Explicitly clear errors to prevent accumulation drift
+        // We rely on new errors specifically from the new redraw
+        this.failedTiles.clear();
+
+        // Update UI (will trigger the debounce hide, but new errors will cancel it fast)
+        this.updateErrorUI();
+
+        // Force redraw of all active layers (owned by WeatherRadar)
+        this.onRetry();
+    }
+
+    showErrorToast(title, message, durationSec = 5) {
+        if (!this.ui.errorToast) return;
+
+        // Cancel any existing timer loop to prevent overlap
+        if (this.toastAnimationFrame) {
+            cancelAnimationFrame(this.toastAnimationFrame);
+            this.toastAnimationFrame = null;
+        }
+
+        this.ui.errorTitle.textContent = title;
+        this.ui.errorMessage.textContent = message;
+        this.ui.errorToast.classList.add('visible');
+        this.ui.errorToast.style.opacity = '1';
+
+        // Handle Countdown UI
+        const endTime = Date.now() + (durationSec * 1000);
+
+        const updateTimer = () => {
+            if (!this.ui.errorToast.classList.contains('visible')) {
+                this.toastAnimationFrame = null;
+                return;
+            }
+
+            const remaining = Math.ceil((endTime - Date.now()) / 1000);
+            if (remaining > 0) {
+                this.ui.errorTimer.textContent = `${remaining}${i18n.t('countdown.secondShort')}`;
+                this.toastAnimationFrame = requestAnimationFrame(updateTimer);
+            } else {
+                this.ui.errorTimer.textContent = '';
+                this.toastAnimationFrame = null;
+                if (durationSec < 10 && this.rateLimitResetTime < Date.now()) {
+                    this.hideErrorToast();
+                }
+            }
+        };
+        // Start the loop
+        this.toastAnimationFrame = requestAnimationFrame(updateTimer);
+    }
+
+    retryingTilesMessage(count) {
+        return i18n.t(count > 1 ? 'radar.retryingFailedTilesPlural' : 'radar.retryingFailedTiles', {
+            count,
+        });
+    }
+
+    hideErrorToast() {
+        if (!this.ui.errorToast) return;
+
+        if (this.toastAnimationFrame) {
+            cancelAnimationFrame(this.toastAnimationFrame);
+            this.toastAnimationFrame = null;
+        }
+
+        this.ui.errorToast.classList.remove('visible');
+        this.ui.errorToast.style.opacity = '0';
+    }
+
+    destroy() {
+        if (this.toastAnimationFrame) cancelAnimationFrame(this.toastAnimationFrame);
+        if (this.retryTimer) clearTimeout(this.retryTimer);
+        if (this.hideErrorTimer) clearTimeout(this.hideErrorTimer);
+    }
+}

--- a/public/src/map/WeatherRadar.js
+++ b/public/src/map/WeatherRadar.js
@@ -1,10 +1,12 @@
 import { CONFIG } from '../config.js';
 import { i18n } from '../i18n/index.js';
+import { RadarErrorToast } from './RadarErrorToast.js';
 
-// TODO: Refactor — this class is large (~1200 lines) and mixes several concerns:
+// TODO: Refactor (in progress) — this class is large and mixes several concerns:
 // frame management, playback animation, polling/reconciliation, and the error/toast
-// UI. Consider splitting these into separate units (the existing test files already
-// hint at these seams: frames, playback, polling, reconcile, toast-timer).
+// UI. The error/toast subsystem has been extracted to RadarErrorToast.js; continue
+// splitting the remaining concerns into separate units (the existing test files
+// hint at these seams: frames, playback, polling, reconcile).
 //
 // TODO: Feature — rain alerts. We already retain ~2h of radar frames; derive an
 // "approaching precipitation" signal relative to the selected circuit centre and
@@ -32,14 +34,8 @@ export class WeatherRadar {
             hour12: false
         });
 
-        // Error Indicator tracking
-        this.failedTiles = new Set();
-        this.lastTileErrorTime = 0;
-        this.isCheckingStatus = false;
-        this.rateLimitResetTime = 0;
-        this.retryTimer = null;
-        this.activeErrorTitle = null;
-        this.toastAnimationFrame = null;
+        // Tile-error tracking + "connection instability" toast
+        this.errorToast = new RadarErrorToast({ onRetry: () => this.redrawLayers() });
 
         // Bolt Optimization: Cache UI elements
         this.ui = {
@@ -51,13 +47,7 @@ export class WeatherRadar {
             timeEnd: document.getElementById('radarTimeEnd'),
             controls: document.getElementById('radarControls'),
             speedBtn: document.getElementById('radarSpeedBtn'),
-            speedLabel: document.getElementById('radarSpeedLabel'),
-
-            // Error Toast Elements
-            errorToast: document.getElementById('errorToast'),
-            errorTitle: document.getElementById('errorTitle'),
-            errorMessage: document.getElementById('errorMessage'),
-            errorTimer: document.getElementById('errorTimer')
+            speedLabel: document.getElementById('radarSpeedLabel')
         };
 
         this.boundLoop = this.loop.bind(this);
@@ -114,6 +104,7 @@ export class WeatherRadar {
     destroy() {
         document.removeEventListener('keydown', this.handleSpaceKey);
         document.removeEventListener('i18n:change', this.handleLanguageChange);
+        this.errorToast.destroy();
     }
 
     cycleSpeed() {
@@ -313,8 +304,7 @@ export class WeatherRadar {
         if (!this.map) return;
 
         // Reset error tracking on full layer rebuild
-        if (this.failedTiles) this.failedTiles.clear();
-        this.updateErrorUI();
+        this.errorToast.reset();
 
         const isMapbox = !this.map.hasLayer;
 
@@ -482,21 +472,15 @@ export class WeatherRadar {
 
         // Track tile loading errors for the error indicator UI
         layer.on('tileerror', (e) => {
-            this.handleTileError(e);
+            this.errorToast.handleTileError(e);
         });
 
         // Track success/cleanup to decrement error count
         layer.on('tileload', (e) => {
-            if (this.failedTiles.has(e.tile)) {
-                this.failedTiles.delete(e.tile);
-                this.updateErrorUI();
-            }
+            this.errorToast.registerTileSuccess(e.tile);
         });
         layer.on('tileunload', (e) => {
-            if (this.failedTiles.has(e.tile)) {
-                this.failedTiles.delete(e.tile);
-                this.updateErrorUI();
-            }
+            this.errorToast.registerTileSuccess(e.tile);
         });
 
         // Store frame metadata on the layer for easy reconciliation
@@ -506,182 +490,13 @@ export class WeatherRadar {
         return layer;
     }
 
-    handleTileError(e) {
-        // Bolt Optimization: Track unique failed tiles to prevent double-counting
-        // during animation frames or rapid panning
-        this.failedTiles.add(e.tile);
-
-        // We cannot check the tile URL directly due to CORS blocks on the tile cache.
-        // Instead, we check the main RainViewer API. If IT is rate limited, we are definitely limited.
-        // If it is OK (200), then the tile error is likely a benign 404 (empty/ocean).
-
-        // Avoid spamming checks
-        if (this.isCheckingStatus) return;
-        this.isCheckingStatus = true;
-
-        // Use proxied API URL to avoid privacy leak (direct connection exposes IP)
-        // Worker now passes through 429 status for this check
-        const checkUrl = CONFIG.rainViewerApi;
-
-        fetch(checkUrl, { method: 'HEAD', signal: AbortSignal.timeout(5000) })
-            .then(response => {
-                this.isCheckingStatus = false;
-
-                if (response.status === 429) {
-                    // Critical: Rate Limit Hit (API is blocked, so tiles likely are too)
-                    this.triggerRateLimitCooldown();
-                } else if (response.ok) {
-                    // Ambiguous Case: API is fine (200), but tile failed.
-                    // We treat this as a transient failure that needs retry.
-                    // Count is already updated at top of method.
-                    this.triggerRateLimitCooldown(15000, i18n.t('radar.connectionInstability'), this.retryingTilesMessage(this.failedTiles.size));
-                } else {
-                    // Service Error
-                    const now = Date.now();
-                    if (now - this.lastTileErrorTime > 2000) {
-                        this.lastTileErrorTime = now;
-                        this.showErrorToast(i18n.t('radar.serviceError'), i18n.t('radar.radarStatus', { status: response.status }), 5);
-                    }
-                }
-            })
-            .catch(error => {
-                this.isCheckingStatus = false;
-                console.error('Network error during API status check:', error);
-
-                // Network error (likely offline)
-                // Count already updated at top.
-                this.updateErrorUI();
-            });
-    }
-
-    updateErrorUI() {
-        const count = this.failedTiles.size;
-        if (count > 0) {
-            // Cancel any pending hide timer since we have errors
-            if (this.hideErrorTimer) {
-                clearTimeout(this.hideErrorTimer);
-                this.hideErrorTimer = null;
-            }
-
-            // Persistent toast while errors exist
-            const message = this.retryingTilesMessage(count);
-
-            // Fix Timer Sync: Use actual remaining time if a retry cooldown is active
-            let duration = 60;
-            if (this.rateLimitResetTime > Date.now()) {
-                duration = Math.ceil((this.rateLimitResetTime - Date.now()) / 1000);
-                duration = Math.max(1, duration); // Ensure at least 1s
-            }
-
-            this.showErrorToast(
-                this.activeErrorTitle || i18n.t('radar.connectionInstability'),
-                message,
-                duration
-            );
-        } else {
-            // DEBOUNCE HIDE: Wait 1s before hiding to prevent "popping" during redraws
-            // If errors reappear within 1s (e.g. strict redraw), the toast stays visible.
-            if (!this.hideErrorTimer) {
-                this.hideErrorTimer = setTimeout(() => {
-                    this.hideErrorToast();
-                    this.hideErrorTimer = null;
-                }, 1000);
-            }
-        }
-    }
-
-    triggerRateLimitCooldown(waitTimeMs = 61000, title = i18n.t('radar.highTraffic'), message = i18n.t('radar.rateLimitExceeded')) {
-        if (this.rateLimitResetTime > Date.now()) return; // Already triggered
-
-        // Playback continues (removed pause) so valid tiles can load
-
-        this.rateLimitResetTime = Date.now() + waitTimeMs;
-        this.activeErrorTitle = title; // Track title for consistency
-
-        // Show persistent toast
-        this.showErrorToast(title, message, Math.ceil(waitTimeMs / 1000));
-
-        // Schedule Retry
-        if (this.retryTimer) clearTimeout(this.retryTimer);
-        this.retryTimer = setTimeout(() => {
-            this.retryTiles();
-        }, waitTimeMs);
-    }
-
-    retryTiles() {
-        this.rateLimitResetTime = 0;
-        this.activeErrorTitle = null;
-
-        // Manual Clean: Explicitly clear errors to prevent accumulation drift
-        // We rely on new errors specifically from the new redraw
-        this.failedTiles.clear();
-
-        // Update UI (will trigger the debounce hide, but new errors will cancel it fast)
-        this.updateErrorUI();
-
-        // Force redraw of all active layers
+    // Force redraw of all active layers (used by the error toast's retry cooldown)
+    redrawLayers() {
         Object.values(this.layers).forEach(layer => {
             if (layer && this.map.hasLayer(layer)) {
                 layer.redraw();
             }
         });
-    }
-
-    showErrorToast(title, message, durationSec = 5) {
-        if (!this.ui.errorToast) return;
-
-        // Cancel any existing timer loop to prevent overlap
-        if (this.toastAnimationFrame) {
-            cancelAnimationFrame(this.toastAnimationFrame);
-            this.toastAnimationFrame = null;
-        }
-
-        this.ui.errorTitle.textContent = title;
-        this.ui.errorMessage.textContent = message;
-        this.ui.errorToast.classList.add('visible');
-        this.ui.errorToast.style.opacity = '1';
-
-        // Handle Countdown UI
-        const endTime = Date.now() + (durationSec * 1000);
-
-        const updateTimer = () => {
-            if (!this.ui.errorToast.classList.contains('visible')) {
-                this.toastAnimationFrame = null;
-                return;
-            }
-
-            const remaining = Math.ceil((endTime - Date.now()) / 1000);
-            if (remaining > 0) {
-                this.ui.errorTimer.textContent = `${remaining}${i18n.t('countdown.secondShort')}`;
-                this.toastAnimationFrame = requestAnimationFrame(updateTimer);
-            } else {
-                this.ui.errorTimer.textContent = '';
-                this.toastAnimationFrame = null;
-                if (durationSec < 10 && this.rateLimitResetTime < Date.now()) {
-                    this.hideErrorToast();
-                }
-            }
-        };
-        // Start the loop
-        this.toastAnimationFrame = requestAnimationFrame(updateTimer);
-    }
-
-    retryingTilesMessage(count) {
-        return i18n.t(count > 1 ? 'radar.retryingFailedTilesPlural' : 'radar.retryingFailedTiles', {
-            count,
-        });
-    }
-
-    hideErrorToast() {
-        if (!this.ui.errorToast) return;
-
-        if (this.toastAnimationFrame) {
-            cancelAnimationFrame(this.toastAnimationFrame);
-            this.toastAnimationFrame = null;
-        }
-
-        this.ui.errorToast.classList.remove('visible');
-        this.ui.errorToast.style.opacity = '0';
     }
 
     // Bolt Optimization: Reuse Leaflet layers to reduce DOM churn

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,7 +8,7 @@
  * - Network-first with cache fallback for navigation
  */
 
-const CACHE_VERSION = '1.1.6';
+const CACHE_VERSION = '1.1.7';
 const CACHE_NAME = `circuit-weather-v${CACHE_VERSION}`;
 
 // App shell resources to pre-cache on install
@@ -28,6 +28,7 @@ const APP_SHELL = [
     '/src/map/RecentreControl.js',
     '/src/map/TrackLayer.js',
     '/src/map/WeatherRadar.js',
+    '/src/map/RadarErrorToast.js',
     '/src/routing/Router.js',
     '/src/ui/CountdownTimer.js',
     '/src/ui/PrivacyModal.js',

--- a/tests/weather-radar-frames.test.js
+++ b/tests/weather-radar-frames.test.js
@@ -217,25 +217,25 @@ describe('WeatherRadar Frame & Speed Logic', () => {
             const tile = { src: 'http://example.com/tile.png' };
             // Provide a fetch mock so the HEAD check inside handleTileError doesn't fail
             global.fetch.mockResolvedValueOnce({ status: 200, ok: true });
-            radar.handleTileError({ tile });
-            expect(radar.failedTiles.has(tile)).toBe(true);
+            radar.errorToast.handleTileError({ tile });
+            expect(radar.errorToast.failedTiles.has(tile)).toBe(true);
         });
 
         it('triggers rate limit cooldown on HTTP 429', async () => {
-            const cooldownSpy = vi.spyOn(radar, 'triggerRateLimitCooldown').mockImplementation(() => { });
+            const cooldownSpy = vi.spyOn(radar.errorToast, 'triggerRateLimitCooldown').mockImplementation(() => { });
             global.fetch.mockResolvedValueOnce({ status: 429, ok: false });
 
-            radar.handleTileError({ tile: {} });
+            radar.errorToast.handleTileError({ tile: {} });
 
             // Wait for the fetch promise chain
             await vi.waitFor(() => expect(cooldownSpy).toHaveBeenCalled());
         });
 
         it('shows connection instability toast on 200 (API ok but tile failed)', async () => {
-            const cooldownSpy = vi.spyOn(radar, 'triggerRateLimitCooldown').mockImplementation(() => { });
+            const cooldownSpy = vi.spyOn(radar.errorToast, 'triggerRateLimitCooldown').mockImplementation(() => { });
             global.fetch.mockResolvedValueOnce({ status: 200, ok: true });
 
-            radar.handleTileError({ tile: {} });
+            radar.errorToast.handleTileError({ tile: {} });
 
             await vi.waitFor(() => {
                 expect(cooldownSpy).toHaveBeenCalledWith(
@@ -247,10 +247,10 @@ describe('WeatherRadar Frame & Speed Logic', () => {
         });
 
         it('shows service error toast on non-429 error status', async () => {
-            const toastSpy = vi.spyOn(radar, 'showErrorToast').mockImplementation(() => { });
+            const toastSpy = vi.spyOn(radar.errorToast, 'showErrorToast').mockImplementation(() => { });
             global.fetch.mockResolvedValueOnce({ status: 503, ok: false });
 
-            radar.handleTileError({ tile: {} });
+            radar.errorToast.handleTileError({ tile: {} });
 
             await vi.waitFor(() => {
                 expect(toastSpy).toHaveBeenCalledWith(
@@ -262,23 +262,23 @@ describe('WeatherRadar Frame & Speed Logic', () => {
         });
 
         it('skips status check if one is already in progress', () => {
-            radar.isCheckingStatus = true;
+            radar.errorToast.isCheckingStatus = true;
             const tile = { src: 'test' };
 
-            radar.handleTileError({ tile });
+            radar.errorToast.handleTileError({ tile });
 
             // Tile should still be tracked
-            expect(radar.failedTiles.has(tile)).toBe(true);
+            expect(radar.errorToast.failedTiles.has(tile)).toBe(true);
             // But no fetch should be made
             expect(global.fetch).not.toHaveBeenCalled();
         });
 
         it('calls updateErrorUI on network error', async () => {
-            const uiSpy = vi.spyOn(radar, 'updateErrorUI').mockImplementation(() => { });
+            const uiSpy = vi.spyOn(radar.errorToast, 'updateErrorUI').mockImplementation(() => { });
             const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
             global.fetch.mockRejectedValueOnce(new Error('offline'));
 
-            radar.handleTileError({ tile: {} });
+            radar.errorToast.handleTileError({ tile: {} });
 
             try {
                 await vi.waitFor(() => {

--- a/tests/weather-radar-lifecycle.test.js
+++ b/tests/weather-radar-lifecycle.test.js
@@ -87,10 +87,10 @@ describe('WeatherRadar Lifecycle & Playback', () => {
         radar.ui.playBtn = createMockElement('radarPlayBtn');
         radar.ui.speedLabel = createMockElement('radarSpeedLabel');
         radar.ui.speedBtn = createMockElement('radarSpeedBtn');
-        radar.ui.errorToast = createMockElement('errorToast');
-        radar.ui.errorTimer = createMockElement('errorTimer');
-        radar.ui.errorTitle = createMockElement('errorTitle');
-        radar.ui.errorMessage = createMockElement('errorMessage');
+        radar.errorToast.ui.errorToast = createMockElement('errorToast');
+        radar.errorToast.ui.errorTimer = createMockElement('errorTimer');
+        radar.errorToast.ui.errorTitle = createMockElement('errorTitle');
+        radar.errorToast.ui.errorMessage = createMockElement('errorMessage');
     });
 
     afterEach(() => {
@@ -168,10 +168,10 @@ describe('WeatherRadar Lifecycle & Playback', () => {
         });
 
         it('clears failed tiles on rebuild', () => {
-            radar.failedTiles.add('tile1');
+            radar.errorToast.failedTiles.add('tile1');
             radar.frames = [{ time: 100, path: '/p1', url: '/u1' }];
             radar.createLayers();
-            expect(radar.failedTiles.size).toBe(0);
+            expect(radar.errorToast.failedTiles.size).toBe(0);
         });
     });
 
@@ -375,29 +375,29 @@ describe('WeatherRadar Lifecycle & Playback', () => {
     describe('triggerRateLimitCooldown', () => {
         it('sets rateLimitResetTime and shows toast', () => {
             vi.setSystemTime(1000000);
-            const toastSpy = vi.spyOn(radar, 'showErrorToast').mockImplementation(() => { });
+            const toastSpy = vi.spyOn(radar.errorToast, 'showErrorToast').mockImplementation(() => { });
 
-            radar.triggerRateLimitCooldown(30000, 'Rate Limited', 'Wait 30s');
+            radar.errorToast.triggerRateLimitCooldown(30000, 'Rate Limited', 'Wait 30s');
 
-            expect(radar.rateLimitResetTime).toBe(1000000 + 30000);
+            expect(radar.errorToast.rateLimitResetTime).toBe(1000000 + 30000);
             expect(toastSpy).toHaveBeenCalledWith('Rate Limited', 'Wait 30s', 30);
         });
 
         it('does not re-trigger if already in cooldown', () => {
             vi.setSystemTime(1000000);
-            radar.rateLimitResetTime = 2000000; // Already set in future
+            radar.errorToast.rateLimitResetTime = 2000000; // Already set in future
 
-            const toastSpy = vi.spyOn(radar, 'showErrorToast').mockImplementation(() => { });
-            radar.triggerRateLimitCooldown();
+            const toastSpy = vi.spyOn(radar.errorToast, 'showErrorToast').mockImplementation(() => { });
+            radar.errorToast.triggerRateLimitCooldown();
 
             expect(toastSpy).not.toHaveBeenCalled();
         });
 
         it('schedules tile retry after cooldown', () => {
-            const retrySpy = vi.spyOn(radar, 'retryTiles').mockImplementation(() => { });
+            const retrySpy = vi.spyOn(radar.errorToast, 'retryTiles').mockImplementation(() => { });
             vi.setSystemTime(1000000);
 
-            radar.triggerRateLimitCooldown(5000);
+            radar.errorToast.triggerRateLimitCooldown(5000);
 
             vi.advanceTimersByTime(5000);
             expect(retrySpy).toHaveBeenCalled();
@@ -409,28 +409,28 @@ describe('WeatherRadar Lifecycle & Playback', () => {
     // ---------------------------------------------------------------
     describe('retryTiles', () => {
         it('clears failed tiles and resets rate limit time', () => {
-            radar.failedTiles.add('t1');
-            radar.failedTiles.add('t2');
-            radar.rateLimitResetTime = 999999;
-            radar.activeErrorTitle = 'Rate Limited';
+            radar.errorToast.failedTiles.add('t1');
+            radar.errorToast.failedTiles.add('t2');
+            radar.errorToast.rateLimitResetTime = 999999;
+            radar.errorToast.activeErrorTitle = 'Rate Limited';
 
             // Mock to prevent error from missing debounce
-            vi.spyOn(radar, 'updateErrorUI').mockImplementation(() => { });
+            vi.spyOn(radar.errorToast, 'updateErrorUI').mockImplementation(() => { });
 
-            radar.retryTiles();
+            radar.errorToast.retryTiles();
 
-            expect(radar.failedTiles.size).toBe(0);
-            expect(radar.rateLimitResetTime).toBe(0);
-            expect(radar.activeErrorTitle).toBeNull();
+            expect(radar.errorToast.failedTiles.size).toBe(0);
+            expect(radar.errorToast.rateLimitResetTime).toBe(0);
+            expect(radar.errorToast.activeErrorTitle).toBeNull();
         });
 
         it('redraws active layers on the map', () => {
             const layer = createMockLayer();
             radar.layers = [layer];
             mockMap.hasLayer.mockReturnValue(true);
-            vi.spyOn(radar, 'updateErrorUI').mockImplementation(() => { });
+            vi.spyOn(radar.errorToast, 'updateErrorUI').mockImplementation(() => { });
 
-            radar.retryTiles();
+            radar.errorToast.retryTiles();
 
             expect(layer.redraw).toHaveBeenCalled();
         });

--- a/tests/weather-radar-toast-timer.test.js
+++ b/tests/weather-radar-toast-timer.test.js
@@ -15,44 +15,44 @@ describe('WeatherRadar Toast Timer', () => {
         vi.clearAllMocks();
         globalThis.lastRafCb = null;
         radar = new WeatherRadar({});
-        radar.ui.errorToast = { classList: { contains: vi.fn().mockReturnValue(true), add: vi.fn(), remove: vi.fn() }, style: {} };
+        radar.errorToast.ui.errorToast = { classList: { contains: vi.fn().mockReturnValue(true), add: vi.fn(), remove: vi.fn() }, style: {} };
     });
 
     afterEach(() => { vi.restoreAllMocks(); vi.useRealTimers(); });
 
     it('updateTimer aborts if toast is no longer visible', () => {
-        radar.showErrorToast('Title', 'Message', 5);
-        radar.ui.errorToast.classList.contains.mockReturnValue(false);
+        radar.errorToast.showErrorToast('Title', 'Message', 5);
+        radar.errorToast.ui.errorToast.classList.contains.mockReturnValue(false);
         globalThis.lastRafCb();
-        expect(radar.toastAnimationFrame).toBeNull();
+        expect(radar.errorToast.toastAnimationFrame).toBeNull();
     });
 
     it('updateTimer requests next frame if time remains', () => {
         vi.useFakeTimers();
         vi.setSystemTime(1000000);
-        radar.showErrorToast('Title', 'Message', 5);
+        radar.errorToast.showErrorToast('Title', 'Message', 5);
 
         vi.setSystemTime(1001000);
         globalThis.requestAnimationFrame.mockClear();
         globalThis.lastRafCb();
 
-        expect(radar.ui.errorTimer.textContent).toBe('4s');
+        expect(radar.errorToast.ui.errorTimer.textContent).toBe('4s');
         expect(globalThis.requestAnimationFrame).toHaveBeenCalled();
     });
 
     it('updateTimer finishes and hides toast when time is up', () => {
         vi.useFakeTimers();
         vi.setSystemTime(1000000);
-        radar.showErrorToast('Title', 'Message', 5);
+        radar.errorToast.showErrorToast('Title', 'Message', 5);
 
         vi.setSystemTime(1006000);
-        radar.hideErrorToast = vi.fn();
-        radar.rateLimitResetTime = 0;
+        radar.errorToast.hideErrorToast = vi.fn();
+        radar.errorToast.rateLimitResetTime = 0;
 
         globalThis.lastRafCb();
 
-        expect(radar.ui.errorTimer.textContent).toBe('');
-        expect(radar.toastAnimationFrame).toBeNull();
-        expect(radar.hideErrorToast).toHaveBeenCalled();
+        expect(radar.errorToast.ui.errorTimer.textContent).toBe('');
+        expect(radar.errorToast.toastAnimationFrame).toBeNull();
+        expect(radar.errorToast.hideErrorToast).toHaveBeenCalled();
     });
 });

--- a/tests/weather-radar.test.js
+++ b/tests/weather-radar.test.js
@@ -70,13 +70,13 @@ describe('WeatherRadar Timer Logic', () => {
 
     it('should cancel previous timer loop when showErrorToast is called again', async () => {
         // Setup
-        radar.ui.errorToast = createMockElement('errorToast');
-        radar.ui.errorTimer = createMockElement('errorTimer');
-        radar.ui.errorTitle = createMockElement('errorTitle');
-        radar.ui.errorMessage = createMockElement('errorMessage');
+        radar.errorToast.ui.errorToast = createMockElement('errorToast');
+        radar.errorToast.ui.errorTimer = createMockElement('errorTimer');
+        radar.errorToast.ui.errorTitle = createMockElement('errorTitle');
+        radar.errorToast.ui.errorMessage = createMockElement('errorMessage');
 
         // Initial call
-        radar.showErrorToast('Title 1', 'Message 1', 60);
+        radar.errorToast.showErrorToast('Title 1', 'Message 1', 60);
 
         expect(requestAnimationFrameMock).toHaveBeenCalledTimes(1);
         // We know the ID is likely 1 because we reset nextRafId in beforeEach
@@ -84,10 +84,10 @@ describe('WeatherRadar Timer Logic', () => {
         const firstLoopId = 1;
 
         expect(rafCallbacks.has(firstLoopId)).toBe(true);
-        expect(radar.toastAnimationFrame).toBe(firstLoopId);
+        expect(radar.errorToast.toastAnimationFrame).toBe(firstLoopId);
 
         // Second call - simulates updateErrorUI being called again
-        radar.showErrorToast('Title 2', 'Message 2', 60);
+        radar.errorToast.showErrorToast('Title 2', 'Message 2', 60);
 
         expect(requestAnimationFrameMock).toHaveBeenCalledTimes(2);
         const secondLoopId = 2;
@@ -95,21 +95,21 @@ describe('WeatherRadar Timer Logic', () => {
         // CRITICAL ASSERTION: The first loop MUST be cancelled.
         expect(rafCallbacks.has(firstLoopId)).toBe(false);
         expect(rafCallbacks.has(secondLoopId)).toBe(true);
-        expect(radar.toastAnimationFrame).toBe(secondLoopId);
+        expect(radar.errorToast.toastAnimationFrame).toBe(secondLoopId);
     });
 
     it('should cancel timer loop when hiding error toast', () => {
-        radar.ui.errorToast = createMockElement('errorToast');
-        radar.ui.errorTimer = createMockElement('errorTimer');
+        radar.errorToast.ui.errorToast = createMockElement('errorToast');
+        radar.errorToast.ui.errorTimer = createMockElement('errorTimer');
 
-        radar.showErrorToast('Title', 'Msg', 60);
+        radar.errorToast.showErrorToast('Title', 'Msg', 60);
         const loopId = 1;
         expect(rafCallbacks.has(loopId)).toBe(true);
 
-        radar.hideErrorToast();
+        radar.errorToast.hideErrorToast();
 
         expect(rafCallbacks.has(loopId)).toBe(false);
-        expect(radar.toastAnimationFrame).toBe(null);
+        expect(radar.errorToast.toastAnimationFrame).toBe(null);
     });
 
     it('should correctly calculate duration in updateErrorUI', () => {
@@ -117,13 +117,13 @@ describe('WeatherRadar Timer Logic', () => {
         const now = 1000000;
         vi.setSystemTime(now);
 
-        radar.rateLimitResetTime = now + 45000; // 45s in future
-        radar.failedTiles = new Set(['tile1']);
+        radar.errorToast.rateLimitResetTime = now + 45000; // 45s in future
+        radar.errorToast.failedTiles = new Set(['tile1']);
 
         // Spy on showErrorToast
-        const toastSpy = vi.spyOn(radar, 'showErrorToast');
+        const toastSpy = vi.spyOn(radar.errorToast, 'showErrorToast');
 
-        radar.updateErrorUI();
+        radar.errorToast.updateErrorUI();
 
         expect(toastSpy).toHaveBeenCalledWith(
             expect.any(String),
@@ -138,17 +138,17 @@ describe('WeatherRadar Timer Logic', () => {
         vi.useFakeTimers();
 
         // Start with no errors to create the timer
-        radar.failedTiles = new Set();
-        radar.updateErrorUI();
+        radar.errorToast.failedTiles = new Set();
+        radar.errorToast.updateErrorUI();
 
-        expect(radar.hideErrorTimer).not.toBeNull();
+        expect(radar.errorToast.hideErrorTimer).not.toBeNull();
 
         // Introduce errors
-        radar.failedTiles = new Set(['tile1']);
-        radar.updateErrorUI();
+        radar.errorToast.failedTiles = new Set(['tile1']);
+        radar.errorToast.updateErrorUI();
 
         // The timer should be cleared
-        expect(radar.hideErrorTimer).toBeNull();
+        expect(radar.errorToast.hideErrorTimer).toBeNull();
 
         vi.useRealTimers();
     });
@@ -156,17 +156,17 @@ describe('WeatherRadar Timer Logic', () => {
     it('should call hideErrorToast from within hideErrorTimer', () => {
         vi.useFakeTimers();
 
-        radar.failedTiles = new Set();
-        const hideErrorToastSpy = vi.spyOn(radar, 'hideErrorToast').mockImplementation(() => {});
+        radar.errorToast.failedTiles = new Set();
+        const hideErrorToastSpy = vi.spyOn(radar.errorToast, 'hideErrorToast').mockImplementation(() => {});
 
-        radar.updateErrorUI();
+        radar.errorToast.updateErrorUI();
 
-        expect(radar.hideErrorTimer).not.toBeNull();
+        expect(radar.errorToast.hideErrorTimer).not.toBeNull();
 
         vi.advanceTimersByTime(1000);
 
         expect(hideErrorToastSpy).toHaveBeenCalled();
-        expect(radar.hideErrorTimer).toBeNull();
+        expect(radar.errorToast.hideErrorTimer).toBeNull();
 
         vi.useRealTimers();
     });
@@ -318,36 +318,36 @@ describe('WeatherRadar Tile Error Handling', () => {
     });
 
     it('should delete from failedTiles and updateErrorUI on tileunload if it was failed', () => {
-        vi.spyOn(radar, 'updateErrorUI').mockImplementation(() => {});
+        vi.spyOn(radar.errorToast, 'updateErrorUI').mockImplementation(() => {});
         const layer = radar.createLayer({ path: 'test', time: 100 });
         const onTileUnload = layer.on.mock.calls.find(call => call[0] === 'tileunload')[1];
 
         const mockTile = {};
-        radar.failedTiles.add(mockTile);
+        radar.errorToast.failedTiles.add(mockTile);
 
         onTileUnload({ tile: mockTile });
 
-        expect(radar.failedTiles.has(mockTile)).toBe(false);
-        expect(radar.updateErrorUI).toHaveBeenCalled();
+        expect(radar.errorToast.failedTiles.has(mockTile)).toBe(false);
+        expect(radar.errorToast.updateErrorUI).toHaveBeenCalled();
     });
 
 
     it('should delete from failedTiles and updateErrorUI on tileload if it was failed', () => {
-        vi.spyOn(radar, 'updateErrorUI').mockImplementation(() => {});
+        vi.spyOn(radar.errorToast, 'updateErrorUI').mockImplementation(() => {});
         const layer = radar.createLayer({ path: 'test', time: 100 });
         const onTileLoad = layer.on.mock.calls.find(call => call[0] === 'tileload')[1];
 
         const mockTile = {};
-        radar.failedTiles.add(mockTile);
+        radar.errorToast.failedTiles.add(mockTile);
 
         onTileLoad({ tile: mockTile });
 
-        expect(radar.failedTiles.has(mockTile)).toBe(false);
-        expect(radar.updateErrorUI).toHaveBeenCalled();
+        expect(radar.errorToast.failedTiles.has(mockTile)).toBe(false);
+        expect(radar.errorToast.updateErrorUI).toHaveBeenCalled();
     });
 
     it('should call handleTileError on tileerror', () => {
-        const handleTileErrorSpy = vi.spyOn(radar, 'handleTileError').mockImplementation(() => {});
+        const handleTileErrorSpy = vi.spyOn(radar.errorToast, 'handleTileError').mockImplementation(() => {});
         const layer = radar.createLayer({ path: 'test', time: 100 });
         const onTileError = layer.on.mock.calls.find(call => call[0] === 'tileerror')[1];
 


### PR DESCRIPTION
## Summary

First, focused step of the `WeatherRadar` refactor TODO. The tile-error tracking and the "connection instability / rate limit" toast — a cohesive ~180-line subsystem — is extracted from the 1200-line `WeatherRadar` class into a new **`RadarErrorToast`** module.

- `WeatherRadar` now composes `this.errorToast` and delegates: tile `tileerror` → `errorToast.handleTileError`, `tileload`/`tileunload` → `errorToast.registerTileSuccess`, full rebuild → `errorToast.reset`, teardown → `errorToast.destroy`.
- The only outward dependency — redrawing the radar's layers after a retry cooldown — is inverted via an `onRetry` callback, so `RadarErrorToast` has no knowledge of layers or the map. `WeatherRadar` exposes a small `redrawLayers()` for that.
- **No behaviour change**: the moved method bodies are verbatim (only `retryTiles`' layer-redraw became `onRetry()`).

The remaining concerns (frames, playback, polling, reconcile) are intentionally left in place; the class-level `TODO` is updated to note the error/toast extraction is done and the rest continues later.

## Testing
- [x] `pnpm test` — all 758 tests pass. The white-box radar tests that reached into the moved internals (`radar.failedTiles`, `radar.handleTileError`, `radar.showErrorToast`, `radar.rateLimitResetTime`, `radar.ui.errorToast`, etc.) were mechanically updated to `radar.errorToast.*` across the 4 affected test files; no behavioural assertions changed.
- [x] `pnpm run test:coverage` — thresholds met (`RadarErrorToast` is exercised through the existing radar tests).
- [x] Bumped the service-worker cache version and pre-cached the new module.

Net: `WeatherRadar.js` shrinks by ~185 lines; the error/toast logic is now isolated and independently testable.

https://claude.ai/code/session_01Un3RuK7bDVG9o4FLSrwF3s

---
_Generated by [Claude Code](https://claude.ai/code/session_01Un3RuK7bDVG9o4FLSrwF3s)_