### PR TITLE
📚 Archivist: Clarify Jolpica F1 cache duration

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -245,10 +245,12 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 
 **Learning:** `AGENTS.md` omitted "Wind Overlay" from its "Core Features" section, even though the feature is fully implemented, documented in `PRIVACY.md`, and is an active feature that persists user preference in `localStorage`.
 **Action:** Added the "Wind Overlay" feature to `AGENTS.md` to ensure a single source of truth for application capabilities.
+
 ## 2026-06-02 - Documentation Drift for Proxied Assets in API Endpoints Table
 
 **Learning:** While `src/worker.js` and `PRIVACY.md` correctly identified that `VENDOR_ASSETS` (handling `/api/assets/*`) proxies both Unpkg and Mapbox CDNs, the "API Endpoints" table in `AGENTS.md` was slightly ambiguous and didn't mention Unpkg or CDNs explicitly.
 **Action:** Updated the "API Endpoints" table in `AGENTS.md` to explicitly state that `/api/assets/*` proxies to Unpkg (Leaflet) and Mapbox CDNs for map library assets, maintaining alignment with `worker.js` and `PRIVACY.md`.
+
 ## 2026-06-02 - Unpkg and Mapbox CDN Proxy Drift
 
 **Learning:** When updating API endpoint documentation, it is critical to reflect exact details from the worker file (e.g., `VENDOR_ASSETS`) such as which specific CDNs (like Unpkg or Mapbox CDNs) are proxied by a wildcard endpoint like `/api/assets/*`. Generic descriptions can mislead human or automated analysis about the architecture.
@@ -256,5 +258,10 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 
 ## 2026-06-02 - Documentation Drift for Local Storage Cache Durations
 
-**Learning:** While the keys for `localStorage` and `SafeStorage` (like `f1_schedule_cache`) were documented in `PRIVACY.md`, the *duration* of the cache (e.g. 7 days vs 24 hours) had drifted from the actual implementation in the codebase (`CACHE_DURATION_MS`). Developers update constants in code but forget to update the corresponding privacy policy entries.
+**Learning:** While the keys for `localStorage` and `SafeStorage` (like `f1_schedule_cache`) were documented in `PRIVACY.md`, the _duration_ of the cache (e.g. 7 days vs 24 hours) had drifted from the actual implementation in the codebase (`CACHE_DURATION_MS`). Developers update constants in code but forget to update the corresponding privacy policy entries.
 **Action:** Always cross-reference the documented cache durations in `PRIVACY.md` against their actual TTL/expiry constants in the source code (e.g. `src/worker.js` or `public/src/api/*.js`).
+
+## 2026-06-03 - Edge Cache TTL Drift
+
+**Learning:** When edge caching configuration (`Cache-Control: max-age`) is updated in Cloudflare Worker code (e.g., in `src/worker.js`), the corresponding documentation for the cache TTL (such as in `AGENTS.md` and `PRIVACY.md`) frequently drifts. Developers often update the implementation but forget to synchronize the publicly documented retention claims.
+**Action:** Whenever a `max-age` value is modified or reviewed in the edge worker logic, always search for the service name (e.g., "Jolpica F1", "track layout") in `AGENTS.md` and `PRIVACY.md` to ensure the documented cache duration is strictly accurate and reflects the code's reality.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,7 +219,7 @@ mode = "smart"
 
 | Endpoint        | Purpose                                                                                                      |
 | --------------- | ------------------------------------------------------------------------------------------------------------ |
-| `/api/f1/*`     | Proxies to Jolpica F1 API with 1-hour edge caching                                                           |
+| `/api/f1/*`     | Proxies to Jolpica F1 API with 24-hour edge caching                                                          |
 | `/api/radar`    | Proxies to RainViewer Maps API with 1-minute caching (initializes animation)                                 |
 | `/api/tiles/*`  | Proxies to RainViewer tile API with 2-hour edge caching (512px optimized)                                    |
 | `/api/track/*`  | Proxies to GitHub for GeoJSON track data with 24-hour caching                                                |

--- a/public/PRIVACY.md
+++ b/public/PRIVACY.md
@@ -85,7 +85,7 @@ To improve performance and reliability, we load standard libraries and assets fr
 
 The following services provide the raw data that we process and cache via Cloudflare. Your device does not connect to them directly for data API calls.
 
-- **Jolpica F1:** Historical and current F1 schedule data (1-hour edge cache).
+- **Jolpica F1:** Historical and current F1 schedule data (24-hour edge cache).
 - **GitHub (bacinger/f1-circuits):** Stores static track layout files (GeoJSON) (24-hour edge cache).
 - **RainViewer:** Weather radar tiles (2-hour edge cache) and metadata (1-minute cache).
 - **Leaflet (via Unpkg):** Map interaction library assets (proxied for security, 1-year immutable cache).

--- a/src/worker.js
+++ b/src/worker.js
@@ -363,7 +363,7 @@ async function handleApiRequest(request, env, ctx, url) {
     // Bolt Optimization: Stream response instead of buffering text
     const [cacheBody, clientBody] = upstreamResponse.body.tee();
 
-    // Create cacheable response (1 hour)
+    // Create cacheable response (24 hours)
     // We store '*' in cache as a fallback, but we always override on delivery
     const cacheHeaders = new Headers({
       'Content-Type': 'application/json',


### PR DESCRIPTION
💡 Problem: The documentation in `AGENTS.md`, `public/PRIVACY.md`, and an inline comment in `src/worker.js` incorrectly stated that the Jolpica F1 API responses were cached for 1 hour at the edge. The actual implementation in `src/worker.js` uses a `max-age=86400` (24 hours).

🎯 Fix: Updated the documented edge cache duration from "1 hour" to "24 hours" in `AGENTS.md` and `public/PRIVACY.md`, and corrected the inline comment in `src/worker.js`. Added an entry to `.jules/archivist.md` to record the TTL drift failure mode.

🧪 Verification: Checked the `Cache-Control` header for `/api/f1/*` endpoints in `src/worker.js` to verify the actual TTL is 86400 (24 hours). Ran `pnpm test` to ensure no functionality was affected.

🔎 Scope: This PR contains ONLY documentation changes and a comment correction. No application logic was modified.

---
*PR created automatically by Jules for task [3782200435983286239](https://jules.google.com/task/3782200435983286239) started by @2fst4u*