### PR TITLE
Extract radar playback controller into RadarPlayback

### DIFF
--- a/public/src/map/RadarPlayback.js
+++ b/public/src/map/RadarPlayback.js
@@ -1,0 +1,135 @@
+import { CONFIG } from '../config.js';
+import { i18n } from '../i18n/index.js';
+
+/**
+ * Drives radar animation playback (play/pause/loop) and the speed control.
+ * Extracted from WeatherRadar to keep that class focused.
+ *
+ * Frame state (the frame list, the current index, and how a frame is shown)
+ * is owned by WeatherRadar and accessed through the injected callbacks, so this
+ * controller only owns playback state (isPlaying, speed, the rAF handle).
+ */
+export class RadarPlayback {
+    constructor(options = {}) {
+        this.getFrameCount = options.getFrameCount || (() => 0);
+        this.getCurrentFrame = options.getCurrentFrame || (() => 0);
+        this.setCurrentFrame = options.setCurrentFrame || (() => {});
+        this.showFrame = options.showFrame || (() => {});
+        // Flush any deferred frame update before playback starts.
+        this.beforePlay = options.beforePlay || (() => {});
+
+        this.isPlaying = false;
+        this.animationFrameId = null;
+        this.lastFrameTime = 0;
+        this.speedIndex = CONFIG.defaultSpeedIndex;
+        this.boundLoop = this.loop.bind(this);
+
+        this.ui = {
+            playBtn: document.getElementById('radarPlayBtn'),
+            speedBtn: document.getElementById('radarSpeedBtn'),
+            speedLabel: document.getElementById('radarSpeedLabel')
+        };
+
+        if (this.ui.playBtn) {
+            this.ui.playBtn.addEventListener('click', () => this.togglePlay());
+        }
+        if (this.ui.speedBtn) {
+            this.ui.speedBtn.addEventListener('click', () => this.cycleSpeed());
+        }
+
+        this.updateSpeedLabel();
+    }
+
+    cycleSpeed() {
+        // Cycle to the next speed
+        this.speedIndex = (this.speedIndex + 1) % CONFIG.radarSpeeds.length;
+        this.updateSpeedLabel();
+
+        // If playing, restart with the new speed
+        if (this.isPlaying) {
+            this.pause();
+            this.play();
+        }
+    }
+
+    updateSpeedLabel() {
+        if (this.ui.speedLabel) {
+            const label = CONFIG.radarSpeeds[this.speedIndex].label;
+            this.ui.speedLabel.textContent = label;
+
+            // Palette Accessibility: Update ARIA label with current state
+            if (this.ui.speedBtn) {
+                const speedLabel = i18n.t('radar.playbackSpeed', { speed: label });
+                this.ui.speedBtn.setAttribute('aria-label', speedLabel);
+                this.ui.speedBtn.setAttribute('title', speedLabel);
+            }
+        }
+    }
+
+    getCurrentSpeed() {
+        return CONFIG.radarSpeeds[this.speedIndex].speed;
+    }
+
+    play() {
+        // Clear any existing timer/loop first to prevent double animations
+        this.pause();
+
+        // Apply any pending updates before starting
+        this.beforePlay();
+
+        this.isPlaying = true;
+        if (this.ui.playBtn) {
+            this.ui.playBtn.classList.add('playing');
+            this.ui.playBtn.setAttribute('aria-pressed', 'true');
+            this.ui.playBtn.setAttribute('aria-label', i18n.t('radar.pause'));
+            this.ui.playBtn.setAttribute('title', i18n.t('radar.pauseTitle'));
+        }
+
+        // Bolt Optimization: Use requestAnimationFrame instead of setInterval
+        // Prevents drift and saves battery in background tabs
+        this.lastFrameTime = performance.now();
+        this.loop();
+    }
+
+    loop() {
+        if (!this.isPlaying) return;
+
+        const now = performance.now();
+        const elapsed = now - this.lastFrameTime;
+        const speed = this.getCurrentSpeed();
+
+        if (elapsed >= speed) {
+            const next = (this.getCurrentFrame() + 1) % this.getFrameCount();
+            this.setCurrentFrame(next);
+            this.showFrame(next);
+            // Adjust for drift while preserving the interval grid
+            this.lastFrameTime = now - (elapsed % speed);
+        }
+
+        this.animationFrameId = requestAnimationFrame(this.boundLoop);
+    }
+
+    pause() {
+        this.isPlaying = false;
+        if (this.ui.playBtn) {
+            this.ui.playBtn.classList.remove('playing');
+            this.ui.playBtn.setAttribute('aria-pressed', 'false');
+            this.ui.playBtn.setAttribute('aria-label', i18n.t('radar.play'));
+            this.ui.playBtn.setAttribute('title', i18n.t('radar.playTitle'));
+        }
+
+        if (this.animationFrameId) {
+            cancelAnimationFrame(this.animationFrameId);
+            this.animationFrameId = null;
+        }
+    }
+
+    togglePlay() {
+        if (this.isPlaying) this.pause();
+        else this.play();
+    }
+
+    destroy() {
+        this.pause();
+    }
+}

