### PR TITLE
Fix mobile circuit name banner rendering below wind particles

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1527,7 +1527,7 @@ body {
         gap: var(--spacing-sm);
         padding: var(--spacing-sm);
         pointer-events: none;
-        z-index: 400;
+        z-index: 460;
     }
 
     .mobile-race-info {


### PR DESCRIPTION
## Problem

On mobile, the circuit name banner (`.mobile-ui-layout`) was rendering *underneath* the animated wind particle canvas because of conflicting z-index values:

| Element | z-index |
|---|---|
| `.wind-flow-canvas` | 450 |
| `.mobile-ui-layout` | 400 ← too low |

## Fix

Raised `.mobile-ui-layout` z-index from `400` → `460`, placing it above the wind particle canvas (450) while keeping it below the mobile header and radar controls (both at 500).

**One-line change in `public/styles.css`.**

---
_Generated by [Claude Code](https://claude.ai/code/session_018A4EnpqdVs2iMpQLb8R6pP)_