### PR TITLE
🌍 Globe: Extract hardcoded round label in dropdown

### DIFF
--- a/.jules/globe.md
+++ b/.jules/globe.md
@@ -10,3 +10,6 @@
 ## 2024-05-24 - Dynamic Unit Suffixes over Hardcoded Symbols
 **Learning:** Do not hardcode unit symbols like the degree symbol (`°`) in the UI components (like the hourly weather timeline). The API response provides proper dynamic localized and unit-aware strings (e.g., `weather.units.temperature_2m`).
 **Action:** Always prefer the dynamic API-provided unit string variables over injecting explicit unit characters to respect user preference and locale correctly.
+## 2024-06-06 - Extracting Hardcoded Concatenations
+**Learning:** Hardcoded strings in UI components often disguise themselves as simple concatenations (e.g. `` `R${race.round}: ${race.name} (${dateStr})` ``). When extracting these, it's crucial to map the raw JavaScript variable names to proper i18n placeholders (like `{{round}}`) to ensure correct interpolation across locales.
+**Action:** Always replace string template literals containing UI text with `i18n.t()` calls passing a context object that maps the local variables to the placeholder keys defined in the dictionary.

--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -492,7 +492,7 @@ export class CircuitWeatherApp {
                 nextFound = true;
             }
 
-            const label = `R${race.round}: ${race.name} (${dateStr})`;
+            const label = i18n.t('controls.roundLabel', { round: race.round, name: race.name, date: dateStr });
             option.textContent = formatStatusLabel(label, status, isNext);
 
             fragment.appendChild(option);

