### PR TITLE
Test suite: extract and cover WindOverlay advection maths

### DIFF
--- a/public/src/map/WindOverlay.js
+++ b/public/src/map/WindOverlay.js
@@ -1,6 +1,6 @@
 import { CONFIG } from '../config.js';
 import { SafeStorage } from '../utils/storage.js';
-import { sampleWindField } from '../utils/wind.js';
+import { sampleWindField, windDisplacement, isWithinField } from '../utils/wind.js';
 
 /**
  * Animated wind overlay: draws flowing particles advected by a gridded wind
@@ -237,18 +237,14 @@ export class WindOverlay {
         const gain = CONFIG.WIND_FIELD_SPEED_GAIN;
         for (const p of this.particles) {
             const { u, v } = sampleWindField(f, p.lat, p.lon);
-            const latRad = p.lat * Math.PI / 180;
-            const dLat = (v / 110.574) * (dt / 3600) * gain;
-            const dLon = (u / (111.320 * Math.cos(latRad))) * (dt / 3600) * gain;
+            const { dLat, dLon } = windDisplacement(p.lat, u, v, dt, gain);
 
             const from = this._project(p.lat, p.lon);
             p.lat += dLat;
             p.lon += dLon;
             p.age += dt;
 
-            if (p.age > CONFIG.WIND_FIELD_PARTICLE_LIFE
-                || p.lat < f.minLat || p.lat > f.maxLat
-                || p.lon < f.minLon || p.lon > f.maxLon) {
+            if (p.age > CONFIG.WIND_FIELD_PARTICLE_LIFE || !isWithinField(p.lat, p.lon, f)) {
                 Object.assign(p, this._spawn(false));
                 continue;
             }

--- a/public/src/utils/wind.js
+++ b/public/src/utils/wind.js
@@ -27,6 +27,31 @@ export function windToVector(speed, direction) {
 }
 
 /**
+ * Per-step geographic displacement (in degrees) for a particle advected by a
+ * wind vector. `u`/`v` are the eastward/northward speed components (km/h),
+ * `dtSeconds` is the elapsed time for the step, and `gain` is a dimensionless
+ * exaggeration factor applied for visual effect. Uses the standard ~110.574 km
+ * per degree of latitude and ~111.320·cos(lat) km per degree of longitude.
+ */
+export function windDisplacement(lat, u, v, dtSeconds, gain) {
+    const latRad = lat * Math.PI / 180;
+    const hours = dtSeconds / 3600;
+    return {
+        dLat: (v / 110.574) * hours * gain,
+        dLon: (u / (111.320 * Math.cos(latRad))) * hours * gain,
+    };
+}
+
+/**
+ * Whether a point lies within a field's geographic bounds (inclusive). Used to
+ * recycle wind particles once they drift outside the sampled region.
+ */
+export function isWithinField(lat, lon, field) {
+    return lat >= field.minLat && lat <= field.maxLat
+        && lon >= field.minLon && lon <= field.maxLon;
+}
+
+/**
  * Bilinearly interpolate the wind vector at (lat, lon) from a gridded field.
  * The field stores u/v as flat row-major arrays (lat ascending, lon ascending).
  * Coordinates outside the field bounds are clamped to the edge.

--- a/tests/wind.test.js
+++ b/tests/wind.test.js
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { getWindDirection, windToVector, sampleWindField } from '../public/src/utils/wind.js';
+import {
+    getWindDirection,
+    windToVector,
+    sampleWindField,
+    windDisplacement,
+    isWithinField,
+} from '../public/src/utils/wind.js';
 
 describe('getWindDirection', () => {
     const cases = [
@@ -79,5 +85,77 @@ describe('sampleWindField', () => {
             rows: 1, cols: 1, u: [7], v: [3],
         };
         expect(sampleWindField(point, 5, 5)).toEqual({ u: 7, v: 3 });
+    });
+});
+
+describe('windDisplacement', () => {
+    // Chosen so a 1-hour step at the equator with gain 1 yields exactly 1° each:
+    // 110.574 km/°lat and 111.320 km/°lon (cos 0 = 1).
+    const U_EQ = 111.320;
+    const V_EQ = 110.574;
+
+    it('moves one degree per hour at the equator for the reference speeds', () => {
+        const { dLat, dLon } = windDisplacement(0, U_EQ, V_EQ, 3600, 1);
+        expect(dLat).toBeCloseTo(1, 6);
+        expect(dLon).toBeCloseTo(1, 6);
+    });
+
+    it('produces no displacement for zero wind', () => {
+        const { dLat, dLon } = windDisplacement(45, 0, 0, 3600, 1);
+        expect(dLat).toBe(0);
+        expect(dLon).toBe(0);
+    });
+
+    it('scales linearly with elapsed time', () => {
+        const half = windDisplacement(0, U_EQ, V_EQ, 1800, 1);
+        expect(half.dLat).toBeCloseTo(0.5, 6);
+        expect(half.dLon).toBeCloseTo(0.5, 6);
+    });
+
+    it('scales linearly with gain', () => {
+        const { dLat, dLon } = windDisplacement(0, U_EQ, V_EQ, 3600, 3);
+        expect(dLat).toBeCloseTo(3, 6);
+        expect(dLon).toBeCloseTo(3, 6);
+    });
+
+    it('stretches longitude by 1/cos(lat) away from the equator', () => {
+        // cos(60°) = 0.5, so the same eastward speed covers twice the longitude.
+        const { dLon } = windDisplacement(60, U_EQ, 0, 3600, 1);
+        expect(dLon).toBeCloseTo(2, 6);
+    });
+
+    it('latitude displacement is independent of latitude', () => {
+        const atEquator = windDisplacement(0, 0, V_EQ, 3600, 1).dLat;
+        const atSixty = windDisplacement(60, 0, V_EQ, 3600, 1).dLat;
+        expect(atSixty).toBeCloseTo(atEquator, 6);
+    });
+
+    it('preserves direction signs (north/east positive, south/west negative)', () => {
+        const north = windDisplacement(0, 0, V_EQ, 3600, 1);
+        expect(north.dLat).toBeGreaterThan(0);
+        const south = windDisplacement(0, 0, -V_EQ, 3600, 1);
+        expect(south.dLat).toBeLessThan(0);
+        const west = windDisplacement(0, -U_EQ, 0, 3600, 1);
+        expect(west.dLon).toBeLessThan(0);
+    });
+});
+
+describe('isWithinField', () => {
+    const field = { minLat: -10, maxLat: 10, minLon: 20, maxLon: 40 };
+
+    it('returns true for an interior point', () => {
+        expect(isWithinField(0, 30, field)).toBe(true);
+    });
+
+    it('is inclusive of the boundary corners', () => {
+        expect(isWithinField(-10, 20, field)).toBe(true);
+        expect(isWithinField(10, 40, field)).toBe(true);
+    });
+
+    it('returns false past each edge', () => {
+        expect(isWithinField(-11, 30, field)).toBe(false); // south of minLat
+        expect(isWithinField(11, 30, field)).toBe(false);  // north of maxLat
+        expect(isWithinField(0, 19, field)).toBe(false);   // west of minLon
+        expect(isWithinField(0, 41, field)).toBe(false);   // east of maxLon
     });
 });


### PR DESCRIPTION
The remaining audit item: `WindOverlay.js` is fully excluded from coverage ("verified in-browser"), which also left its pure geographic maths untested.

This extracts that maths into `utils/wind.js` (which *is* covered) and unit-tests it — no behaviour change to the overlay.

## Changes

**New pure helpers in `utils/wind.js`**
- `windDisplacement(lat, u, v, dtSeconds, gain)` — per-step lat/lon displacement for a particle advected by a wind vector (110.574 km/°lat, 111.320 km/°lon, longitude stretched by 1/cos(lat)).
- `isWithinField(lat, lon, field)` — inclusive in-bounds predicate used to recycle particles that drift outside the sampled region.

**`WindOverlay._frame`** now calls these helpers instead of inlining the advection formula and the four-way bounds check. The extracted `!isWithinField(...)` is logically identical to the previous `lat < minLat || lat > maxLat || lon < minLon || lon > maxLon`.

**10 new tests** (`wind.test.js`): the reference 1°/hour equator case, dt/gain linearity, the 1/cos(lat) longitude stretch, latitude-independence of `dLat`, sign conventions (N/E positive, S/W negative), and boundary inclusivity.

## Result
- `npm test` → 51 files, **836 passing** (`wind.test.js` 14 → 24)
- `npm run test:coverage` → `wind.js` stays at 100%; thresholds met. `WindOverlay.js` remains coverage-excluded but now carries far less untested logic.

https://claude.ai/code/session_01GC3mA6ntUKHgfnYviAs3oc

---
_Generated by [Claude Code](https://claude.ai/code/session_01GC3mA6ntUKHgfnYviAs3oc)_