### PR TITLE
📚 Archivist: Update /api/assets/* description in API Endpoints table

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -245,3 +245,11 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 
 **Learning:** `AGENTS.md` omitted "Wind Overlay" from its "Core Features" section, even though the feature is fully implemented, documented in `PRIVACY.md`, and is an active feature that persists user preference in `localStorage`.
 **Action:** Added the "Wind Overlay" feature to `AGENTS.md` to ensure a single source of truth for application capabilities.
+## 2026-06-02 - Documentation Drift for Proxied Assets in API Endpoints Table
+
+**Learning:** While `src/worker.js` and `PRIVACY.md` correctly identified that `VENDOR_ASSETS` (handling `/api/assets/*`) proxies both Unpkg and Mapbox CDNs, the "API Endpoints" table in `AGENTS.md` was slightly ambiguous and didn't mention Unpkg or CDNs explicitly.
+**Action:** Updated the "API Endpoints" table in `AGENTS.md` to explicitly state that `/api/assets/*` proxies to Unpkg (Leaflet) and Mapbox CDNs for map library assets, maintaining alignment with `worker.js` and `PRIVACY.md`.
+## 2026-06-02 - Unpkg and Mapbox CDN Proxy Drift
+
+**Learning:** When updating API endpoint documentation, it is critical to reflect exact details from the worker file (e.g., `VENDOR_ASSETS`) such as which specific CDNs (like Unpkg or Mapbox CDNs) are proxied by a wildcard endpoint like `/api/assets/*`. Generic descriptions can mislead human or automated analysis about the architecture.
+**Action:** When updating proxy endpoint documentation in `AGENTS.md`, always cross-reference the exact configurations in `src/worker.js` (like `VENDOR_ASSETS`) and list the actual upstream domains/services involved.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,15 +217,15 @@ mode = "smart"
 
 ### API Endpoints
 
-| Endpoint        | Purpose                                                                                          |
-| --------------- | ------------------------------------------------------------------------------------------------ |
-| `/api/f1/*`     | Proxies to Jolpica F1 API with 1-hour edge caching                                               |
-| `/api/radar`    | Proxies to RainViewer Maps API with 1-minute caching (initializes animation)                     |
-| `/api/tiles/*`  | Proxies to RainViewer tile API with 2-hour edge caching (512px optimized)                        |
-| `/api/track/*`  | Proxies to GitHub for GeoJSON track data with 24-hour caching                                    |
-| `/api/assets/*` | Proxies to Leaflet and Mapbox assets with 1-year immutable caching (strict CSP)                  |
-| `/api/health`   | System status check (connectivity to upstreams, version, env) with 60-second caching             |
-| `/api/config`   | Securely provides client configuration (e.g., Mapbox token) to the frontend with 24-hour caching |
+| Endpoint        | Purpose                                                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------------------------ |
+| `/api/f1/*`     | Proxies to Jolpica F1 API with 1-hour edge caching                                                           |
+| `/api/radar`    | Proxies to RainViewer Maps API with 1-minute caching (initializes animation)                                 |
+| `/api/tiles/*`  | Proxies to RainViewer tile API with 2-hour edge caching (512px optimized)                                    |
+| `/api/track/*`  | Proxies to GitHub for GeoJSON track data with 24-hour caching                                                |
+| `/api/assets/*` | Proxies to Unpkg (Leaflet) and Mapbox CDNs for map library assets with 1-year immutable caching (strict CSP) |
+| `/api/health`   | System status check (connectivity to upstreams, version, env) with 60-second caching                         |
+| `/api/config`   | Securely provides client configuration (e.g., Mapbox token) to the frontend with 24-hour caching             |
 
 ---
 


### PR DESCRIPTION
💡 Problem: The description for `/api/assets/*` in the "API Endpoints" table of `AGENTS.md` was slightly ambiguous, stating it "Proxies to Leaflet and Mapbox assets" without specifying the upstream CDNs, which left it slightly misaligned with `src/worker.js` (which specifies Unpkg and Mapbox CDNs via `VENDOR_ASSETS`) and `PRIVACY.md`.
🎯 Fix: Updated the description in `AGENTS.md` to explicitly state that it proxies to "Unpkg (Leaflet) and Mapbox CDNs for map library assets".
🧪 Verification: Read `src/worker.js` and confirmed the `VENDOR_ASSETS` configuration correctly points to `unpkg.com` and `api.mapbox.com`. Ran `pnpm test` successfully.
🔎 Scope: Only modified documentation in `AGENTS.md`.

---
*PR created automatically by Jules for task [9431858927083167144](https://jules.google.com/task/9431858927083167144) started by @2fst4u*