### PR TITLE
🧪 Spec: Add cache eviction test for WeatherClient getWindField

### DIFF
--- a/tests/weather-client.test.js
+++ b/tests/weather-client.test.js
@@ -446,6 +446,23 @@ describe('WeatherClient cache edge cases', () => {
         await client.getForecast(51.5, -0.1, sessionTime);
     });
 
+    it('evicts the oldest wind field cache entry when exceeding maxCacheSize', async () => {
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => [{ current: { wind_speed_10m: 10, wind_direction_10m: 180 } }]
+        });
+
+        // Fill cache
+        for (let i = 0; i < client.maxCacheSize; i++) {
+            client.windFieldCache.set(`old-key-${i}`, { timestamp: Date.now(), field: {} });
+        }
+
+        await client.getWindField(45, 9);
+
+        expect(client.windFieldCache.size).toBe(client.maxCacheSize);
+        expect(client.windFieldCache.has('old-key-0')).toBe(false);
+    });
+
     describe('getWindField', () => {
         const makeGridResponse = (n, speed, dir) => {
             const list = [];


### PR DESCRIPTION
💡 What: Added a test in `weather-client.test.js` to ensure the `getWindField` cache correctly evicts the oldest entry when its size exceeds `maxCacheSize`.
🎯 Why: Caching bounds in memory must be verified to prevent potential memory leaks over time during prolonged application use if caching goes unchecked.
📈 Maturity Impact: No threshold changes needed as the existing bounds (95%) were successfully preserved.

---
*PR created automatically by Jules for task [9116315778932705443](https://jules.google.com/task/9116315778932705443) started by @2fst4u*