### PR TITLE
📚 Archivist: Update f1_schedule_cache duration in privacy policy

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -253,3 +253,8 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 
 **Learning:** When updating API endpoint documentation, it is critical to reflect exact details from the worker file (e.g., `VENDOR_ASSETS`) such as which specific CDNs (like Unpkg or Mapbox CDNs) are proxied by a wildcard endpoint like `/api/assets/*`. Generic descriptions can mislead human or automated analysis about the architecture.
 **Action:** When updating proxy endpoint documentation in `AGENTS.md`, always cross-reference the exact configurations in `src/worker.js` (like `VENDOR_ASSETS`) and list the actual upstream domains/services involved.
+
+## 2026-06-02 - Documentation Drift for Local Storage Cache Durations
+
+**Learning:** While the keys for `localStorage` and `SafeStorage` (like `f1_schedule_cache`) were documented in `PRIVACY.md`, the *duration* of the cache (e.g. 7 days vs 24 hours) had drifted from the actual implementation in the codebase (`CACHE_DURATION_MS`). Developers update constants in code but forget to update the corresponding privacy policy entries.
+**Action:** Always cross-reference the documented cache durations in `PRIVACY.md` against their actual TTL/expiry constants in the source code (e.g. `src/worker.js` or `public/src/api/*.js`).

--- a/public/PRIVACY.md
+++ b/public/PRIVACY.md
@@ -91,7 +91,7 @@ The application stores preference settings locally in your browser to remember y
 - **unit:** `metric` or `imperial`
 - **language:** your selected locale (e.g., `en-NZ`, `fr`)
 - **windOverlay:** `true` or `false` (remembers if the wind animation layer is enabled)
-- **f1_schedule_cache:** caches the F1 schedule data (24-hour cache)
+- **f1_schedule_cache:** caches the F1 schedule data (7-day cache)
 
 This data resides solely on your device and is never transmitted to our servers.
 

--- a/public/privacy/PRIVACY.de.md
+++ b/public/privacy/PRIVACY.de.md
@@ -88,7 +88,7 @@ Lokale Einstellungen im Browser:
 - **unit:** `metric` oder `imperial`
 - **language:** Ihre ausgewählte Sprache (z. B. `de`, `en-US`)
 - **windOverlay:** `true` oder `false` (speichert, ob die Windanimations-Ebene aktiviert ist)
-- **f1_schedule_cache:** speichert die F1-Kalenderdaten zwischen (24-Stunden-Cache)
+- **f1_schedule_cache:** speichert die F1-Kalenderdaten zwischen (7-Tage-Cache)
 
 ## Open Source
 

--- a/public/privacy/PRIVACY.en-GB.md
+++ b/public/privacy/PRIVACY.en-GB.md
@@ -88,7 +88,7 @@ Preference settings are stored locally in your browser:
 - **unit:** `metric` or `imperial`
 - **language:** your selected locale (e.g., `en-GB`, `fr`)
 - **windOverlay:** `true` or `false` (remembers if the wind animation layer is enabled)
-- **f1_schedule_cache:** caches the F1 schedule data (24-hour cache)
+- **f1_schedule_cache:** caches the F1 schedule data (7-day cache)
 
 This data remains on your device and is not sent to our servers.
 

--- a/public/privacy/PRIVACY.en-NZ.md
+++ b/public/privacy/PRIVACY.en-NZ.md
@@ -88,7 +88,7 @@ Preference settings are stored locally in your browser:
 - **unit:** `metric` or `imperial`
 - **language:** your selected locale (e.g., `en-NZ`, `fr`)
 - **windOverlay:** `true` or `false` (remembers if the wind animation layer is enabled)
-- **f1_schedule_cache:** caches the F1 schedule data (24-hour cache)
+- **f1_schedule_cache:** caches the F1 schedule data (7-day cache)
 
 This data remains on your device and is not sent to our servers.
 

--- a/public/privacy/PRIVACY.en-US.md
+++ b/public/privacy/PRIVACY.en-US.md
@@ -88,7 +88,7 @@ Preference settings are stored locally in your browser:
 - **unit:** `metric` or `imperial`
 - **language:** your selected locale (e.g., `en-US`, `fr`)
 - **windOverlay:** `true` or `false` (remembers if the wind animation layer is enabled)
-- **f1_schedule_cache:** caches the F1 schedule data (24-hour cache)
+- **f1_schedule_cache:** caches the F1 schedule data (7-day cache)
 
 This data remains on your device and is not sent to our servers.
 

--- a/public/privacy/PRIVACY.es.md
+++ b/public/privacy/PRIVACY.es.md
@@ -88,7 +88,7 @@ El navegador guarda preferencias locales:
 - **unit:** `metric` o `imperial`
 - **language:** su idioma seleccionado (ej. `es`, `en-US`)
 - **windOverlay:** `true` o `false` (recuerda si la capa de animación de viento está habilitada)
-- **f1_schedule_cache:** guarda en caché los datos del calendario de F1 (caché de 24 horas)
+- **f1_schedule_cache:** guarda en caché los datos del calendario de F1 (caché de 7 días)
 
 Estos datos permanecen en tu dispositivo.
 

