### PR TITLE
🔭 Archivist: Update privacy policy with windOverlay storage setting

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -231,3 +231,7 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 ## 2024-05-09 - Missing Caching Durations in Privacy Policy
 **Learning:** The privacy policy only documented caching durations for one out of five proxied data sources, leaving the data retention times for the others ambiguous despite them being explicitly defined in the worker cache headers.
 **Action:** Always verify that documentation of data retention and caching covers all relevant services consistently.
+
+## 2026-05-25 - Documenting Wind Overlay Preference Storage
+**Learning:** When introducing new UI toggles that persist state via `SafeStorage` (like the `windOverlay` feature), the documentation in `PRIVACY.md` and its localized variants often drifts, omitting the new storage key. Developers must ensure all user-facing preferences are documented to maintain privacy transparency.
+**Action:** When adding or modifying `SafeStorage` keys, always grep across the entire codebase and update the Local Storage section in `public/PRIVACY.md` and all `public/privacy/PRIVACY.*.md` variants.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ Circuit Weather is a real-time F1 race circuit weather radar application. It dis
 ### Data Handling
 
 - **No first-party cookies** used (third-party widgets may use cookies - see PRIVACY.md)
-- **localStorage only** for theme/unit/language preferences and f1_schedule_cache
+- **localStorage only** for theme/unit/language/windOverlay preferences and f1_schedule_cache
 - **No PII collected** - See PRIVACY.md
 
 ### Language & Spelling

--- a/public/PRIVACY.md
+++ b/public/PRIVACY.md
@@ -90,6 +90,7 @@ The application stores preference settings locally in your browser to remember y
 - **theme:** `light` or `dark`
 - **unit:** `metric` or `imperial`
 - **language:** your selected locale (e.g., `en-NZ`, `fr`)
+- **windOverlay:** `true` or `false` (remembers if the wind animation layer is enabled)
 - **f1_schedule_cache:** caches the F1 schedule data (24-hour cache)
 
 This data resides solely on your device and is never transmitted to our servers.

--- a/public/privacy/PRIVACY.de.md
+++ b/public/privacy/PRIVACY.de.md
@@ -87,6 +87,7 @@ Lokale Einstellungen im Browser:
 - **theme:** `light` oder `dark`
 - **unit:** `metric` oder `imperial`
 - **language:** Ihre ausgewählte Sprache (z. B. `de`, `en-US`)
+- **windOverlay:** `true` oder `false` (speichert, ob die Windanimations-Ebene aktiviert ist)
 - **f1_schedule_cache:** speichert die F1-Kalenderdaten zwischen (24-Stunden-Cache)
 
 ## Open Source

--- a/public/privacy/PRIVACY.en-GB.md
+++ b/public/privacy/PRIVACY.en-GB.md
@@ -87,6 +87,7 @@ Preference settings are stored locally in your browser:
 - **theme:** `light` or `dark`
 - **unit:** `metric` or `imperial`
 - **language:** your selected locale (e.g., `en-GB`, `fr`)
+- **windOverlay:** `true` or `false` (remembers if the wind animation layer is enabled)
 - **f1_schedule_cache:** caches the F1 schedule data (24-hour cache)
 
 This data remains on your device and is not sent to our servers.

--- a/public/privacy/PRIVACY.en-NZ.md
+++ b/public/privacy/PRIVACY.en-NZ.md
@@ -87,6 +87,7 @@ Preference settings are stored locally in your browser:
 - **theme:** `light` or `dark`
 - **unit:** `metric` or `imperial`
 - **language:** your selected locale (e.g., `en-NZ`, `fr`)
+- **windOverlay:** `true` or `false` (remembers if the wind animation layer is enabled)
 - **f1_schedule_cache:** caches the F1 schedule data (24-hour cache)
 
 This data remains on your device and is not sent to our servers.

--- a/public/privacy/PRIVACY.en-US.md
+++ b/public/privacy/PRIVACY.en-US.md
@@ -87,6 +87,7 @@ Preference settings are stored locally in your browser:
 - **theme:** `light` or `dark`
 - **unit:** `metric` or `imperial`
 - **language:** your selected locale (e.g., `en-GB`, `fr`)
+- **windOverlay:** `true` or `false` (remembers if the wind animation layer is enabled)
 - **f1_schedule_cache:** caches the F1 schedule data (24-hour cache)
 
 This data remains on your device and is not sent to our servers.

--- a/public/privacy/PRIVACY.es.md
+++ b/public/privacy/PRIVACY.es.md
@@ -87,6 +87,7 @@ El navegador guarda preferencias locales:
 - **theme:** `light` o `dark`
 - **unit:** `metric` o `imperial`
 - **language:** su idioma seleccionado (ej. `es`, `en-US`)
+- **windOverlay:** `true` o `false` (recuerda si la capa de animación de viento está habilitada)
 - **f1_schedule_cache:** guarda en caché los datos del calendario de F1 (caché de 24 horas)
 
 Estos datos permanecen en tu dispositivo.

