### PR TITLE
🔭 Scout: Upgrade MapWeatherWidget to semantic description list

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -62,3 +62,6 @@
 ## 2025-02-14 - Dialog Content Deprioritization
 **Learning:** Upgrading `<div>` wrappers inside `<dialog>` modals to `<header>` and `<section>` tags is technically correct HTML5, but has negligible SEO impact because search engines deprioritize hidden modal content.
 **Action:** Prioritize structural SEO improvements within the `<main>`, `<article>`, or core visible components of the page before optimizing hidden modal structures.
+## 2025-02-14 - Semantic List Upgrades
+**Learning:** Upgrading loosely grouped generic `<div>` wrappers into semantic HTML lists (`<dl>`, `<dt>`, `<dd>`) can break visual layout depending on global browser defaults and parent CSS rules for list elements, as they often introduce default margins/paddings.
+**Action:** When converting elements to `<dl>` or `<dd>` for SEO/a11y improvements without changing stylesheets, immediately apply inline CSS resets (e.g., `margin: 0`, `padding: 0`, `display: flex`) to strictly preserve the visual design constraints mandated by the SEO prompt guidelines.

--- a/public/src/map/MapWeatherWidget.js
+++ b/public/src/map/MapWeatherWidget.js
@@ -1,115 +1,137 @@
-import { i18n } from '../i18n/index.js';
-import { getWindDirection } from '../utils/wind.js';
+import { i18n } from "../i18n/index.js";
+import { getWindDirection } from "../utils/wind.js";
 
 /**
  * Custom Control for showing weather data on the map.
  * Compatible with both Leaflet and Mapbox GL JS interfaces.
  */
 class MapWeatherWidgetClass {
-    constructor() {
-        // Scout: Upgraded generic div to semantic section to improve document outline and explicitly signal this standalone widget region to search engines.
-        this._div = document.createElement('section');
-        this._div.className = 'leaflet-control-weather mapboxgl-ctrl mapboxgl-ctrl-group';
-        this._div.setAttribute('role', 'region');
-        this._div.setAttribute('aria-label', i18n.t('weather.currentCircuitWeather'));
-        this._div.setAttribute('data-i18n-attr', 'aria-label:weather.currentCircuitWeather');
-        this._div.setAttribute('tabindex', '0');
+  constructor() {
+    // Scout: Upgraded generic div to semantic section to improve document outline and explicitly signal this standalone widget region to search engines.
+    this._div = document.createElement("section");
+    this._div.className =
+      "leaflet-control-weather mapboxgl-ctrl mapboxgl-ctrl-group";
+    this._div.setAttribute("role", "region");
+    this._div.setAttribute(
+      "aria-label",
+      i18n.t("weather.currentCircuitWeather"),
+    );
+    this._div.setAttribute(
+      "data-i18n-attr",
+      "aria-label:weather.currentCircuitWeather",
+    );
+    this._div.setAttribute("tabindex", "0");
 
-        this._div.innerHTML = `
-            <h2 class="weather-widget-heading" data-i18n="weather.currentConditions">${i18n.t('weather.currentConditions')}</h2>
-            <div class="weather-widget-metric" role="group" aria-label="${i18n.t('weather.temperature')}" title="${i18n.t('weather.temperature')}" data-i18n-attr="aria-label:weather.temperature,title:weather.temperature">
-                <svg class="icon-weather icon-temp" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0z" /></svg>
-                <span class="temp-value">--</span>
-            </div>
-            <div class="weather-widget-metric" role="group" aria-label="${i18n.t('weather.rainChance')}" title="${i18n.t('weather.rainChance')}" data-i18n-attr="aria-label:weather.rainChance,title:weather.rainChance">
-                <svg class="icon-weather icon-rain" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242"/><path d="M16 14v6"/><path d="M8 14v6"/><path d="M12 16v6"/></svg>
-                <span class="rain-value">--%</span>
-            </div>
-            <div class="weather-widget-metric" role="group" aria-label="${i18n.t('weather.humidity')}" title="${i18n.t('weather.humidity')}" data-i18n-attr="aria-label:weather.humidity,title:weather.humidity">
-                <svg class="icon-weather icon-humidity" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0z" /></svg>
-                <span class="humid-value">--%</span>
-            </div>
-            <div class="weather-widget-metric" role="group" aria-label="${i18n.t('weather.windSpeed')}" title="${i18n.t('weather.wind')}" data-i18n-attr="aria-label:weather.windSpeed,title:weather.wind">
-                 <svg class="icon-weather icon-wind" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9.59 4.59A2 2 0 1 1 11 8H2m10.59 11.41A2 2 0 1 0 14 16H2m15.73-8.27A2.5 2.5 0 1 1 19.5 12H2" /></svg>
-                <span class="wind-value">--</span>
-                <span class="wind-dir">
-                    <span class="wind-dir-text"></span>
-                    <svg class="icon-wind-arrow" aria-hidden="true" style="visibility: hidden;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"></line><polyline points="5 12 12 5 19 12"></polyline></svg>
-                </span>
-            </div>
+    this._div.innerHTML = `
+            <h2 class="weather-widget-heading" data-i18n="weather.currentConditions">${i18n.t("weather.currentConditions")}</h2>
+            <!-- Scout: Upgraded generic div/span wrappers to semantic description list (dl/dt/dd) to explicitly associate weather labels with their values for crawlers and assistive tech. -->
+            <dl class="weather-widget-list" style="margin: 0; padding: 0;">
+                <div class="weather-widget-metric" role="group" aria-label="${i18n.t("weather.temperature")}" title="${i18n.t("weather.temperature")}" data-i18n-attr="aria-label:weather.temperature,title:weather.temperature">
+                    <dt class="sr-only">${i18n.t("weather.temperature")}</dt>
+                    <dd style="display: flex; align-items: center; margin: 0;">
+                        <svg class="icon-weather icon-temp" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0z" /></svg>
+                        <span class="temp-value">--</span>
+                    </dd>
+                </div>
+                <div class="weather-widget-metric" role="group" aria-label="${i18n.t("weather.rainChance")}" title="${i18n.t("weather.rainChance")}" data-i18n-attr="aria-label:weather.rainChance,title:weather.rainChance">
+                    <dt class="sr-only">${i18n.t("weather.rainChance")}</dt>
+                    <dd style="display: flex; align-items: center; margin: 0;">
+                        <svg class="icon-weather icon-rain" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242"/><path d="M16 14v6"/><path d="M8 14v6"/><path d="M12 16v6"/></svg>
+                        <span class="rain-value">--%</span>
+                    </dd>
+                </div>
+                <div class="weather-widget-metric" role="group" aria-label="${i18n.t("weather.humidity")}" title="${i18n.t("weather.humidity")}" data-i18n-attr="aria-label:weather.humidity,title:weather.humidity">
+                    <dt class="sr-only">${i18n.t("weather.humidity")}</dt>
+                    <dd style="display: flex; align-items: center; margin: 0;">
+                        <svg class="icon-weather icon-humidity" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0z" /></svg>
+                        <span class="humid-value">--%</span>
+                    </dd>
+                </div>
+                <div class="weather-widget-metric" role="group" aria-label="${i18n.t("weather.windSpeed")}" title="${i18n.t("weather.wind")}" data-i18n-attr="aria-label:weather.windSpeed,title:weather.wind">
+                    <dt class="sr-only">${i18n.t("weather.wind")}</dt>
+                    <dd style="display: flex; align-items: center; margin: 0;">
+                        <svg class="icon-weather icon-wind" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9.59 4.59A2 2 0 1 1 11 8H2m10.59 11.41A2 2 0 1 0 14 16H2m15.73-8.27A2.5 2.5 0 1 1 19.5 12H2" /></svg>
+                        <span class="wind-value">--</span>
+                        <span class="wind-dir">
+                            <span class="wind-dir-text"></span>
+                            <svg class="icon-wind-arrow" aria-hidden="true" style="visibility: hidden;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"></line><polyline points="5 12 12 5 19 12"></polyline></svg>
+                        </span>
+                    </dd>
+                </div>
+            </dl>
         `;
 
-        this._ui = {
-            temp: this._div.querySelector('.temp-value'),
-            rain: this._div.querySelector('.rain-value'),
-            humid: this._div.querySelector('.humid-value'),
-            wind: this._div.querySelector('.wind-value'),
-            windDirText: this._div.querySelector('.wind-dir-text'),
-            windArrow: this._div.querySelector('.icon-wind-arrow')
-        };
+    this._ui = {
+      temp: this._div.querySelector(".temp-value"),
+      rain: this._div.querySelector(".rain-value"),
+      humid: this._div.querySelector(".humid-value"),
+      wind: this._div.querySelector(".wind-value"),
+      windDirText: this._div.querySelector(".wind-dir-text"),
+      windArrow: this._div.querySelector(".icon-wind-arrow"),
+    };
+  }
+
+  // Leaflet interface
+  onAdd(map) {
+    // Ensure Leaflet-specific classes are present
+    this._div.classList.add("leaflet-control");
+    return this._div;
+  }
+
+  onRemove(map) {
+    if (this._div.parentNode) {
+      this._div.parentNode.removeChild(this._div);
+    }
+  }
+
+  // Mapbox GL JS interface
+  getDefaultPosition() {
+    return "top-right";
+  }
+
+  update(weather) {
+    if (!this._div || !this._ui) return;
+
+    if (!weather || !weather.current) {
+      this._ui.temp.textContent = "--";
+      this._ui.rain.textContent = "--%";
+      this._ui.humid.textContent = "--%";
+      this._ui.wind.textContent = "--";
+      this.setWindDirection(null);
+      return;
     }
 
-    // Leaflet interface
-    onAdd(map) {
-        // Ensure Leaflet-specific classes are present
-        this._div.classList.add('leaflet-control');
-        return this._div;
+    const temp = Math.round(weather.current.temperature_2m);
+    const rain = Math.round(weather.current.precipitation_probability || 0);
+    const humidity = Math.round(weather.current.relative_humidity_2m || 0);
+    const wind = Math.round(weather.current.wind_speed_10m);
+
+    this._ui.temp.textContent = `${temp}${weather.units.temperature_2m}`;
+    this._ui.rain.textContent = `${rain}%`;
+    this._ui.humid.textContent = `${humidity}%`;
+    this._ui.wind.textContent = `${wind} ${weather.units.wind_speed_10m}`;
+    this.setWindDirection(weather.current.wind_direction_10m);
+  }
+
+  setWindDirection(degrees) {
+    if (!this._ui || !this._ui.windDirText || !this._ui.windArrow) return;
+
+    if (!Number.isFinite(degrees)) {
+      this._ui.windDirText.textContent = "";
+      this._ui.windArrow.style.transform = "";
+      this._ui.windArrow.style.visibility = "hidden";
+      return;
     }
 
-    onRemove(map) {
-        if (this._div.parentNode) {
-            this._div.parentNode.removeChild(this._div);
-        }
-    }
-
-    // Mapbox GL JS interface
-    getDefaultPosition() {
-        return 'top-right';
-    }
-
-    update(weather) {
-        if (!this._div || !this._ui) return;
-
-        if (!weather || !weather.current) {
-            this._ui.temp.textContent = '--';
-            this._ui.rain.textContent = '--%';
-            this._ui.humid.textContent = '--%';
-            this._ui.wind.textContent = '--';
-            this.setWindDirection(null);
-            return;
-        }
-
-        const temp = Math.round(weather.current.temperature_2m);
-        const rain = Math.round(weather.current.precipitation_probability || 0);
-        const humidity = Math.round(weather.current.relative_humidity_2m || 0);
-        const wind = Math.round(weather.current.wind_speed_10m);
-
-        this._ui.temp.textContent = `${temp}${weather.units.temperature_2m}`;
-        this._ui.rain.textContent = `${rain}%`;
-        this._ui.humid.textContent = `${humidity}%`;
-        this._ui.wind.textContent = `${wind} ${weather.units.wind_speed_10m}`;
-        this.setWindDirection(weather.current.wind_direction_10m);
-    }
-
-    setWindDirection(degrees) {
-        if (!this._ui || !this._ui.windDirText || !this._ui.windArrow) return;
-
-        if (!Number.isFinite(degrees)) {
-            this._ui.windDirText.textContent = '';
-            this._ui.windArrow.style.transform = '';
-            this._ui.windArrow.style.visibility = 'hidden';
-            return;
-        }
-
-        const { text, rotation } = getWindDirection(degrees);
-        this._ui.windDirText.textContent = text;
-        this._ui.windArrow.style.transform = `rotate(${rotation}deg)`;
-        this._ui.windArrow.style.visibility = '';
-    }
+    const { text, rotation } = getWindDirection(degrees);
+    this._ui.windDirText.textContent = text;
+    this._ui.windArrow.style.transform = `rotate(${rotation}deg)`;
+    this._ui.windArrow.style.visibility = "";
+  }
 }
 
 // Ensure the class supports both L.Control.extend patterns (if called via Leaflet) and standard ES6 class patterns (Mapbox)
-export const MapWeatherWidget = function() {
-    return new MapWeatherWidgetClass();
+export const MapWeatherWidget = function () {
+  return new MapWeatherWidgetClass();
 };
 MapWeatherWidget.prototype = MapWeatherWidgetClass.prototype;


### PR DESCRIPTION
💡 **What**: Upgraded the generic `<div>` and `<span>` wrappers inside `public/src/map/MapWeatherWidget.js` into a semantic description list (`<dl>`, `<dt>`, `<dd>`).
🎯 **Why**: The previous implementation used `role="group"` with nested generic elements. A description list explicitly maps the terms (e.g. "Temperature" label/icon) to their descriptions (the data value) semantically.
📊 **Value**: Enhances the document outline structure for crawlers by properly associating metric labels with values, significantly improving machine readability without altering visual aesthetics.
🔬 **Measurement**: Inspect the Mapbox/Leaflet widget in the DOM when a session is active and confirm the inner markup now uses `<dl>`, `<dt>`, and `<dd>` correctly instead of grouped `<div>` elements.

---
*PR created automatically by Jules for task [8729775804706043722](https://jules.google.com/task/8729775804706043722) started by @2fst4u*