### PR TITLE
🧹 Sweep: un-export unused OPENF1_CIRCUIT_MAP

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -19,3 +19,8 @@ This file tracks critical learnings from Sweep's cleanup operations.
 
 **Learning:** I encountered a `console.log` statement in `src/worker.js` that was dynamically sampling logs (e.g., `if (bucket >= 4 || Math.random() < 0.05)`) and wrapped in an environment check (`if (env.ENVIRONMENT !== 'production')`). This was initially misidentified as a leftover debug artifact. However, the comments and structure explicitly indicated it was a functional observability mechanism for development/staging environments, not dead code.
 **Action:** When evaluating `console.log` statements for removal, carefully analyze the surrounding context. If a log is explicitly conditional based on environments (like non-production), samples requests, or serves a clear monitoring purpose, it is an intentional operational tool, not an orphaned debug artifact. Do not remove such functional observability mechanisms.
+
+## 2024-06-03 - Temporary Artifacts Policy
+
+**Learning:** The project's "Test & Verification File Policy" strictly prohibits committing any temporary scratchpad or verification scripts (e.g., `test_script.js`) created during an investigation.
+**Action:** When acting as 'Sweep', ensure that any ad-hoc scripts used to verify an unused asset are deleted (e.g., `rm test_script.js`) before requesting a code review or submitting the final PR, as leaving them behind contradicts the fundamental goal of reducing codebase bloat.

--- a/public/src/api/openf1.js
+++ b/public/src/api/openf1.js
@@ -13,7 +13,7 @@
 // Abu Dhabi is "Yas Marina Circuit", Brazil is "Interlagos"), so the numeric key is
 // the reliable join. Values map to the Ergast circuitId used by CIRCUIT_MAP for the
 // track GeoJSON overlays.
-export const OPENF1_CIRCUIT_MAP = {
+const OPENF1_CIRCUIT_MAP = {
     63: 'bahrain',
     149: 'jeddah',
     10: 'albert_park',


### PR DESCRIPTION
**💡 What:** Removed the `export` keyword from `OPENF1_CIRCUIT_MAP` in `public/src/api/openf1.js`.

**🎯 Why:** `OPENF1_CIRCUIT_MAP` is only used internally within `openf1.js` (to map OpenF1 circuit keys to Ergast circuit IDs). Removing the `export` keyword safely reduces the module's public surface area and cleans up a declared but never imported variable.

**🔬 Verification:** Verified that `OPENF1_CIRCUIT_MAP` is completely unused externally by running a global text search (`grep -r "OPENF1_CIRCUIT_MAP" --exclude="openf1.js" public/src/ tests/ src/`) and using the `knip` unused file/export analyzer, both of which confirmed there are zero external references. Also verified test suite passing (`pnpm test`).

---
*PR created automatically by Jules for task [10047512517772936429](https://jules.google.com/task/10047512517772936429) started by @2fst4u*