--- a/public/privacy/PRIVACY.fr.md
+++ b/public/privacy/PRIVACY.fr.md
@@ -87,6 +87,7 @@ Les preferences sont stockees localement dans le navigateur :
 - **theme:** `light` ou `dark`
 - **unit:** `metric` ou `imperial`
 - **language:** votre langue sélectionnée (ex: `fr`, `en-US`)
+- **windOverlay:** `true` ou `false` (mémorise si le calque d'animation du vent est activé)
 - **f1_schedule_cache:** met en cache les données du calendrier de la F1 (cache de 24 heures)
 
 ## Open source

--- a/public/privacy/PRIVACY.hu.md
+++ b/public/privacy/PRIVACY.hu.md
@@ -87,6 +87,7 @@ A beállításokat a böngészője helyileg tárolja:
 - **theme (téma):** `light` (világos) vagy `dark` (sötét)
 - **unit (mértékegység):** `metric` (metrikus) vagy `imperial` (birodalmi)
 - **language (nyelv):** a kiválasztott nyelv (pl. `hu`, `en-US`)
+- **windOverlay:** `true` vagy `false` (megjegyzi, hogy a szélanimációs réteg be van-e kapcsolva)
 - **f1_schedule_cache:** gyorsítótárazza az F1 naptáradatokat (24 órás gyorsítótár)
 
 Ezek az adatok az Ön eszközén maradnak, és nem kerülnek elküldésre a szervereinkre.

--- a/public/privacy/PRIVACY.it.md
+++ b/public/privacy/PRIVACY.it.md
@@ -87,6 +87,7 @@ Preferenze salvate localmente nel browser:
 - **theme:** `light` o `dark`
 - **unit:** `metric` o `imperial`
 - **language:** la lingua selezionata (es. `it`, `en-US`)
+- **windOverlay:** `true` o `false` (ricorda se il livello di animazione del vento è abilitato)
 - **f1_schedule_cache:** memorizza i dati del calendario F1 (cache di 24 ore)
 
 ## Open source

--- a/public/privacy/PRIVACY.ja.md
+++ b/public/privacy/PRIVACY.ja.md
@@ -87,6 +87,7 @@ Circuit Weather は、Formula 1 サーキット向けのリアルタイム天気
 - **theme:** `light` または `dark`
 - **unit:** `metric` または `imperial`
 - **language:** 選択した言語 (例: `ja`, `en-US`)
+- **windOverlay:** `true` または `false` (風のアニメーションレイヤーが有効かどうかを記憶します)
 - **f1_schedule_cache:** F1のスケジュールデータをキャッシュします (24時間キャッシュ)
 
 これらのデータは端末内にのみ保存されます。

--- a/public/privacy/PRIVACY.pt-BR.md
+++ b/public/privacy/PRIVACY.pt-BR.md
@@ -87,6 +87,7 @@ Preferencias guardadas localmente no navegador:
 - **theme:** `light` ou `dark`
 - **unit:** `metric` ou `imperial`
 - **language:** o seu idioma selecionado (ex. `pt-BR`, `en-US`)
+- **windOverlay:** `true` ou `false` (lembra se a camada de animação de vento está habilitada)
 - **f1_schedule_cache:** faz cache dos dados do calendário da F1 (cache de 24 horas)
 
 ## Open source

--- a/public/privacy/PRIVACY.zh-CN.md
+++ b/public/privacy/PRIVACY.zh-CN.md
@@ -87,6 +87,7 @@ Circuit Weather 是一个开源网站应用，用于显示 Formula 1 赛道的�
 - **theme:** `light` 或 `dark`
 - **unit:** `metric` 或 `imperial`
 - **language:** 您选择的语言 (如 `zh-CN`, `en-US`)
+- **windOverlay:** `true` 或 `false` (记住风场动画图层是否启用)
 - **f1_schedule_cache:** 缓存 F1 赛程数据 (24小时缓存)
 
 这些数据仅保存在你的设备上。


### PR DESCRIPTION
💡 Problem: The `windOverlay` user preference toggle was recently added and stores its state using `SafeStorage`, but it was omitted from the Local Storage section of `PRIVACY.md` and its localized variants, leading to incomplete privacy documentation.

🎯 Fix: Added the `windOverlay` key to the Local Storage list in `public/PRIVACY.md`, updated all 11 localized variants in `public/privacy/`, and added it to the `localStorage` note in `AGENTS.md`. Also recorded this drift pattern in the Archivist journal.

🔬 Verification: Verified file modifications via `git diff`. Ran the full test suite (`pnpm test`) which successfully passed all 765 tests, confirming no application logic was accidentally affected.

🔎 Scope: This PR contains ONLY documentation changes to privacy policies, `AGENTS.md`, and the Archivist journal. No application code or behavior was modified.

---
*PR created automatically by Jules for task [8018821859722727998](https://jules.google.com/task/8018821859722727998) started by @2fst4u*