### PR TITLE
🧪 Spec: Fix flaky test handling in radar-countdown-live

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -24,3 +24,6 @@
 ## 2024-05-25 - Mocking Mapbox Proxy Methods
 **Learning:** In Map-related unit tests (e.g., `WeatherRadar`), the component infers a Mapbox map instance (versus Leaflet) by checking `!this.map.hasLayer`. To test Mapbox-specific logic correctly, mock map objects must explicitly omit the `hasLayer` function. The proxy object returned by `createMapboxLayer` has its own simulated `on`/`off` events and a `redraw` mechanism manipulating Mapbox specific `addSource`/`setTiles` that need dedicated test blocks since they diverge significantly from Leaflet's standard `TileLayer`.
 **Action:** Created dedicated test block for Mapbox proxy methods by passing a mocked map omitting `hasLayer` and explicitly simulated `mockMap.once` callbacks to trigger the registered proxy load events.
+## 2024-05-25 - Fixing synchronous test callback violation
+**Learning:** Fixing a "flaky" `setTimeout` test by removing it entirely and calling a mocked callback synchronously violates the requirement to preserve asynchronous testing intent.
+**Action:** When fixing async event handlers (like `on('load', ...)`), retain the `setTimeout` simulation if `vi.useFakeTimers()` is active, and ensure `vi.advanceTimersByTime` is correctly paired with `await promise` to assert the final state.

--- a/tests/radar-countdown-live.test.js
+++ b/tests/radar-countdown-live.test.js
@@ -246,13 +246,15 @@ describe('WeatherRadar Live Countdown', () => {
             setOpacity: vi.fn(),
             addTo: vi.fn(),
             on: vi.fn((event, cb) => {
-                if (event === 'load') cb();
+                if (event === 'load') setTimeout(cb, 10);
             }),
             off: vi.fn(),
         };
         vi.spyOn(radar, 'getLayer').mockReturnValue(mockLayer);
 
-        await radar.preloadFrame(1);
+        const promise = radar.preloadFrame(1);
+        vi.advanceTimersByTime(10);
+        await promise;
 
         expect(mockLayer.addTo).toHaveBeenCalledWith(mockMap);
         expect(mockLayer.setOpacity).toHaveBeenCalledWith(0);


### PR DESCRIPTION
💡 What: Restored the asynchronous `setTimeout` mock inside the `on('load')` test double in `radar-countdown-live.test.js` and utilized `vi.advanceTimersByTime()` properly to resolve it.
🎯 Why: A previous attempt to fix the flaky test replaced the `setTimeout` with a synchronous callback invocation `if (event === 'load') cb();`. This violates the testing rule to preserve asynchronous testing intent, effectively hiding true asynchronous bugs. Since `vi.useFakeTimers()` is active, advancing the system clock deterministically solves flakiness without changing test semantics.
📈 Maturity Impact: Solidified test intent and compliance without dropping global coverage.

---
*PR created automatically by Jules for task [12988539387456644760](https://jules.google.com/task/12988539387456644760) started by @2fst4u*