### PR TITLE
🎨 Palette: Add hover state for sidebar toggle button

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1073,7 +1073,12 @@ body {
     background: transparent;
     color: var(--color-text);
     cursor: pointer;
+    transition: background-color var(--transition-fast);
     flex-shrink: 0;
+}
+
+.sidebar-toggle:hover {
+    background: var(--color-surface-elevated);
 }
 
 .sidebar-toggle svg {


### PR DESCRIPTION
💡 What: Added a missing hover state (`:hover`) background color and transition for the `.sidebar-toggle` button (the mobile/sidebar menu hamburger button).
🎯 Why: Provides tactile, immediate visual feedback that the button is interactive, matching other UI elements (like the theme toggle and mobile menu toggle) and improving micro-UX.
📸 Before/After: Verified via headless Playwright screenshots; hovering over the hamburger button now correctly shifts its background to `--color-surface-elevated` smoothly.
♿ Accessibility: Improves visual affordance for sighted keyboard/mouse users interacting with the main navigation trigger.

---
*PR created automatically by Jules for task [7287680140192532995](https://jules.google.com/task/7287680140192532995) started by @2fst4u*