### PR TITLE
🧹 Sweep: remove unused `mockCallback2` variable in tests

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -24,3 +24,7 @@ This file tracks critical learnings from Sweep's cleanup operations.
 
 **Learning:** The project's "Test & Verification File Policy" strictly prohibits committing any temporary scratchpad or verification scripts (e.g., `test_script.js`) created during an investigation.
 **Action:** When acting as 'Sweep', ensure that any ad-hoc scripts used to verify an unused asset are deleted (e.g., `rm test_script.js`) before requesting a code review or submitting the final PR, as leaving them behind contradicts the fundamental goal of reducing codebase bloat.
+
+## 2024-10-27 - Knip False Positives for Dynamically Loaded Scripts
+**Learning:** Static analysis tools like `knip` may incorrectly flag dynamically loaded entry-point scripts (e.g., `public/src/main.js`, `public/sw.js`, `public/theme.js`) as unused files because they are loaded directly via HTML script tags rather than standard ES module imports.
+**Action:** Always verify if a seemingly "unused" file reported by `knip` or similar tools is referenced in HTML files (e.g., `index.html`, `manifest.json`) before considering it for removal.

--- a/tests/weather-radar.test.js
+++ b/tests/weather-radar.test.js
@@ -207,7 +207,6 @@ describe('createMapboxLayer Proxy Methods', () => {
 
         // Test off behavior
         layerProxy.off('load');
-        const mockCallback2 = vi.fn();
 
         // Mock map.once again to reset
         mockMap.once.mockClear();


### PR DESCRIPTION
🧹 Sweep: remove unused `mockCallback2` variable in tests

💡 What: Removed `const mockCallback2 = vi.fn();` from `tests/weather-radar.test.js`.
🎯 Why: It was declared but never read or utilized anywhere in the test suite. Removing it reduces cognitive overhead and codebase clutter.
🔬 Verification: Ran `grep -rn "mockCallback2" tests` to verify the variable was only declared once and never used, and ran `pnpm test` to confirm there are no regressions.

---
*PR created automatically by Jules for task [10403077178191438228](https://jules.google.com/task/10403077178191438228) started by @2fst4u*