### PR TITLE
🌍 Globe: Extract translation for weather timeline temperature

### DIFF
--- a/.jules/globe.md
+++ b/.jules/globe.md
@@ -7,3 +7,6 @@
 ## 2024-05-19 - Hardcoded Suffix Logic Causes Pluralization Bugs
 **Learning:** Using an English-centric hardcoded suffix placeholder like `{{suffix}}` (e.g. `suffix: count > 1 ? 's' : ''`) for pluralization causes severe grammatical errors in target languages. For example, German requires "Kacheln" instead of "Kachels", and Italian requires "riuscite" instead of "riuscitass".
 **Action:** Never use string concatenation or single-character suffix injections to handle plurals. Always create explicit singular and plural translation keys (e.g., `retryingFailedTiles` and `retryingFailedTilesPlural`) in the base dictionary and duplicate them in languages without plural forms if necessary.
+## 2024-05-24 - Dynamic Unit Suffixes over Hardcoded Symbols
+**Learning:** Do not hardcode unit symbols like the degree symbol (`°`) in the UI components (like the hourly weather timeline). The API response provides proper dynamic localized and unit-aware strings (e.g., `weather.units.temperature_2m`).
+**Action:** Always prefer the dynamic API-provided unit string variables over injecting explicit unit characters to respect user preference and locale correctly.

--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -1097,7 +1097,7 @@ export class CircuitWeatherApp {
                             <div class="weather-timeline-wind">${escapeHtml(hour.windSpeed)} ${escapeHtml(weather.units.wind_speed_10m)}</div>
                         </div>
                         <div class="weather-timeline-temp" aria-hidden="true">
-                            <div>${escapeHtml(temp)}°</div>
+                            <div>${escapeHtml(temp)}${escapeHtml(weather.units.temperature_2m)}</div>
                             <div class="weather-timeline-precip">${escapeHtml(hour.precipProb)}%</div>
                         </div>
                     </li>

--- a/tests/circuit-weather-app.test.js
+++ b/tests/circuit-weather-app.test.js
@@ -747,7 +747,7 @@ describe('CircuitWeatherApp Pure Methods', () => {
             // We check that the primary temperature value is 26
             expect(app.ui.forecastContent.innerHTML).toContain('id="weatherTemp">26°C</dd>');
             // 24 should still be in the timeline, but not the primary temp
-            expect(app.ui.forecastContent.innerHTML).toContain('<div>24°</div>');
+            expect(app.ui.forecastContent.innerHTML).toContain('<div>24°C</div>');
         });
     });
 


### PR DESCRIPTION
💡 What: Replaced the hardcoded degree symbol (`°`) in the hourly weather forecast timeline (`CircuitWeatherApp.js`) with the dynamic, unit-aware API value (`weather.units.temperature_2m`). Updated the corresponding unit test expectations.
🎯 Why: Hardcoding the degree symbol ignores user unit preferences (if the API were to provide something other than Celsius/Fahrenheit degrees, or just for string consistency) and bypassed proper localization formatting.
🌐 Nuance: The API natively supplies `weather.units.temperature_2m` to represent the selected metric system (e.g. `°C`), avoiding the need for a separate localization key and string concatenation.

---
*PR created automatically by Jules for task [11646478796341009537](https://jules.google.com/task/11646478796341009537) started by @2fst4u*