### PR TITLE
Improve F1 schedule resilience: aggressive caching + clearer error message

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -142,7 +142,8 @@ export class CircuitWeatherApp {
 
         } catch (error) {
             console.error('Initialization failed:', error);
-            this.renderError(i18n.t('errors.initFailed'));
+            const isScheduleError = error.message?.startsWith('F1_SCHEDULE_UNAVAILABLE');
+            this.renderError(i18n.t(isScheduleError ? 'errors.scheduleUnavailable' : 'errors.initFailed'));
         } finally {
             this.showLoading(false);
         }

--- a/public/src/api/F1API.js
+++ b/public/src/api/F1API.js
@@ -5,7 +5,7 @@ export class F1API {
     constructor() {
         this.cache = new Map();
         this.LOCAL_STORAGE_KEY = 'f1_schedule_cache';
-        this.CACHE_DURATION_MS = 24 * 60 * 60 * 1000; // 24 hours
+        this.CACHE_DURATION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
     }
 
     async getSchedule() {
@@ -33,7 +33,7 @@ export class F1API {
         const response = await fetch(`${CONFIG.f1ApiBase}/current.json`, {
             signal: AbortSignal.timeout(5000)
         });
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        if (!response.ok) throw new Error(`F1_SCHEDULE_UNAVAILABLE: HTTP ${response.status}`);
 
         const data = await response.json();
         const races = data.MRData?.RaceTable?.Races || [];

--- a/public/src/i18n/locales/de.js
+++ b/public/src/i18n/locales/de.js
@@ -118,6 +118,7 @@ export const de = {
     retryConnection: "Verbindung erneut versuchen",
     retryingConnection: "Verbindung wird erneut versucht",
     initFailed: "Initialisierung der Anwendung fehlgeschlagen.",
+    scheduleUnavailable: "Der F1-Rennkalender konnte nicht geladen werden. Die Datenquelle ist möglicherweise vorübergehend nicht verfügbar – bitte versuchen Sie es später erneut.",
     sessionError: "Session-Fehler",
     sessionLoadFailed:
       "Session-Prognose oder Radar konnte nicht geladen werden.",

--- a/public/src/i18n/locales/en.js
+++ b/public/src/i18n/locales/en.js
@@ -115,6 +115,7 @@ export const en = {
     retryConnection: "Retry connection",
     retryingConnection: "Retrying connection",
     initFailed: "Failed to initialize application.",
+    scheduleUnavailable: "The F1 race schedule could not be loaded. The data source may be temporarily unavailable — please try again later.",
     sessionError: "Session Error",
     sessionLoadFailed: "Failed to load session forecast or radar data.",
   },

--- a/public/src/i18n/locales/es.js
+++ b/public/src/i18n/locales/es.js
@@ -116,6 +116,7 @@ export const es = {
     retryConnection: "Reintentar conexion",
     retryingConnection: "Reintentando conexion",
     initFailed: "No se pudo iniciar la aplicacion.",
+    scheduleUnavailable: "No se pudo cargar el calendario de F1. La fuente de datos puede estar temporalmente no disponible. Por favor, inténtelo más tarde.",
     sessionError: "Error de sesion",
     sessionLoadFailed: "No se pudo cargar el pronostico o radar de la sesion.",
   },

--- a/public/src/i18n/locales/fr.js
+++ b/public/src/i18n/locales/fr.js
@@ -117,6 +117,7 @@ export const fr = {
     retryConnection: "Reessayer la connexion",
     retryingConnection: "Nouvelle tentative de connexion",
     initFailed: "Echec de l'initialisation de l'application.",
+    scheduleUnavailable: "Le calendrier F1 n'a pas pu être chargé. La source de données est peut-être temporairement indisponible. Veuillez réessayer plus tard.",
     sessionError: "Erreur de session",
     sessionLoadFailed:
       "Echec du chargement des previsions ou du radar de session.",

--- a/public/src/i18n/locales/hu.js
+++ b/public/src/i18n/locales/hu.js
@@ -118,6 +118,7 @@ export const hu = {
     retryConnection: "Csatlakozás újrapróbálása",
     retryingConnection: "Csatlakozás újrapróbálása folyamatban",
     initFailed: "Nem sikerült inicializálni az alkalmazást.",
+    scheduleUnavailable: "Az F1-es versenynaptár nem tölthető be. Az adatforrás ideiglenesen nem érhető el – kérjük, próbálja újra később.",
     sessionError: "Esemény hiba",
     sessionLoadFailed:
       "Nem sikerült betölteni az esemény előrejelzését vagy a radart.",

--- a/public/src/i18n/locales/it.js
+++ b/public/src/i18n/locales/it.js
@@ -116,6 +116,7 @@ export const it = {
     retryConnection: "Riprova connessione",
     retryingConnection: "Nuovo tentativo di connessione",
     initFailed: "Inizializzazione applicazione non riuscita.",
+    scheduleUnavailable: "Impossibile caricare il calendario F1. La fonte dei dati potrebbe essere temporaneamente non disponibile. Riprova più tardi.",
     sessionError: "Errore sessione",
     sessionLoadFailed:
       "Impossibile caricare previsioni o radar della sessione.",

--- a/public/src/i18n/locales/ja.js
+++ b/public/src/i18n/locales/ja.js
@@ -116,6 +116,7 @@ export const ja = {
     retryConnection: "接続を再試行",
     retryingConnection: "接続を再試行中",
     initFailed: "アプリの初期化に失敗しました。",
+    scheduleUnavailable: "F1レーススケジュールを読み込めませんでした。データソースが一時的に利用できない可能性があります。後でもう一度お試しください。",
     sessionError: "セッションエラー",
     sessionLoadFailed:
       "セッションの予報またはレーダーの読み込みに失敗しました。",

--- a/public/src/i18n/locales/nl.js
+++ b/public/src/i18n/locales/nl.js
@@ -116,6 +116,7 @@ export const nl = {
     retryConnection: "Probeer verbinding opnieuw",
     retryingConnection: "Verbinding opnieuw proberen",
     initFailed: "Applicatie initialiseren mislukt.",
+    scheduleUnavailable: "De F1-racekalender kon niet worden geladen. De gegevensbron is mogelijk tijdelijk niet beschikbaar. Probeer het later opnieuw.",
     sessionError: "Sessiefout",
     sessionLoadFailed: "Sessie voorspelling of radargegevens laden mislukt.",
   },

--- a/public/src/i18n/locales/pt-BR.js
+++ b/public/src/i18n/locales/pt-BR.js
@@ -117,6 +117,7 @@ export const ptBR = {
     retryConnection: "Tentar novamente ligacao",
     retryingConnection: "A tentar novamente ligacao",
     initFailed: "Falha ao iniciar a aplicacao.",
+    scheduleUnavailable: "Não foi possível carregar o calendário de F1. A fonte de dados pode estar temporariamente indisponível. Por favor, tente novamente mais tarde.",
     sessionError: "Erro de sessao",
     sessionLoadFailed: "Falha ao carregar previsao ou radar da sessao.",
   },

--- a/public/src/i18n/locales/zh-CN.js
+++ b/public/src/i18n/locales/zh-CN.js
@@ -108,6 +108,7 @@ export const zhCN = {
     retryConnection: "重试连接",
     retryingConnection: "正在重试连接",
     initFailed: "应用初始化失败。",
+    scheduleUnavailable: "无法加载F1赛程。数据源可能暂时不可用，请稍后重试。",
     sessionError: "赛段错误",
     sessionLoadFailed: "加载赛段预报或雷达失败。",
   },

--- a/src/worker.js
+++ b/src/worker.js
@@ -367,7 +367,7 @@ async function handleApiRequest(request, env, ctx, url) {
     // We store '*' in cache as a fallback, but we always override on delivery
     const cacheHeaders = new Headers({
       'Content-Type': 'application/json',
-      'Cache-Control': 'public, max-age=3600',
+      'Cache-Control': 'public, max-age=86400',
       'X-Cache': 'MISS',
       'X-Upstream-Status': status.toString(),
       'Access-Control-Allow-Origin': '*', // Store permissive, override on delivery

--- a/tests/f1-api.test.js
+++ b/tests/f1-api.test.js
@@ -188,7 +188,7 @@ describe('F1API', () => {
         it('fetches fresh data if localStorage cache is expired', async () => {
             const mockRaces = [{ round: '4', raceName: 'Fresh GP' }];
             SafeStorage.getItem.mockReturnValueOnce(JSON.stringify({
-                timestamp: Date.now() - (48 * 60 * 60 * 1000), // 48 hours ago
+                timestamp: Date.now() - (8 * 24 * 60 * 60 * 1000), // 8 days ago (past 7-day TTL)
                 races: [{ round: '3', raceName: 'Expired GP' }]
             }));
             mockFetch.mockResolvedValueOnce({


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Worker cache**: F1 API responses cached 1h → 24h (schedule is essentially static per season)
- **Client cache**: localStorage TTL 24h → 7 days for the same reason
- **Error message**: Generic "Failed to initialize application." replaced with "The F1 race schedule could not be loaded. The data source may be temporarily unavailable — please try again later." when the schedule fetch specifically fails
- **Error tagging**: F1API now throws a tagged error (`F1_SCHEDULE_UNAVAILABLE: ...`) so the app can distinguish a data-source outage from other init failures

## Context

The app is currently failing on all deployments because `api.jolpi.ca` (the Jolpica F1 API) is returning HTTP 403. This PR doesn't fix the upstream outage, but it:
1. Means returning visitors with a cached schedule won't see the error at all (7-day localStorage cache)
2. Reduces load on Jolpica once it recovers (24h worker-side cache vs 1h previously)
3. Shows a meaningful error to users who have no cached data, instead of the generic "Failed to initialize application."

## Test plan

- [ ] Confirm returning visitors (schedule in localStorage < 7 days old) see the app normally when Jolpica is down
- [ ] Confirm first-time visitors see "The F1 race schedule could not be loaded..." instead of "Failed to initialize application."
- [ ] Confirm `X-Cache: MISS` responses from `/api/f1/current.json` now carry `Cache-Control: public, max-age=86400`
- [ ] Confirm normal init still shows generic error if a non-schedule step fails

https://claude.ai/code/session_014fsyJStQeYrUZbt6chYWpz
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014fsyJStQeYrUZbt6chYWpz)_