### PR TITLE
🔭 Scout: Add dir="ltr" to root HTML element for improved text direction semantics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <!-- Scout: Changed lang attribute to match New Zealand English locale configuration (og:locale is en_NZ), ensuring search engines correctly target the content for regional variations. -->
-<html lang="en-NZ">
+<!-- Scout: Added explicit dir="ltr" to help search engines correctly interpret the document's text directionality alongside the locale. -->
+<html lang="en-NZ" dir="ltr">
 
 <head>
     <meta charset="UTF-8">


### PR DESCRIPTION
🔭 Scout: Add `dir="ltr"` to root HTML element for improved text direction semantics

**💡 What:** Injected the `dir="ltr"` attribute into the root `<html>` tag in `public/index.html`, along with an HTML comment explaining its SEO value.
**🎯 Why:** While text direction defaults to left-to-right (ltr), explicitly declaring the document direction alongside the locale (`lang="en-NZ"`) is an HTML best practice. It helps search engines, crawlers, and accessibility tools correctly and unambiguously interpret the document's text directionality.
**📊 Value:** Improves document parsing and structural semantic context for internationalized codebases and search engine indexing.
**🔬 Measurement:** Verify the `<html>` tag in the DOM contains both `lang="en-NZ"` and `dir="ltr"` attributes.

---
*PR created automatically by Jules for task [17650109313421233694](https://jules.google.com/task/17650109313421233694) started by @2fst4u*