--- a/public/src/i18n/locales/de.js
+++ b/public/src/i18n/locales/de.js
@@ -25,6 +25,7 @@ export const de = {
     f1: "Formel 1",
     series: "Serie",
     round: "Runde",
+    roundLabel: "R{{round}}: {{name}} ({{date}})",
     session: "Session",
     units: "Einheiten",
     selectRound: "Runde auswahlen...",
@@ -33,7 +34,8 @@ export const de = {
     metricLabel: "Kilometer",
     imperialLabel: "Meilen",
     windOverlay: "Wind-Overlay",
-    windZoomDisabled: "Wind-Overlay bei Zoom {{zoom}} pausiert — einzoomen um Wind zu sehen",
+    windZoomDisabled:
+      "Wind-Overlay bei Zoom {{zoom}} pausiert — einzoomen um Wind zu sehen",
   },
   forecast: {
     heading: "Session-Prognose",
@@ -119,9 +121,12 @@ export const de = {
     retryConnection: "Verbindung erneut versuchen",
     retryingConnection: "Verbindung wird erneut versucht",
     initFailed: "Initialisierung der Anwendung fehlgeschlagen.",
-    scheduleUnavailable: "Der F1-Rennkalender konnte nicht geladen werden. Die Datenquelle (api.jolpi.ca) ist derzeit nicht verfügbar – bitte versuchen Sie es später erneut.",
-    scheduleAllUnavailable: "Der F1-Rennkalender konnte nicht geladen werden. Beide Datenquellen (api.jolpi.ca und api.openf1.org) sind derzeit nicht verfügbar – bitte versuchen Sie es später erneut.",
-    usingFallbackSource: "Primäre Datenquelle (api.jolpi.ca) nicht verfügbar – Daten werden von der Backup-Quelle (api.openf1.org) angezeigt.",
+    scheduleUnavailable:
+      "Der F1-Rennkalender konnte nicht geladen werden. Die Datenquelle (api.jolpi.ca) ist derzeit nicht verfügbar – bitte versuchen Sie es später erneut.",
+    scheduleAllUnavailable:
+      "Der F1-Rennkalender konnte nicht geladen werden. Beide Datenquellen (api.jolpi.ca und api.openf1.org) sind derzeit nicht verfügbar – bitte versuchen Sie es später erneut.",
+    usingFallbackSource:
+      "Primäre Datenquelle (api.jolpi.ca) nicht verfügbar – Daten werden von der Backup-Quelle (api.openf1.org) angezeigt.",
     sessionError: "Session-Fehler",
     sessionLoadFailed:
       "Session-Prognose oder Radar konnte nicht geladen werden.",

--- a/public/src/i18n/locales/en.js
+++ b/public/src/i18n/locales/en.js
@@ -25,6 +25,7 @@ export const en = {
     f1: "Formula 1",
     series: "Series",
     round: "Round",
+    roundLabel: "R{{round}}: {{name}} ({{date}})",
     session: "Session",
     units: "Units",
     selectRound: "Select round...",
@@ -33,7 +34,8 @@ export const en = {
     metricLabel: "Kilometres",
     imperialLabel: "Miles",
     windOverlay: "Wind overlay",
-    windZoomDisabled: "Wind overlay paused at zoom {{zoom}} — zoom in to see wind",
+    windZoomDisabled:
+      "Wind overlay paused at zoom {{zoom}} — zoom in to see wind",
   },
   forecast: {
     heading: "Session Forecast",
@@ -116,9 +118,12 @@ export const en = {
     retryConnection: "Retry connection",
     retryingConnection: "Retrying connection",
     initFailed: "Failed to initialize application.",
-    scheduleUnavailable: "The F1 race schedule could not be loaded. The data source (api.jolpi.ca) is currently unavailable — please try again later.",
-    scheduleAllUnavailable: "The F1 race schedule could not be loaded. Both data sources (api.jolpi.ca and api.openf1.org) appear to be unavailable — please try again later.",
-    usingFallbackSource: "Primary schedule source (api.jolpi.ca) is unavailable — showing data from the backup source (api.openf1.org).",
+    scheduleUnavailable:
+      "The F1 race schedule could not be loaded. The data source (api.jolpi.ca) is currently unavailable — please try again later.",
+    scheduleAllUnavailable:
+      "The F1 race schedule could not be loaded. Both data sources (api.jolpi.ca and api.openf1.org) appear to be unavailable — please try again later.",
+    usingFallbackSource:
+      "Primary schedule source (api.jolpi.ca) is unavailable — showing data from the backup source (api.openf1.org).",
     sessionError: "Session Error",
     sessionLoadFailed: "Failed to load session forecast or radar data.",
   },

--- a/public/src/i18n/locales/es.js
+++ b/public/src/i18n/locales/es.js
@@ -25,6 +25,7 @@ export const es = {
     f1: "Formula 1",
     series: "Serie",
     round: "Ronda",
+    roundLabel: "R{{round}}: {{name}} ({{date}})",
     session: "Sesion",
     units: "Unidades",
     selectRound: "Selecciona ronda...",
@@ -33,7 +34,8 @@ export const es = {
     metricLabel: "Kilometros",
     imperialLabel: "Millas",
     windOverlay: "Capa de viento",
-    windZoomDisabled: "Capa de viento pausada en nivel {{zoom}} — acerque para ver el viento",
+    windZoomDisabled:
+      "Capa de viento pausada en nivel {{zoom}} — acerque para ver el viento",
   },
   forecast: {
     heading: "Pronostico de sesion",
@@ -117,9 +119,12 @@ export const es = {
     retryConnection: "Reintentar conexion",
     retryingConnection: "Reintentando conexion",
     initFailed: "No se pudo iniciar la aplicacion.",
-    scheduleUnavailable: "No se pudo cargar el calendario de F1. La fuente de datos (api.jolpi.ca) no está disponible actualmente. Por favor, inténtelo más tarde.",
-    scheduleAllUnavailable: "No se pudo cargar el calendario de F1. Ambas fuentes de datos (api.jolpi.ca y api.openf1.org) parecen no estar disponibles. Por favor, inténtelo más tarde.",
-    usingFallbackSource: "La fuente principal (api.jolpi.ca) no está disponible: mostrando datos de la fuente de respaldo (api.openf1.org).",
+    scheduleUnavailable:
+      "No se pudo cargar el calendario de F1. La fuente de datos (api.jolpi.ca) no está disponible actualmente. Por favor, inténtelo más tarde.",
+    scheduleAllUnavailable:
+      "No se pudo cargar el calendario de F1. Ambas fuentes de datos (api.jolpi.ca y api.openf1.org) parecen no estar disponibles. Por favor, inténtelo más tarde.",
+    usingFallbackSource:
+      "La fuente principal (api.jolpi.ca) no está disponible: mostrando datos de la fuente de respaldo (api.openf1.org).",
     sessionError: "Error de sesion",
     sessionLoadFailed: "No se pudo cargar el pronostico o radar de la sesion.",
   },

--- a/public/src/i18n/locales/fr.js
+++ b/public/src/i18n/locales/fr.js
@@ -25,6 +25,7 @@ export const fr = {
     f1: "Formule 1",
     series: "Serie",
     round: "Manche",
+    roundLabel: "R{{round}}: {{name}} ({{date}})",
     session: "Session",
     units: "Unites",
     selectRound: "Selectionner une manche...",
@@ -33,7 +34,8 @@ export const fr = {
     metricLabel: "Kilometres",
     imperialLabel: "Miles",
     windOverlay: "Calque de vent",
-    windZoomDisabled: "Calque de vent pause au zoom {{zoom}} — zoomez pour voir le vent",
+    windZoomDisabled:
+      "Calque de vent pause au zoom {{zoom}} — zoomez pour voir le vent",
   },
   forecast: {
     heading: "Previsions de session",
@@ -118,9 +120,12 @@ export const fr = {
     retryConnection: "Reessayer la connexion",
     retryingConnection: "Nouvelle tentative de connexion",
     initFailed: "Echec de l'initialisation de l'application.",
-    scheduleUnavailable: "Le calendrier F1 n'a pas pu être chargé. La source de données (api.jolpi.ca) est actuellement indisponible. Veuillez réessayer plus tard.",
-    scheduleAllUnavailable: "Le calendrier F1 n'a pas pu être chargé. Les deux sources de données (api.jolpi.ca et api.openf1.org) semblent indisponibles. Veuillez réessayer plus tard.",
-    usingFallbackSource: "La source principale (api.jolpi.ca) est indisponible — affichage des données de la source de secours (api.openf1.org).",
+    scheduleUnavailable:
+      "Le calendrier F1 n'a pas pu être chargé. La source de données (api.jolpi.ca) est actuellement indisponible. Veuillez réessayer plus tard.",
+    scheduleAllUnavailable:
+      "Le calendrier F1 n'a pas pu être chargé. Les deux sources de données (api.jolpi.ca et api.openf1.org) semblent indisponibles. Veuillez réessayer plus tard.",
+    usingFallbackSource:
+      "La source principale (api.jolpi.ca) est indisponible — affichage des données de la source de secours (api.openf1.org).",
     sessionError: "Erreur de session",
     sessionLoadFailed:
       "Echec du chargement des previsions ou du radar de session.",

--- a/public/src/i18n/locales/hu.js
+++ b/public/src/i18n/locales/hu.js
@@ -25,6 +25,7 @@ export const hu = {
     f1: "Forma-1",
     series: "Sorozat",
     round: "Forduló",
+    roundLabel: "R{{round}}: {{name}} ({{date}})",
     session: "Esemény",
     units: "Mértékegységek",
     selectRound: "Forduló kiválasztása...",
@@ -33,7 +34,8 @@ export const hu = {
     metricLabel: "Kilométer",
     imperialLabel: "Mérföld",
     windOverlay: "Szélréteg",
-    windZoomDisabled: "Szélréteg {{zoom}} nagyítási szinten szüneteltetve — közelíts a szél megtekintéséhez",
+    windZoomDisabled:
+      "Szélréteg {{zoom}} nagyítási szinten szüneteltetve — közelíts a szél megtekintéséhez",
   },
   forecast: {
     heading: "Esemény előrejelzése",
@@ -119,9 +121,12 @@ export const hu = {
     retryConnection: "Csatlakozás újrapróbálása",
     retryingConnection: "Csatlakozás újrapróbálása folyamatban",
     initFailed: "Nem sikerült inicializálni az alkalmazást.",
-    scheduleUnavailable: "Az F1-es versenynaptár nem tölthető be. Az adatforrás (api.jolpi.ca) jelenleg nem érhető el – kérjük, próbálja újra később.",
-    scheduleAllUnavailable: "Az F1-es versenynaptár nem tölthető be. Mindkét adatforrás (api.jolpi.ca és api.openf1.org) jelenleg nem érhető el – kérjük, próbálja újra később.",
-    usingFallbackSource: "Az elsődleges adatforrás (api.jolpi.ca) nem érhető el – az adatok a tartalék forrásból (api.openf1.org) származnak.",
+    scheduleUnavailable:
+      "Az F1-es versenynaptár nem tölthető be. Az adatforrás (api.jolpi.ca) jelenleg nem érhető el – kérjük, próbálja újra később.",
+    scheduleAllUnavailable:
+      "Az F1-es versenynaptár nem tölthető be. Mindkét adatforrás (api.jolpi.ca és api.openf1.org) jelenleg nem érhető el – kérjük, próbálja újra később.",
+    usingFallbackSource:
+      "Az elsődleges adatforrás (api.jolpi.ca) nem érhető el – az adatok a tartalék forrásból (api.openf1.org) származnak.",
     sessionError: "Esemény hiba",
     sessionLoadFailed:
       "Nem sikerült betölteni az esemény előrejelzését vagy a radart.",

--- a/public/src/i18n/locales/it.js
+++ b/public/src/i18n/locales/it.js
@@ -25,6 +25,7 @@ export const it = {
     f1: "Formula 1",
     series: "Serie",
     round: "Round",
+    roundLabel: "R{{round}}: {{name}} ({{date}})",
     session: "Sessione",
     units: "Unita",
     selectRound: "Seleziona round...",
@@ -33,7 +34,8 @@ export const it = {
     metricLabel: "Chilometri",
     imperialLabel: "Miglia",
     windOverlay: "Overlay vento",
-    windZoomDisabled: "Overlay vento in pausa allo zoom {{zoom}} — avvicina per vedere il vento",
+    windZoomDisabled:
+      "Overlay vento in pausa allo zoom {{zoom}} — avvicina per vedere il vento",
   },
   forecast: {
     heading: "Previsioni sessione",
@@ -117,9 +119,12 @@ export const it = {
     retryConnection: "Riprova connessione",
     retryingConnection: "Nuovo tentativo di connessione",
     initFailed: "Inizializzazione applicazione non riuscita.",
-    scheduleUnavailable: "Impossibile caricare il calendario F1. La fonte dei dati (api.jolpi.ca) è attualmente non disponibile. Riprova più tardi.",
-    scheduleAllUnavailable: "Impossibile caricare il calendario F1. Entrambe le fonti di dati (api.jolpi.ca e api.openf1.org) risultano non disponibili. Riprova più tardi.",
-    usingFallbackSource: "La fonte primaria (api.jolpi.ca) non è disponibile: dati mostrati dalla fonte di backup (api.openf1.org).",
+    scheduleUnavailable:
+      "Impossibile caricare il calendario F1. La fonte dei dati (api.jolpi.ca) è attualmente non disponibile. Riprova più tardi.",
+    scheduleAllUnavailable:
+      "Impossibile caricare il calendario F1. Entrambe le fonti di dati (api.jolpi.ca e api.openf1.org) risultano non disponibili. Riprova più tardi.",
+    usingFallbackSource:
+      "La fonte primaria (api.jolpi.ca) non è disponibile: dati mostrati dalla fonte di backup (api.openf1.org).",
     sessionError: "Errore sessione",
     sessionLoadFailed:
       "Impossibile caricare previsioni o radar della sessione.",

--- a/public/src/i18n/locales/ja.js
+++ b/public/src/i18n/locales/ja.js
@@ -25,6 +25,7 @@ export const ja = {
     f1: "F1",
     series: "シリーズ",
     round: "ラウンド",
+    roundLabel: "R{{round}}: {{name}} ({{date}})",
     session: "セッション",
     units: "単位",
     selectRound: "ラウンドを選択...",
@@ -33,7 +34,8 @@ export const ja = {
     metricLabel: "キロメートル",
     imperialLabel: "マイル",
     windOverlay: "風の表示",
-    windZoomDisabled: "ズーム{{zoom}}で風表示を停止中 — 拡大すると風が表示されます",
+    windZoomDisabled:
+      "ズーム{{zoom}}で風表示を停止中 — 拡大すると風が表示されます",
   },
   forecast: {
     heading: "セッション予報",
@@ -117,9 +119,12 @@ export const ja = {
     retryConnection: "接続を再試行",
     retryingConnection: "接続を再試行中",
     initFailed: "アプリの初期化に失敗しました。",
-    scheduleUnavailable: "F1レーススケジュールを読み込めませんでした。データソース (api.jolpi.ca) が現在利用できません。後でもう一度お試しください。",
-    scheduleAllUnavailable: "F1レーススケジュールを読み込めませんでした。両方のデータソース (api.jolpi.ca および api.openf1.org) が現在利用できないようです。後でもう一度お試しください。",
-    usingFallbackSource: "プライマリのデータソース (api.jolpi.ca) が利用できないため、バックアップソース (api.openf1.org) のデータを表示しています。",
+    scheduleUnavailable:
+      "F1レーススケジュールを読み込めませんでした。データソース (api.jolpi.ca) が現在利用できません。後でもう一度お試しください。",
+    scheduleAllUnavailable:
+      "F1レーススケジュールを読み込めませんでした。両方のデータソース (api.jolpi.ca および api.openf1.org) が現在利用できないようです。後でもう一度お試しください。",
+    usingFallbackSource:
+      "プライマリのデータソース (api.jolpi.ca) が利用できないため、バックアップソース (api.openf1.org) のデータを表示しています。",
     sessionError: "セッションエラー",
     sessionLoadFailed:
       "セッションの予報またはレーダーの読み込みに失敗しました。",

--- a/public/src/i18n/locales/nl.js
+++ b/public/src/i18n/locales/nl.js
@@ -25,6 +25,7 @@ export const nl = {
     f1: "Formule 1",
     series: "Serie",
     round: "Ronde",
+    roundLabel: "R{{round}}: {{name}} ({{date}})",
     session: "Sessie",
     units: "Eenheden",
     selectRound: "Selecteer ronde...",
@@ -33,7 +34,8 @@ export const nl = {
     metricLabel: "Kilometers",
     imperialLabel: "Mijlen",
     windOverlay: "Wind overlay",
-    windZoomDisabled: "Wind overlay gepauzeerd op zoom {{zoom}} — zoom in om wind te zien",
+    windZoomDisabled:
+      "Wind overlay gepauzeerd op zoom {{zoom}} — zoom in om wind te zien",
   },
   forecast: {
     heading: "Sessie voorspelling",
@@ -117,9 +119,12 @@ export const nl = {
     retryConnection: "Probeer verbinding opnieuw",
     retryingConnection: "Verbinding opnieuw proberen",
     initFailed: "Applicatie initialiseren mislukt.",
-    scheduleUnavailable: "De F1-racekalender kon niet worden geladen. De gegevensbron (api.jolpi.ca) is momenteel niet beschikbaar. Probeer het later opnieuw.",
-    scheduleAllUnavailable: "De F1-racekalender kon niet worden geladen. Beide gegevensbronnen (api.jolpi.ca en api.openf1.org) lijken niet beschikbaar. Probeer het later opnieuw.",
-    usingFallbackSource: "Primaire gegevensbron (api.jolpi.ca) niet beschikbaar — gegevens worden getoond vanaf de back-upbron (api.openf1.org).",
+    scheduleUnavailable:
+      "De F1-racekalender kon niet worden geladen. De gegevensbron (api.jolpi.ca) is momenteel niet beschikbaar. Probeer het later opnieuw.",
+    scheduleAllUnavailable:
+      "De F1-racekalender kon niet worden geladen. Beide gegevensbronnen (api.jolpi.ca en api.openf1.org) lijken niet beschikbaar. Probeer het later opnieuw.",
+    usingFallbackSource:
+      "Primaire gegevensbron (api.jolpi.ca) niet beschikbaar — gegevens worden getoond vanaf de back-upbron (api.openf1.org).",
     sessionError: "Sessiefout",
     sessionLoadFailed: "Sessie voorspelling of radargegevens laden mislukt.",
   },

--- a/public/src/i18n/locales/pt-BR.js
+++ b/public/src/i18n/locales/pt-BR.js
@@ -25,6 +25,7 @@ export const ptBR = {
     f1: "Formula 1",
     series: "Serie",
     round: "Ronda",
+    roundLabel: "R{{round}}: {{name}} ({{date}})",
     session: "Sessao",
     units: "Unidades",
     selectRound: "Selecionar ronda...",
@@ -33,7 +34,8 @@ export const ptBR = {
     metricLabel: "Quilometros",
     imperialLabel: "Milhas",
     windOverlay: "Camada de vento",
-    windZoomDisabled: "Camada de vento pausada no nivel {{zoom}} — aproxime para ver o vento",
+    windZoomDisabled:
+      "Camada de vento pausada no nivel {{zoom}} — aproxime para ver o vento",
   },
   forecast: {
     heading: "Previsao da sessao",
@@ -118,9 +120,12 @@ export const ptBR = {
     retryConnection: "Tentar novamente ligacao",
     retryingConnection: "A tentar novamente ligacao",
     initFailed: "Falha ao iniciar a aplicacao.",
-    scheduleUnavailable: "Não foi possível carregar o calendário de F1. A fonte de dados (api.jolpi.ca) está indisponível no momento. Por favor, tente novamente mais tarde.",
-    scheduleAllUnavailable: "Não foi possível carregar o calendário de F1. Ambas as fontes de dados (api.jolpi.ca e api.openf1.org) parecem indisponíveis. Por favor, tente novamente mais tarde.",
-    usingFallbackSource: "A fonte primária (api.jolpi.ca) está indisponível — exibindo dados da fonte de backup (api.openf1.org).",
+    scheduleUnavailable:
+      "Não foi possível carregar o calendário de F1. A fonte de dados (api.jolpi.ca) está indisponível no momento. Por favor, tente novamente mais tarde.",
+    scheduleAllUnavailable:
+      "Não foi possível carregar o calendário de F1. Ambas as fontes de dados (api.jolpi.ca e api.openf1.org) parecem indisponíveis. Por favor, tente novamente mais tarde.",
+    usingFallbackSource:
+      "A fonte primária (api.jolpi.ca) está indisponível — exibindo dados da fonte de backup (api.openf1.org).",
     sessionError: "Erro de sessao",
     sessionLoadFailed: "Falha ao carregar previsao ou radar da sessao.",
   },

--- a/public/src/i18n/locales/zh-CN.js
+++ b/public/src/i18n/locales/zh-CN.js
@@ -22,6 +22,7 @@ export const zhCN = {
     f1: "F1",
     series: "系列赛",
     round: "分站",
+    roundLabel: "R{{round}}: {{name}} ({{date}})",
     session: "赛段",
     units: "单位",
     selectRound: "选择分站...",
@@ -109,9 +110,12 @@ export const zhCN = {
     retryConnection: "重试连接",
     retryingConnection: "正在重试连接",
     initFailed: "应用初始化失败。",
-    scheduleUnavailable: "无法加载F1赛程。数据源 (api.jolpi.ca) 目前不可用，请稍后重试。",
-    scheduleAllUnavailable: "无法加载F1赛程。两个数据源 (api.jolpi.ca 和 api.openf1.org) 目前均不可用，请稍后重试。",
-    usingFallbackSource: "主数据源 (api.jolpi.ca) 不可用 — 正在显示备用数据源 (api.openf1.org) 的数据。",
+    scheduleUnavailable:
+      "无法加载F1赛程。数据源 (api.jolpi.ca) 目前不可用，请稍后重试。",
+    scheduleAllUnavailable:
+      "无法加载F1赛程。两个数据源 (api.jolpi.ca 和 api.openf1.org) 目前均不可用，请稍后重试。",
+    usingFallbackSource:
+      "主数据源 (api.jolpi.ca) 不可用 — 正在显示备用数据源 (api.openf1.org) 的数据。",
     sessionError: "赛段错误",
     sessionLoadFailed: "加载赛段预报或雷达失败。",
   },


### PR DESCRIPTION
🌍 Globe: Extract hardcoded round label in dropdown

💡 What: Extracted the hardcoded `R${round}: ${name} (${date})` string from the round selection dropdown and replaced it with a proper localized `i18n.t` call using a new `controls.roundLabel` key. The new key was added to `en.js` and programmatically inserted into all other supported locale dictionaries.
🎯 Why: The string was previously hardcoded in `CircuitWeatherApp.js` using JavaScript template literals, which bypassed the localization system completely. Extracting it allows the prefix and structure to be properly translated or adapted to local conventions by future translators (e.g., "Manche X" in French instead of "RX").

---
*PR created automatically by Jules for task [7032059297818964941](https://jules.google.com/task/7032059297818964941) started by @2fst4u*