### PR TITLE
🌍 Globe: Extract hardcoded unit for weather.windDirection

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -1054,7 +1054,7 @@ export class CircuitWeatherApp {
                     <div class="weather-metric">
                         <dt class="weather-label" data-i18n="weather.wind">${escapeHtml(i18n.t('weather.wind'))}</dt>
                         <dd class="weather-value" id="weatherWind">${escapeHtml(wind)} ${escapeHtml(weather.units.wind_speed_10m)}</dd>
-                        <dd class="weather-sub" id="weatherWindDir" title="${escapeHtml(dir)}°" aria-label="${escapeHtml(i18n.t('weather.windDirection', { direction: windInfo.text, degrees: dir }))}">
+                        <dd class="weather-sub" id="weatherWindDir" title="${escapeHtml(dir)}${escapeHtml(weather.units.wind_direction_10m)}" aria-label="${escapeHtml(i18n.t('weather.windDirection', { direction: windInfo.text, degrees: dir }))}">
                             ${escapeHtml(windInfo.text)}
                             <svg class="icon-wind-arrow" style="transform: rotate(${escapeHtml(rotation)}deg); width: 14px; height: 14px;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                 <line x1="12" y1="19" x2="12" y2="5"></line>


### PR DESCRIPTION
💡 **What:** Replaced the hardcoded degree symbol `°` in the `weatherWindDir` tooltip `title` attribute with the dynamic `weather.units.wind_direction_10m` provided by the Open-Meteo API.

🎯 **Why:** Hardcoding the degree symbol bypasses internationalization and ignores the unit context provided by the API. Using the dynamic unit respects potential data formatting changes and aligns the wind direction logic with the adjacent wind speed logic, which already uses `weather.units.wind_speed_10m`.

🌐 **Nuance:** Since the unit is dynamically provided by the weather API response based on the requested format, it does not need to be added to the static translation dictionaries (like `en.js` or `es.js`).

---
*PR created automatically by Jules for task [7983516405249952673](https://jules.google.com/task/7983516405249952673) started by @2fst4u*