--- a/public/src/map/WeatherRadar.js
+++ b/public/src/map/WeatherRadar.js
@@ -1,12 +1,13 @@
 import { CONFIG } from '../config.js';
 import { i18n } from '../i18n/index.js';
 import { RadarErrorToast } from './RadarErrorToast.js';
+import { RadarPlayback } from './RadarPlayback.js';
 
 // TODO: Refactor (in progress) — this class is large and mixes several concerns:
 // frame management, playback animation, polling/reconciliation, and the error/toast
-// UI. The error/toast subsystem has been extracted to RadarErrorToast.js; continue
-// splitting the remaining concerns into separate units (the existing test files
-// hint at these seams: frames, playback, polling, reconcile).
+// UI. The error/toast subsystem (RadarErrorToast.js) and playback (RadarPlayback.js)
+// have been extracted; continue splitting the remaining concerns into separate units
+// (the existing test files hint at these seams: frames, polling, reconcile).
 //
 // TODO: Feature — rain alerts. We already retain ~2h of radar frames; derive an
 // "approaching precipitation" signal relative to the selected circuit centre and
@@ -18,14 +19,10 @@ export class WeatherRadar {
         this.layers = [];
         this.visibleLayerIndex = -1;
         this.currentFrame = 0;
-        this.isPlaying = false;
-        this.animationFrameId = null;
-        this.lastFrameTime = 0;
         this.pollingTimeout = null;
         this.sessionTime = null;
         this.pastFrameCount = 0;
         this.pendingFrames = null;
-        this.speedIndex = CONFIG.defaultSpeedIndex;
 
         // Shared time formatter (O(1) creation, reuse in loops)
         this.timeFormatter = new Intl.DateTimeFormat(i18n.locale, {
@@ -37,24 +34,34 @@ export class WeatherRadar {
         // Tile-error tracking + "connection instability" toast
         this.errorToast = new RadarErrorToast({ onRetry: () => this.redrawLayers() });
 
+        // Animation playback + speed control. Frame state stays here and is
+        // accessed via callbacks.
+        this.playback = new RadarPlayback({
+            getFrameCount: () => this.frames.length,
+            getCurrentFrame: () => this.currentFrame,
+            setCurrentFrame: (i) => { this.currentFrame = i; },
+            showFrame: (i) => this.showFrame(i),
+            beforePlay: () => {
+                if (this.pendingFrames) {
+                    this.applyFrameUpdate(this.pendingFrames);
+                    this.pendingFrames = null;
+                }
+            }
+        });
+
         // Bolt Optimization: Cache UI elements
         this.ui = {
             slider: document.getElementById('radarSlider'),
-            playBtn: document.getElementById('radarPlayBtn'),
             time: document.getElementById('radarTime'),
             relative: document.getElementById('radarRelative'),
             timeStart: document.getElementById('radarTimeStart'),
             timeEnd: document.getElementById('radarTimeEnd'),
-            controls: document.getElementById('radarControls'),
-            speedBtn: document.getElementById('radarSpeedBtn'),
-            speedLabel: document.getElementById('radarSpeedLabel')
+            controls: document.getElementById('radarControls')
         };
 
-        this.boundLoop = this.loop.bind(this);
         this.handleSpaceKey = this.handleSpaceKey.bind(this);
         this.handleLanguageChange = this.handleLanguageChange.bind(this);
         this.bindEvents();
-        this.updateSpeedLabel();
 
         // Palette UX: Start a 1-minute timer to keep the relative time updated
         this.relativeTimeInterval = setInterval(() => {
@@ -65,18 +72,12 @@ export class WeatherRadar {
     }
 
     bindEvents() {
-        if (this.ui.playBtn) {
-            this.ui.playBtn.addEventListener('click', () => this.togglePlay());
-        }
         if (this.ui.slider) {
             this.ui.slider.addEventListener('input', (e) => {
                 this.currentFrame = parseInt(e.target.value, 10);
                 this.showFrame(this.currentFrame);
-                this.pause();
+                this.playback.pause();
             });
-        }
-        if (this.ui.speedBtn) {
-            this.ui.speedBtn.addEventListener('click', () => this.cycleSpeed());
         }
 
         // Global shortcut: Space to toggle play/pause
@@ -97,7 +98,7 @@ export class WeatherRadar {
             }
 
             e.preventDefault();
-            this.togglePlay();
+            this.playback.togglePlay();
         }
     }
 
@@ -105,36 +106,7 @@ export class WeatherRadar {
         document.removeEventListener('keydown', this.handleSpaceKey);
         document.removeEventListener('i18n:change', this.handleLanguageChange);
         this.errorToast.destroy();
-    }
-
-    cycleSpeed() {
-        // Cycle to the next speed
-        this.speedIndex = (this.speedIndex + 1) % CONFIG.radarSpeeds.length;
-        this.updateSpeedLabel();
-
-        // If playing, restart with the new speed
-        if (this.isPlaying) {
-            this.pause();
-            this.play();
-        }
-    }
-
-    updateSpeedLabel() {
-        if (this.ui.speedLabel) {
-            const label = CONFIG.radarSpeeds[this.speedIndex].label;
-            this.ui.speedLabel.textContent = label;
-
-            // Palette Accessibility: Update ARIA label with current state
-            if (this.ui.speedBtn) {
-                const speedLabel = i18n.t('radar.playbackSpeed', { speed: label });
-                this.ui.speedBtn.setAttribute('aria-label', speedLabel);
-                this.ui.speedBtn.setAttribute('title', speedLabel);
-            }
-        }
-    }
-
-    getCurrentSpeed() {
-        return CONFIG.radarSpeeds[this.speedIndex].speed;
+        this.playback.destroy();
     }
 
     setSessionTime(sessionTime) {
@@ -194,7 +166,7 @@ export class WeatherRadar {
             // This prevents "hammering" by loading one frame at a time in the background
             this.preloadSequence();
 
-            this.play();
+            this.playback.play();
         } catch (error) {
             console.error('Radar load failed:', error);
         } finally {
@@ -276,7 +248,7 @@ export class WeatherRadar {
             }
 
             // Always attempt update - rebuild logic is cheap and robust
-            if (this.isPlaying) {
+            if (this.playback.isPlaying) {
                 this.applyFrameUpdate(newFrames);
             } else {
                 // Defer update until played
@@ -869,67 +841,6 @@ export class WeatherRadar {
         }
     }
 
-    play() {
-        // Clear any existing timer/loop first to prevent double animations
-        this.pause();
-
-        // Apply any pending updates before starting
-        if (this.pendingFrames) {
-            this.applyFrameUpdate(this.pendingFrames);
-            this.pendingFrames = null;
-        }
-
-        this.isPlaying = true;
-        if (this.ui.playBtn) {
-            this.ui.playBtn.classList.add('playing');
-            this.ui.playBtn.setAttribute('aria-pressed', 'true');
-            this.ui.playBtn.setAttribute('aria-label', i18n.t('radar.pause'));
-            this.ui.playBtn.setAttribute('title', i18n.t('radar.pauseTitle'));
-        }
-
-        // Bolt Optimization: Use requestAnimationFrame instead of setInterval
-        // Prevents drift and saves battery in background tabs
-        this.lastFrameTime = performance.now();
-        this.loop();
-    }
-
-    loop() {
-        if (!this.isPlaying) return;
-
-        const now = performance.now();
-        const elapsed = now - this.lastFrameTime;
-        const speed = this.getCurrentSpeed();
-
-        if (elapsed >= speed) {
-            this.currentFrame = (this.currentFrame + 1) % this.frames.length;
-            this.showFrame(this.currentFrame);
-            // Adjust for drift while preserving the interval grid
-            this.lastFrameTime = now - (elapsed % speed);
-        }
-
-        this.animationFrameId = requestAnimationFrame(this.boundLoop);
-    }
-
-    pause() {
-        this.isPlaying = false;
-        if (this.ui.playBtn) {
-            this.ui.playBtn.classList.remove('playing');
-            this.ui.playBtn.setAttribute('aria-pressed', 'false');
-            this.ui.playBtn.setAttribute('aria-label', i18n.t('radar.play'));
-            this.ui.playBtn.setAttribute('title', i18n.t('radar.playTitle'));
-        }
-
-        if (this.animationFrameId) {
-            cancelAnimationFrame(this.animationFrameId);
-            this.animationFrameId = null;
-        }
-    }
-
-    togglePlay() {
-        if (this.isPlaying) this.pause();
-        else this.play();
-    }
-
     showControls(visible) {
         if (this.ui.controls) {
             this.ui.controls.style.display = visible ? 'flex' : 'none';
@@ -952,7 +863,7 @@ export class WeatherRadar {
             hour12: false
         });
 
-        this.updateSpeedLabel();
+        this.playback.updateSpeedLabel();
         this.updateSlider();
 
         // Update current frame time display

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,7 +8,7 @@
  * - Network-first with cache fallback for navigation
  */
 
-const CACHE_VERSION = '1.1.7';
+const CACHE_VERSION = '1.1.8';
 const CACHE_NAME = `circuit-weather-v${CACHE_VERSION}`;
 
 // App shell resources to pre-cache on install
@@ -29,6 +29,7 @@ const APP_SHELL = [
     '/src/map/TrackLayer.js',
     '/src/map/WeatherRadar.js',
     '/src/map/RadarErrorToast.js',
+    '/src/map/RadarPlayback.js',
     '/src/routing/Router.js',
     '/src/ui/CountdownTimer.js',
     '/src/ui/PrivacyModal.js',

--- a/tests/radar-countdown-live.test.js
+++ b/tests/radar-countdown-live.test.js
@@ -254,14 +254,14 @@ describe('WeatherRadar Live Countdown', () => {
     it('animates frames in a loop', () => {
         radar.frames = [{ time: 1000 }, { time: 2000 }];
         radar.currentFrame = 0;
-        radar.isPlaying = true;
-        vi.spyOn(radar, 'getCurrentSpeed').mockReturnValue(100);
+        radar.playback.isPlaying = true;
+        vi.spyOn(radar.playback, 'getCurrentSpeed').mockReturnValue(100);
         vi.spyOn(radar, 'showFrame');
 
-        radar.lastFrameTime = 0;
+        radar.playback.lastFrameTime = 0;
         vi.spyOn(performance, 'now').mockReturnValue(100);
 
-        radar.loop();
+        radar.playback.loop();
 
         expect(radar.showFrame).toHaveBeenCalledWith(1);
     });

--- a/tests/radar-playback.test.js
+++ b/tests/radar-playback.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// RadarPlayback is normally driven by WeatherRadar (covered by the weather-radar
+// suites). These tests exercise it in isolation, including its default no-op
+// callbacks, which WeatherRadar always overrides.
+vi.stubGlobal('document', { getElementById: vi.fn(() => null), addEventListener: vi.fn() });
+vi.stubGlobal('navigator', { language: 'en-US' });
+let nowVal = 0;
+vi.stubGlobal('performance', { now: () => nowVal });
+vi.stubGlobal('requestAnimationFrame', vi.fn(() => 42));
+vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
+const { RadarPlayback } = await import('../public/src/map/RadarPlayback.js');
+
+describe('RadarPlayback', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        nowVal = 0;
+    });
+
+    it('uses safe default callbacks when none are provided', () => {
+        const pb = new RadarPlayback();
+        expect(pb.isPlaying).toBe(false);
+
+        pb.play();
+        expect(pb.isPlaying).toBe(true);
+
+        // Force the frame-advance branch; the default callbacks must not throw
+        pb.lastFrameTime = 0;
+        nowVal = 100000;
+        expect(() => pb.loop()).not.toThrow();
+        expect(requestAnimationFrame).toHaveBeenCalled();
+
+        pb.pause();
+        expect(pb.isPlaying).toBe(false);
+        expect(cancelAnimationFrame).toHaveBeenCalledWith(42);
+    });
+
+    it('advances the current frame through the injected callbacks', () => {
+        const showFrame = vi.fn();
+        let current = 0;
+        const pb = new RadarPlayback({
+            getFrameCount: () => 5,
+            getCurrentFrame: () => current,
+            setCurrentFrame: (i) => { current = i; },
+            showFrame,
+        });
+
+        pb.play();
+        pb.lastFrameTime = 0;
+        nowVal = 100000; // elapsed >> speed, so a frame advances
+        pb.loop();
+
+        expect(current).toBe(1);
+        expect(showFrame).toHaveBeenCalledWith(1);
+    });
+
+    it('flushes pending work via beforePlay when starting', () => {
+        const beforePlay = vi.fn();
+        const pb = new RadarPlayback({ beforePlay });
+        pb.play();
+        expect(beforePlay).toHaveBeenCalledOnce();
+    });
+
+    it('cycles speed and restarts playback when already playing', () => {
+        const pb = new RadarPlayback();
+        const startIndex = pb.speedIndex;
+        pb.play();
+        pb.cycleSpeed();
+        expect(pb.speedIndex).not.toBe(startIndex);
+        expect(pb.isPlaying).toBe(true);
+    });
+});

--- a/tests/weather-radar-frames.test.js
+++ b/tests/weather-radar-frames.test.js
@@ -160,9 +160,9 @@ describe('WeatherRadar Frame & Speed Logic', () => {
     // ---------------------------------------------------------------
     describe('cycleSpeed', () => {
         it('increments speedIndex', () => {
-            const initialIndex = radar.speedIndex;
-            radar.cycleSpeed();
-            expect(radar.speedIndex).toBe(initialIndex + 1);
+            const initialIndex = radar.playback.speedIndex;
+            radar.playback.cycleSpeed();
+            expect(radar.playback.speedIndex).toBe(initialIndex + 1);
         });
 
         it('wraps around to 0 when at the last speed', () => {
@@ -173,36 +173,36 @@ describe('WeatherRadar Frame & Speed Logic', () => {
 
             // Cycle until we wrap back to 0
             do {
-                radar.cycleSpeed();
+                radar.playback.cycleSpeed();
                 cycleCount++;
                 if (cycleCount > 20) break; // Safety limit
-            } while (radar.speedIndex !== 0);
+            } while (radar.playback.speedIndex !== 0);
 
-            expect(radar.speedIndex).toBe(0);
+            expect(radar.playback.speedIndex).toBe(0);
             expect(cycleCount).toBeGreaterThan(1); // Proves there were multiple speeds
         });
 
         it('restarts playback if currently playing', () => {
-            const pauseSpy = vi.spyOn(radar, 'pause').mockImplementation(() => {
-                radar.isPlaying = false;
+            const pauseSpy = vi.spyOn(radar.playback, 'pause').mockImplementation(() => {
+                radar.playback.isPlaying = false;
             });
-            const playSpy = vi.spyOn(radar, 'play').mockImplementation(() => {
-                radar.isPlaying = true;
+            const playSpy = vi.spyOn(radar.playback, 'play').mockImplementation(() => {
+                radar.playback.isPlaying = true;
             });
 
-            radar.isPlaying = true;
-            radar.cycleSpeed();
+            radar.playback.isPlaying = true;
+            radar.playback.cycleSpeed();
 
             expect(pauseSpy).toHaveBeenCalled();
             expect(playSpy).toHaveBeenCalled();
         });
 
         it('does not restart playback if not playing', () => {
-            const pauseSpy = vi.spyOn(radar, 'pause').mockImplementation(() => { });
-            const playSpy = vi.spyOn(radar, 'play').mockImplementation(() => { });
+            const pauseSpy = vi.spyOn(radar.playback, 'pause').mockImplementation(() => { });
+            const playSpy = vi.spyOn(radar.playback, 'play').mockImplementation(() => { });
 
-            radar.isPlaying = false;
-            radar.cycleSpeed();
+            radar.playback.isPlaying = false;
+            radar.playback.cycleSpeed();
 
             expect(pauseSpy).not.toHaveBeenCalled();
             expect(playSpy).not.toHaveBeenCalled();

--- a/tests/weather-radar-lifecycle.test.js
+++ b/tests/weather-radar-lifecycle.test.js
@@ -84,9 +84,9 @@ describe('WeatherRadar Lifecycle & Playback', () => {
         radar.ui.timeStart = createMockElement('radarTimeStart');
         radar.ui.timeEnd = createMockElement('radarTimeEnd');
         radar.ui.controls = createMockElement('radarControls');
-        radar.ui.playBtn = createMockElement('radarPlayBtn');
-        radar.ui.speedLabel = createMockElement('radarSpeedLabel');
-        radar.ui.speedBtn = createMockElement('radarSpeedBtn');
+        radar.playback.ui.playBtn = createMockElement('radarPlayBtn');
+        radar.playback.ui.speedLabel = createMockElement('radarSpeedLabel');
+        radar.playback.ui.speedBtn = createMockElement('radarSpeedBtn');
         radar.errorToast.ui.errorToast = createMockElement('errorToast');
         radar.errorToast.ui.errorTimer = createMockElement('errorTimer');
         radar.errorToast.ui.errorTitle = createMockElement('errorTitle');
@@ -214,17 +214,17 @@ describe('WeatherRadar Lifecycle & Playback', () => {
     describe('play', () => {
         it('sets isPlaying to true and starts animation loop', () => {
             radar.frames = [{ time: 100 }];
-            radar.play();
+            radar.playback.play();
 
-            expect(radar.isPlaying).toBe(true);
+            expect(radar.playback.isPlaying).toBe(true);
             expect(requestAnimationFrame).toHaveBeenCalled();
         });
 
         it('adds playing class and updates ARIA on play button', () => {
-            radar.play();
+            radar.playback.play();
 
-            expect(radar.ui.playBtn.classList.add).toHaveBeenCalledWith('playing');
-            expect(radar.ui.playBtn.setAttribute).toHaveBeenCalledWith('aria-label', 'Pause radar animation');
+            expect(radar.playback.ui.playBtn.classList.add).toHaveBeenCalledWith('playing');
+            expect(radar.playback.ui.playBtn.setAttribute).toHaveBeenCalledWith('aria-label', 'Pause radar animation');
         });
 
         it('applies pending frames before starting', () => {
@@ -232,7 +232,7 @@ describe('WeatherRadar Lifecycle & Playback', () => {
             const pendingFrames = [{ time: 300, path: '/p3' }];
             radar.pendingFrames = pendingFrames;
 
-            radar.play();
+            radar.playback.play();
 
             expect(applyUpdateSpy).toHaveBeenCalledWith(pendingFrames);
             expect(radar.pendingFrames).toBeNull();
@@ -241,31 +241,31 @@ describe('WeatherRadar Lifecycle & Playback', () => {
 
     describe('pause', () => {
         it('stops animation and updates button state', () => {
-            radar.isPlaying = true;
-            radar.animationFrameId = 42;
+            radar.playback.isPlaying = true;
+            radar.playback.animationFrameId = 42;
 
-            radar.pause();
+            radar.playback.pause();
 
-            expect(radar.isPlaying).toBe(false);
+            expect(radar.playback.isPlaying).toBe(false);
             expect(cancelAnimationFrame).toHaveBeenCalledWith(42);
-            expect(radar.animationFrameId).toBeNull();
-            expect(radar.ui.playBtn.classList.remove).toHaveBeenCalledWith('playing');
-            expect(radar.ui.playBtn.setAttribute).toHaveBeenCalledWith('aria-label', 'Play radar animation');
+            expect(radar.playback.animationFrameId).toBeNull();
+            expect(radar.playback.ui.playBtn.classList.remove).toHaveBeenCalledWith('playing');
+            expect(radar.playback.ui.playBtn.setAttribute).toHaveBeenCalledWith('aria-label', 'Play radar animation');
         });
     });
 
     describe('togglePlay', () => {
         it('plays when paused', () => {
-            radar.isPlaying = false;
-            const playSpy = vi.spyOn(radar, 'play').mockImplementation(() => { });
-            radar.togglePlay();
+            radar.playback.isPlaying = false;
+            const playSpy = vi.spyOn(radar.playback, 'play').mockImplementation(() => { });
+            radar.playback.togglePlay();
             expect(playSpy).toHaveBeenCalled();
         });
 
         it('pauses when playing', () => {
-            radar.isPlaying = true;
-            const pauseSpy = vi.spyOn(radar, 'pause').mockImplementation(() => { });
-            radar.togglePlay();
+            radar.playback.isPlaying = true;
+            const pauseSpy = vi.spyOn(radar.playback, 'pause').mockImplementation(() => { });
+            radar.playback.togglePlay();
             expect(pauseSpy).toHaveBeenCalled();
         });
     });
@@ -291,7 +291,7 @@ describe('WeatherRadar Lifecycle & Playback', () => {
             await radar.load();
 
             expect(radar.frames).toHaveLength(2);
-            expect(radar.isPlaying).toBe(true);
+            expect(radar.playback.isPlaying).toBe(true);
         });
 
         it('handles empty API response gracefully', async () => {
@@ -302,7 +302,7 @@ describe('WeatherRadar Lifecycle & Playback', () => {
             await radar.load();
 
             expect(radar.frames).toHaveLength(0);
-            expect(radar.isPlaying).toBe(false);
+            expect(radar.playback.isPlaying).toBe(false);
         });
 
         it('always starts polling even if load fails', async () => {
@@ -574,27 +574,27 @@ describe('WeatherRadar Lifecycle & Playback', () => {
         });
 
         it('loop does nothing if not playing', () => {
-            radar.isPlaying = false;
-            radar.loop();
-            expect(radar.animationFrameId).toBeNull();
+            radar.playback.isPlaying = false;
+            radar.playback.loop();
+            expect(radar.playback.animationFrameId).toBeNull();
         });
 
         it('loop advances frame when enough time elapsed', () => {
-            radar.isPlaying = true;
+            radar.playback.isPlaying = true;
             radar.frames = [{ time: 1000 }, { time: 2000 }];
             radar.currentFrame = 0;
-            radar.lastFrameTime = 0;
+            radar.playback.lastFrameTime = 0;
 
-            vi.spyOn(radar, 'getCurrentSpeed').mockReturnValue(100);
+            vi.spyOn(radar.playback, 'getCurrentSpeed').mockReturnValue(100);
             vi.spyOn(performance, 'now').mockReturnValue(150); // > 100
             vi.spyOn(radar, 'showFrame').mockImplementation(() => {});
 
-            radar.loop();
+            radar.playback.loop();
 
             expect(radar.currentFrame).toBe(1);
             expect(radar.showFrame).toHaveBeenCalledWith(1);
             // 150 - (150 % 100) = 150 - 50 = 100
-            expect(radar.lastFrameTime).toBe(100);
+            expect(radar.playback.lastFrameTime).toBe(100);
         });
     });
 
@@ -665,15 +665,15 @@ describe('WeatherRadar Lifecycle & Playback', () => {
         });
 
         it('togglePlay pauses if playing, plays if not playing', () => {
-            const playSpy = vi.spyOn(radar, 'play').mockImplementation(() => {});
-            const pauseSpy = vi.spyOn(radar, 'pause').mockImplementation(() => {});
+            const playSpy = vi.spyOn(radar.playback, 'play').mockImplementation(() => {});
+            const pauseSpy = vi.spyOn(radar.playback, 'pause').mockImplementation(() => {});
 
-            radar.isPlaying = true;
-            radar.togglePlay();
+            radar.playback.isPlaying = true;
+            radar.playback.togglePlay();
             expect(pauseSpy).toHaveBeenCalled();
 
-            radar.isPlaying = false;
-            radar.togglePlay();
+            radar.playback.isPlaying = false;
+            radar.playback.togglePlay();
             expect(playSpy).toHaveBeenCalled();
         });
 
@@ -736,7 +736,7 @@ describe('WeatherRadar Lifecycle & Playback', () => {
 
     describe('handleLanguageChange Coverage', () => {
         it('updates formatters and UI components', () => {
-            const updateSpeedLabelSpy = vi.spyOn(radar, 'updateSpeedLabel').mockImplementation(() => {});
+            const updateSpeedLabelSpy = vi.spyOn(radar.playback, 'updateSpeedLabel').mockImplementation(() => {});
             const updateSliderSpy = vi.spyOn(radar, 'updateSlider').mockImplementation(() => {});
             const updateTimeDisplaySpy = vi.spyOn(radar, 'updateTimeDisplay').mockImplementation(() => {});
 

--- a/tests/weather-radar-playback.test.js
+++ b/tests/weather-radar-playback.test.js
@@ -74,9 +74,9 @@ describe('WeatherRadar Playback & Speed Control', () => {
         radar = new WeatherRadar(mockMap);
 
         // Mock UI elements involved in speed control
-        radar.ui.speedBtn = createMockElement('radarSpeedBtn');
-        radar.ui.speedLabel = createMockElement('radarSpeedLabel');
-        radar.ui.playBtn = createMockElement('radarPlayBtn');
+        radar.playback.ui.speedBtn = createMockElement('radarSpeedBtn');
+        radar.playback.ui.speedLabel = createMockElement('radarSpeedLabel');
+        radar.playback.ui.playBtn = createMockElement('radarPlayBtn');
     });
 
     // ---------------------------------------------------------------
@@ -85,55 +85,55 @@ describe('WeatherRadar Playback & Speed Control', () => {
     describe('Speed Control', () => {
         it('should cycle through available speeds', () => {
             // Initial state (default index 1: 1x)
-            expect(radar.speedIndex).toBe(CONFIG.defaultSpeedIndex);
+            expect(radar.playback.speedIndex).toBe(CONFIG.defaultSpeedIndex);
 
             // Cycle 1 -> 2 (2x)
-            radar.cycleSpeed();
-            expect(radar.speedIndex).toBe(2);
-            expect(radar.ui.speedLabel.textContent).toBe('2x');
-            expect(radar.getCurrentSpeed()).toBe(500);
+            radar.playback.cycleSpeed();
+            expect(radar.playback.speedIndex).toBe(2);
+            expect(radar.playback.ui.speedLabel.textContent).toBe('2x');
+            expect(radar.playback.getCurrentSpeed()).toBe(500);
 
             // Cycle 2 -> 0 (0.5x)
-            radar.cycleSpeed();
-            expect(radar.speedIndex).toBe(0);
-            expect(radar.ui.speedLabel.textContent).toBe('0.5x');
-            expect(radar.getCurrentSpeed()).toBe(2000);
+            radar.playback.cycleSpeed();
+            expect(radar.playback.speedIndex).toBe(0);
+            expect(radar.playback.ui.speedLabel.textContent).toBe('0.5x');
+            expect(radar.playback.getCurrentSpeed()).toBe(2000);
 
             // Cycle 0 -> 1 (1x)
-            radar.cycleSpeed();
-            expect(radar.speedIndex).toBe(1);
-            expect(radar.ui.speedLabel.textContent).toBe('1x');
-            expect(radar.getCurrentSpeed()).toBe(1000);
+            radar.playback.cycleSpeed();
+            expect(radar.playback.speedIndex).toBe(1);
+            expect(radar.playback.ui.speedLabel.textContent).toBe('1x');
+            expect(radar.playback.getCurrentSpeed()).toBe(1000);
         });
 
         it('should restart playback if currently playing when speed changes', () => {
-            radar.isPlaying = true;
-            const pauseSpy = vi.spyOn(radar, 'pause');
-            const playSpy = vi.spyOn(radar, 'play');
+            radar.playback.isPlaying = true;
+            const pauseSpy = vi.spyOn(radar.playback, 'pause');
+            const playSpy = vi.spyOn(radar.playback, 'play');
 
-            radar.cycleSpeed();
+            radar.playback.cycleSpeed();
 
             expect(pauseSpy).toHaveBeenCalled();
             expect(playSpy).toHaveBeenCalled();
             // speedIndex should have updated
-            expect(radar.speedIndex).not.toBe(CONFIG.defaultSpeedIndex);
+            expect(radar.playback.speedIndex).not.toBe(CONFIG.defaultSpeedIndex);
         });
 
         it('should NOT restart playback if paused when speed changes', () => {
-            radar.isPlaying = false;
-            const pauseSpy = vi.spyOn(radar, 'pause');
-            const playSpy = vi.spyOn(radar, 'play');
+            radar.playback.isPlaying = false;
+            const pauseSpy = vi.spyOn(radar.playback, 'pause');
+            const playSpy = vi.spyOn(radar.playback, 'play');
 
-            radar.cycleSpeed();
+            radar.playback.cycleSpeed();
 
             expect(pauseSpy).not.toHaveBeenCalled();
             expect(playSpy).not.toHaveBeenCalled();
         });
 
         it('should update ARIA label on speed button', () => {
-            radar.cycleSpeed();
-            const label = CONFIG.radarSpeeds[radar.speedIndex].label;
-            expect(radar.ui.speedBtn.setAttribute).toHaveBeenCalledWith('aria-label', `Playback speed: ${label}`);
+            radar.playback.cycleSpeed();
+            const label = CONFIG.radarSpeeds[radar.playback.speedIndex].label;
+            expect(radar.playback.ui.speedBtn.setAttribute).toHaveBeenCalledWith('aria-label', `Playback speed: ${label}`);
         });
     });
 
@@ -165,7 +165,7 @@ describe('WeatherRadar Playback & Speed Control', () => {
 
             // Mock active element as body
             documentMock.activeElement = { tagName: 'BODY' };
-            const toggleSpy = vi.spyOn(radar, 'togglePlay');
+            const toggleSpy = vi.spyOn(radar.playback, 'togglePlay');
             const preventDefault = vi.fn();
 
             // Trigger event
@@ -177,7 +177,7 @@ describe('WeatherRadar Playback & Speed Control', () => {
 
         it('should NOT toggle when focus is on an input', () => {
             documentMock.activeElement = { tagName: 'INPUT' };
-            const toggleSpy = vi.spyOn(radar, 'togglePlay');
+            const toggleSpy = vi.spyOn(radar.playback, 'togglePlay');
             const preventDefault = vi.fn();
 
             keydownHandler({ code: 'Space', preventDefault });
@@ -188,7 +188,7 @@ describe('WeatherRadar Playback & Speed Control', () => {
 
         it('should NOT toggle when focus is on a button', () => {
             documentMock.activeElement = { tagName: 'BUTTON' };
-            const toggleSpy = vi.spyOn(radar, 'togglePlay');
+            const toggleSpy = vi.spyOn(radar.playback, 'togglePlay');
 
             keydownHandler({ code: 'Space', preventDefault: vi.fn() });
 
@@ -197,7 +197,7 @@ describe('WeatherRadar Playback & Speed Control', () => {
 
         it('should ignore other keys', () => {
             documentMock.activeElement = { tagName: 'BODY' };
-            const toggleSpy = vi.spyOn(radar, 'togglePlay');
+            const toggleSpy = vi.spyOn(radar.playback, 'togglePlay');
 
             keydownHandler({ code: 'Enter', preventDefault: vi.fn() });
 

--- a/tests/weather-radar-polling.test.js
+++ b/tests/weather-radar-polling.test.js
@@ -163,7 +163,7 @@ describe('WeatherRadar Polling Logic', () => {
             radar.frames = [
                 { time: 100, path: '/path1' }
             ];
-            radar.isPlaying = true;
+            radar.playback.isPlaying = true;
 
             // Mock API returning new frames
             global.fetch.mockResolvedValueOnce({ ok: true,
@@ -184,7 +184,7 @@ describe('WeatherRadar Polling Logic', () => {
 
         it('should defer update if not playing', async () => {
             radar.frames = [{ time: 100, path: '/path1' }];
-            radar.isPlaying = false;
+            radar.playback.isPlaying = false;
 
             global.fetch.mockResolvedValueOnce({ ok: true,
                 json: () => Promise.resolve({


### PR DESCRIPTION
## Summary

Second step of the `WeatherRadar` refactor TODO. Animation playback (play/pause/loop) and the speed control are extracted into a new **`RadarPlayback`** module.

- `WeatherRadar` composes `this.playback` and delegates: the play button + speed button listeners, the spacebar shortcut, the slider's pause-on-scrub, and `checkForUpdates`/`load` all go through `playback`.
- **Frame state stays in `WeatherRadar`** (the frame list, `currentFrame`, `showFrame`). `RadarPlayback` reaches it through injected callbacks (`getFrameCount`, `getCurrentFrame`, `setCurrentFrame`, `showFrame`), and the deferred-frame flush in `play()` is injected as a `beforePlay` callback — so the controller owns only playback state (`isPlaying`, speed, the rAF handle) and its own play/speed buttons.
- **No behaviour change**: moved method bodies are verbatim aside from the callback indirection.

Updated TODO in `WeatherRadar.js` notes both the error/toast and playback extractions are done; frames, polling and reconcile remain.

## Testing
- [x] `pnpm test` — all 761 tests pass. White-box radar tests that reached into the moved internals (`radar.isPlaying`, `radar.play/pause/loop/togglePlay`, `radar.speedIndex`, `radar.getCurrentSpeed`, `radar.ui.playBtn/speedBtn/speedLabel`, `spyOn(radar, …)`) were mechanically updated to `radar.playback.*` across 5 test files; `currentFrame` deliberately stays on `WeatherRadar` and was left untouched.
- [x] Added a focused `RadarPlayback` unit test (covers the module in isolation incl. default callbacks) — `RadarPlayback.js` is 100% covered.
- [x] `pnpm run test:coverage` — thresholds met (99.7%).
- [x] Bumped the service-worker cache version and pre-cached the new module.

`WeatherRadar.js` shrinks another ~120 lines.

https://claude.ai/code/session_01Un3RuK7bDVG9o4FLSrwF3s

---
_Generated by [Claude Code](https://claude.ai/code/session_01Un3RuK7bDVG9o4FLSrwF3s)_