--- a/public/privacy/PRIVACY.fr.md
+++ b/public/privacy/PRIVACY.fr.md
@@ -88,7 +88,7 @@ Les preferences sont stockees localement dans le navigateur :
 - **unit:** `metric` ou `imperial`
 - **language:** votre langue sélectionnée (ex: `fr`, `en-US`)
 - **windOverlay:** `true` ou `false` (mémorise si le calque d'animation du vent est activé)
-- **f1_schedule_cache:** met en cache les données du calendrier de la F1 (cache de 24 heures)
+- **f1_schedule_cache:** met en cache les données du calendrier de la F1 (cache de 7 jours)
 
 ## Open source
 

--- a/public/privacy/PRIVACY.hu.md
+++ b/public/privacy/PRIVACY.hu.md
@@ -88,7 +88,7 @@ A beállításokat a böngészője helyileg tárolja:
 - **unit (mértékegység):** `metric` (metrikus) vagy `imperial` (birodalmi)
 - **language (nyelv):** a kiválasztott nyelv (pl. `hu`, `en-US`)
 - **windOverlay:** `true` vagy `false` (megjegyzi, hogy a szélanimációs réteg be van-e kapcsolva)
-- **f1_schedule_cache:** gyorsítótárazza az F1 naptáradatokat (24 órás gyorsítótár)
+- **f1_schedule_cache:** gyorsítótárazza az F1 naptáradatokat (7 napos gyorsítótár)
 
 Ezek az adatok az Ön eszközén maradnak, és nem kerülnek elküldésre a szervereinkre.
 

--- a/public/privacy/PRIVACY.it.md
+++ b/public/privacy/PRIVACY.it.md
@@ -88,7 +88,7 @@ Preferenze salvate localmente nel browser:
 - **unit:** `metric` o `imperial`
 - **language:** la lingua selezionata (es. `it`, `en-US`)
 - **windOverlay:** `true` o `false` (ricorda se il livello di animazione del vento è abilitato)
-- **f1_schedule_cache:** memorizza i dati del calendario F1 (cache di 24 ore)
+- **f1_schedule_cache:** memorizza i dati del calendario F1 (cache di 7 giorni)
 
 ## Open source
 

--- a/public/privacy/PRIVACY.ja.md
+++ b/public/privacy/PRIVACY.ja.md
@@ -88,7 +88,7 @@ Circuit Weather は、Formula 1 サーキット向けのリアルタイム天気
 - **unit:** `metric` または `imperial`
 - **language:** 選択した言語 (例: `ja`, `en-US`)
 - **windOverlay:** `true` または `false` (風のアニメーションレイヤーが有効かどうかを記憶します)
-- **f1_schedule_cache:** F1のスケジュールデータをキャッシュします (24時間キャッシュ)
+- **f1_schedule_cache:** F1のスケジュールデータをキャッシュします (7日間キャッシュ)
 
 これらのデータは端末内にのみ保存されます。
 

--- a/public/privacy/PRIVACY.pt-BR.md
+++ b/public/privacy/PRIVACY.pt-BR.md
@@ -88,7 +88,7 @@ Preferencias guardadas localmente no navegador:
 - **unit:** `metric` ou `imperial`
 - **language:** o seu idioma selecionado (ex. `pt-BR`, `en-US`)
 - **windOverlay:** `true` ou `false` (lembra se a camada de animação de vento está habilitada)
-- **f1_schedule_cache:** faz cache dos dados do calendário da F1 (cache de 24 horas)
+- **f1_schedule_cache:** faz cache dos dados do calendário da F1 (cache de 7 dias)
 
 ## Open source
 

--- a/public/privacy/PRIVACY.zh-CN.md
+++ b/public/privacy/PRIVACY.zh-CN.md
@@ -88,7 +88,7 @@ Circuit Weather 是一个开源网站应用，用于显示 Formula 1 赛道的�
 - **unit:** `metric` 或 `imperial`
 - **language:** 您选择的语言 (如 `zh-CN`, `en-US`)
 - **windOverlay:** `true` 或 `false` (记住风场动画图层是否启用)
-- **f1_schedule_cache:** 缓存 F1 赛程数据 (24小时缓存)
+- **f1_schedule_cache:** 缓存 F1 赛程数据 (7天缓存)
 
 这些数据仅保存在你的设备上。
 


### PR DESCRIPTION
💡 Problem
The `f1_schedule_cache` entry in `PRIVACY.md` (and all translated variants) stated a "24-hour cache" duration. However, the actual implementation in `public/src/api/F1API.js` uses `this.CACHE_DURATION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days`. This discrepancy created a privacy policy drift where users were incorrectly informed about how long schedule data persists locally.

🎯 Fix
Updated `public/PRIVACY.md` and all 11 localized variants in `public/privacy/PRIVACY.*.md` to accurately state that `f1_schedule_cache` uses a 7-day cache. Also logged the learning in `.jules/archivist.md` to prevent future drift.

🧪 Verification
- Grepped the `public/src/` folder to verify `SafeStorage` and `localStorage` usage.
- Cross-checked the `CACHE_DURATION_MS` value in `F1API.js`.
- Wrote a Node script to replace the strings consistently.
- Visually checked `git diff` to ensure no markdown or structural breakage.
- Ran `npx prettier --write` to assert formatting.
- Ran the full `pnpm test` suite (889 tests) to verify no application changes broke.

🔎 Scope
This PR contains ONLY documentation changes. Application code remains untouched.

---
*PR created automatically by Jules for task [16203581980583094780](https://jules.google.com/task/16203581980583094780) started by @2fst4u*