### PR TITLE
Double wind particle render area (radius 50→100 km)

### DIFF
--- a/public/src/config.js
+++ b/public/src/config.js
@@ -39,9 +39,9 @@ export const CONFIG = {
     WEATHER_CACHE_MAX_ENTRIES: 50,
 
     // Wind overlay (animated flow particles over the map)
-    WIND_FIELD_RADIUS_KM: 50, // Half-extent of the sampled grid box around the circuit
+    WIND_FIELD_RADIUS_KM: 100, // Half-extent of the sampled grid box around the circuit
     WIND_FIELD_GRID: 6, // Grid is N x N points (one batched Open-Meteo request)
-    WIND_FIELD_PARTICLES: 400,
+    WIND_FIELD_PARTICLES: 800,
     WIND_FIELD_PARTICLE_LIFE: 4, // Seconds before a particle respawns
     WIND_FIELD_FADE: 0.06, // Trail fade per frame (higher = shorter trails)
     WIND_FIELD_SPEED_GAIN: 1000, // Visual speed-up factor for advection


### PR DESCRIPTION
## Changes

Expands the animated wind particle bounding box from ~100×100 km to ~200×200 km — 4× the previous area.

| Config | Before | After |
|---|---|---|
| `WIND_FIELD_RADIUS_KM` | 50 | 100 |
| `WIND_FIELD_PARTICLES` | 400 | 800 |

`WIND_FIELD_PARTICLES` is also doubled to maintain a similar visual particle density across the larger field. The 6×6 sample grid and all other parameters are unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_018A4EnpqdVs2iMpQLb8R6pP)_