### PR TITLE
📚 Archivist: Update AGENTS.md with OpenF1 data source

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -265,3 +265,8 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 
 **Learning:** When edge caching configuration (`Cache-Control: max-age`) is updated in Cloudflare Worker code (e.g., in `src/worker.js`), the corresponding documentation for the cache TTL (such as in `AGENTS.md` and `PRIVACY.md`) frequently drifts. Developers often update the implementation but forget to synchronize the publicly documented retention claims.
 **Action:** Whenever a `max-age` value is modified or reviewed in the edge worker logic, always search for the service name (e.g., "Jolpica F1", "track layout") in `AGENTS.md` and `PRIVACY.md` to ensure the documented cache duration is strictly accurate and reflects the code's reality.
+
+## 2026-06-07 - Fixing Third-Party Data Source Omission
+
+**Learning:** `AGENTS.md` omitted "OpenF1" from its "Third-Party Services" table, even though it is used as a fallback data source for F1 schedules. It must be documented that OpenF1 is accessed directly (Client-side) because it blocks requests from datacenter IP ranges (Cloudflare Workers).
+**Action:** Added the "OpenF1" data source to the `AGENTS.md` Third-Party Services table to ensure architectural claims are exhaustive.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Circuit Weather is a real-time F1 race circuit weather radar application. It dis
 | Service         | Purpose                                                          | Connection           |
 | --------------- | ---------------------------------------------------------------- | -------------------- |
 | Jolpica F1 API  | Race schedule data (1-hour cache)                                | Proxied (Cached)     |
+| OpenF1          | Fallback race schedule data                                      | Direct (Client-side) |
 | RainViewer      | Weather radar tiles (2-hour cache) and metadata (1-minute cache) | Proxied (Cached)     |
 | Open-Meteo      | Weather forecasts                                                | Direct (Client-side) |
 | Mapbox API      | Primary map basemap tiles and rendering                          | Direct (Client-side) |


### PR DESCRIPTION
💡 Problem: The third-party services table in `AGENTS.md` omitted "OpenF1", a service used as a fallback data source for F1 schedules when Jolpica fails or blocks requests. Furthermore, it did not document that this connection is direct (client-side) because OpenF1 blocks datacenter IPs (like Cloudflare Workers).

🎯 Fix: Added `OpenF1` to the Third-Party Services table in `AGENTS.md` to ensure completeness, explicitly noting its `Direct (Client-side)` connection type. Appended a journal entry to `.jules/archivist.md` capturing this architectural constraint. Formatted the changes with Prettier.

🧪 Verification: Checked `AGENTS.md` with `git diff`. Ran the full test suite (`pnpm test`) to ensure no regressions. Tests passed cleanly.

🔎 Scope: This PR contains ONLY documentation changes and a journal update. Application logic and configurations are untouched.

---
*PR created automatically by Jules for task [185127153287815228](https://jules.google.com/task/185127153287815228) started by @2fst4u*