### PR TITLE
Test suite audit follow-up: missing worker coverage + stronger assertions

### DIFF
--- a/tests/circuit-weather-app.test.js
+++ b/tests/circuit-weather-app.test.js
@@ -505,7 +505,12 @@ describe('CircuitWeatherApp Pure Methods', () => {
             expect(app.ui.sessionSelect.setAttribute).toHaveBeenCalledWith('aria-disabled', 'false');
             expect(app.ui.sessionSelect.removeAttribute).toHaveBeenCalledWith('title');
 
-            expect(app.ui.sessionSelect.appendChild).toHaveBeenCalled();
+            // One <option> built per session, then the batched fragment appended.
+            const optionCreations = documentMock.createElement.mock.calls.filter(
+                ([tag]) => tag === 'option'
+            );
+            expect(optionCreations).toHaveLength(sessions.length);
+            expect(app.ui.sessionSelect.appendChild).toHaveBeenCalledTimes(1);
             expect(app.ui.sessionSelect.innerHTML).toContain('Select session...');
         });
 
@@ -766,7 +771,8 @@ describe('CircuitWeatherApp Pure Methods', () => {
         it('renders the skeleton loader correctly', () => {
             const mockTemplate = createMockElement('forecast-skeleton-template');
             mockTemplate.cloneNode = vi.fn();
-            mockTemplate.content = { cloneNode: vi.fn(() => createMockElement('clonedContent')) };
+            const clonedSkeleton = createMockElement('clonedContent');
+            mockTemplate.content = { cloneNode: vi.fn(() => clonedSkeleton) };
 
             // Temporarily replace document.getElementById to return our mock template
             const originalGetElementById = document.getElementById;
@@ -778,7 +784,8 @@ describe('CircuitWeatherApp Pure Methods', () => {
             expect(app.ui.forecastContent.setAttribute).toHaveBeenCalledWith('aria-busy', 'true');
             expect(app.ui.forecastContent.style.display).toBe('block');
             expect(app.ui.forecastContent.innerHTML).toBe('');
-            expect(app.ui.forecastContent.appendChild).toHaveBeenCalled();
+            // The cloned template content (not some other node) is what's mounted.
+            expect(app.ui.forecastContent.appendChild).toHaveBeenCalledWith(clonedSkeleton);
 
             document.getElementById = originalGetElementById;
         });

--- a/tests/worker-security-content-type.test.js
+++ b/tests/worker-security-content-type.test.js
@@ -93,12 +93,8 @@ describe('Worker Security: Strict Content-Type Validation', () => {
       const req = createRequest('/api/f1/current');
       const res = await worker.fetch(req, global.env, global.ctx);
 
-      // Should fail if loose matching is used (includes 'application/json')
-      // Currently fails (returns 200) because validation is loose.
-      // After fix, should return 502.
-      if (res.status === 200) {
-        throw new Error('FAILED: Accepted application/jsonp');
-      }
+      // A loose `includes('application/json')` check would accept this; the
+      // strict MIME comparison must reject it as an upstream error.
       expect(res.status).toBe(502);
       expect(errorSpy).toHaveBeenCalled();
       errorSpy.mockRestore();
@@ -114,9 +110,6 @@ describe('Worker Security: Strict Content-Type Validation', () => {
         const req = createRequest('/api/f1/current');
         const res = await worker.fetch(req, global.env, global.ctx);
 
-        if (res.status === 200) {
-            throw new Error('FAILED: Accepted application/json-evil');
-        }
         expect(res.status).toBe(502);
         expect(errorSpy).toHaveBeenCalled();
         errorSpy.mockRestore();
@@ -124,9 +117,31 @@ describe('Worker Security: Strict Content-Type Validation', () => {
   });
 
   describe('Radar API Proxy (/api/radar)', () => {
+    it('allows application/json; charset=utf-8 and proxies the upstream payload', async () => {
+      // Distinctive payload so we can tell the proxied data apart from the
+      // empty-radar fallback (which has past: []). Exercises the charset
+      // normalization (split(';')[0]) on the radar handler.
+      const upstream = { radar: { past: [{ time: 111 }], nowcast: [] }, host: 'up' };
+      mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(upstream), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json; charset=utf-8' }
+      }));
+
+      const req = createRequest('/api/radar');
+      const res = await worker.fetch(req, global.env, global.ctx);
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.radar.past).toHaveLength(1);
+      expect(data.radar.past[0].time).toBe(111);
+    });
+
     it('blocks deceptive type: application/json-evil', async () => {
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      mockFetch.mockResolvedValueOnce(new Response('{}', {
+      // Non-empty upstream payload: if validation wrongly accepted the type the
+      // proxied data (past length 1) would surface instead of the empty fallback.
+      const upstream = { radar: { past: [{ time: 999 }], nowcast: [] }, host: 'up' };
+      mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(upstream), {
         status: 200,
         headers: { 'Content-Type': 'application/json-evil' }
       }));
@@ -134,24 +149,10 @@ describe('Worker Security: Strict Content-Type Validation', () => {
       const req = createRequest('/api/radar');
       const res = await worker.fetch(req, global.env, global.ctx);
 
-      // Check if it returned the "empty radar" response which is used for errors
-      // The current implementation returns getEmptyRadarResponse() on error.
-      // So status is 200, but content is empty radar.
+      // Rejected → safe empty-radar fallback, NOT the upstream payload.
       const data = await res.json();
-
-      // If validation fails, it should return empty radar.
-      // If validation passes (bug), it returns the upstream data ({}).
-      // Wait, handleRadarRequest:
-      // if (!contentType || !contentType.includes('application/json')) { return getEmptyRadarResponse(request); }
-      // So if it accepts json-evil, it returns the upstream data.
-
-      // Our mock returns {}, empty radar has radar: { past: [], ... }
-      if (!data.radar) { // Upstream mocked data
-          throw new Error('FAILED: Accepted application/json-evil (returned upstream data)');
-      }
-
-      // Correct behavior: returns empty radar structure
-      expect(data.radar).toBeDefined();
+      expect(data.radar.past).toEqual([]);
+      expect(data.radar.nowcast).toEqual([]);
       expect(errorSpy).toHaveBeenCalled();
       errorSpy.mockRestore();
     });
@@ -214,9 +215,6 @@ describe('Worker Security: Strict Content-Type Validation', () => {
         const req = createRequest('/api/assets/leaflet.js');
         const res = await worker.fetch(req, global.env, global.ctx);
 
-        if (res.status === 200) {
-            throw new Error('FAILED: Accepted text/javascript-evil');
-        }
         expect(res.status).toBe(502);
         expect(errorSpy).toHaveBeenCalled();
         errorSpy.mockRestore();
@@ -245,11 +243,8 @@ describe('Worker Security: Strict Content-Type Validation', () => {
         const req = createRequest('/api/tiles/test.png');
         const res = await worker.fetch(req, global.env, global.ctx);
 
-        // handleTileRequest uses startsWith('image/png')
-        // So image/png-evil passes!
-        if (res.status === 200) {
-            throw new Error('FAILED: Accepted image/png-evil');
-        }
+        // Strict comparison must reject image/png-evil (a startsWith check would
+        // wrongly accept it).
         expect(res.status).toBe(502);
         expect(errorSpy).toHaveBeenCalled();
         errorSpy.mockRestore();

--- a/tests/worker-tile-errors.test.js
+++ b/tests/worker-tile-errors.test.js
@@ -134,7 +134,7 @@ describe('Worker Logic - Tile Errors', () => {
     expect(res.headers.has('Access-Control-Allow-Origin')).toBe(false);
   });
 
-  it('removes CORS headers on error response via cacheAndReturnError when invalid Origin is provided', async () => {
+  it('removes CORS headers on a non-cacheable 500 error response when invalid Origin is provided', async () => {
     mockFetch.mockResolvedValueOnce(new Response('Upstream Server Error', {
       status: 500,
       headers: { 'Content-Type': 'text/html' }

--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -82,6 +82,21 @@ describe("Worker Logic", () => {
       expect(res.status).toBe(404);
     });
 
+    it("allows HEAD requests (not rejected as a disallowed method)", async () => {
+      mockFetch.mockResolvedValue({
+        status: 200,
+        ok: true,
+        text: async () => "ok",
+      });
+
+      const req = createRequest("/api/health", { method: "HEAD" });
+      const res = await worker.fetch(req, global.env, global.ctx);
+
+      // HEAD is explicitly allowed alongside GET/OPTIONS — must not 405.
+      expect(res.status).not.toBe(405);
+      expect(res.status).toBe(200);
+    });
+
     it("blocks hotlinking (invalid Origin/Referer)", async () => {
       const req = new Request("https://circuit-weather.racing/api/health", {
         headers: {},
@@ -157,6 +172,29 @@ describe("Worker Logic", () => {
       const data = await res.json();
       expect(data.error.message).toBe("Upstream API error");
       expect(data.error.status).toBe(404);
+    });
+
+    it("caches an upstream 429 with a longer max-age=300 TTL", async () => {
+      // cacheAndReturnError uses a 300s TTL for 429 (vs 60s otherwise) to back
+      // off harder when the upstream is rate-limiting us.
+      mockFetch.mockResolvedValueOnce(
+        new Response("Too Many Requests", {
+          status: 429,
+          headers: { "Content-Type": "text/plain" },
+        }),
+      );
+
+      const req = createRequest("/api/f1/current");
+      const res = await worker.fetch(req, global.env, global.ctx);
+
+      expect(res.status).toBe(429);
+      expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+      expect(res.headers.get("X-Cache")).toBe("ERROR-CACHED");
+
+      // The error must be written to cache so we don't re-hammer the upstream.
+      expect(mockCache.put).toHaveBeenCalled();
+      const cached = [...cacheStore.values()].at(-1);
+      expect(cached.headers.get("Cache-Control")).toBe("public, max-age=300");
     });
 
     it("sets CORS headers for cache miss when valid Origin is provided", async () => {


### PR DESCRIPTION
Follow-up to the audit work in #690, implementing the recommendations I'd documented but left out of that PR.

## Changes

**Missing worker coverage**
- **HEAD method** — `/api/health` is asserted to respond `200` (not `405`). HEAD is explicitly allowed alongside GET/OPTIONS but had no test.
- **Radar charset normalization** — `application/json; charset=utf-8` is accepted and the upstream payload proxied through, distinguished from the empty-radar fallback. Covers the `split(';')[0]` MIME parsing on the radar handler (the f1/assets handlers had this; radar didn't).
- **`cacheAndReturnError` 429 TTL** — an upstream `429` is cached with the longer `max-age=300` (vs `60` for other errors), asserted on both the client response and the cached copy.

**Stronger / cleaner assertions**
- Radar `json-evil` rejection now asserts the safe empty fallback (`past`/`nowcast` empty) instead of merely that `radar` exists (the fallback *also* has `radar`, so the old check was weak).
- Removed dead `if (status === 200) throw …` guards in the content-type tests — the following `expect()` already fails the test.
- Fixed a mislabeled `worker-tile-errors` title that claimed `cacheAndReturnError` (the tile 5xx path uses `createErrorResponse`).
- Replaced two bare `toHaveBeenCalled()` checks in `circuit-weather-app.test.js` with assertions on *what* was built/mounted: one `<option>` created per session, and the cloned skeleton node is the one appended.

## Result
- `npm test` → 51 files, **816 passing**
- `npm run test:coverage` → thresholds met; `worker.js` branch coverage rose **96.39% → 96.95%**, all-files branches **96.16% → 96.24%**.

https://claude.ai/code/session_01GC3mA6ntUKHgfnYviAs3oc

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC3mA6ntUKHgfnYviAs3oc)_