### PR TITLE
🌍 Globe: Extract translation for relative time hour string

### DIFF
--- a/public/src/api/WeatherClient.js
+++ b/public/src/api/WeatherClient.js
@@ -235,8 +235,8 @@ export class WeatherClient {
         const roundedDiff = Math.round(diffHours);
 
         if (roundedDiff === 0) return i18n.t('radar.sessionStart');
-        if (roundedDiff < 0) return `${roundedDiff}h`;
-        return `+${roundedDiff}h`;
+        if (roundedDiff < 0) return `${roundedDiff}${i18n.t('countdown.hourShort')}`;
+        return `+${roundedDiff}${i18n.t('countdown.hourShort')}`;
     }
 
     getAccessibleRelativeTime(timestamp, sessionTime) {


### PR DESCRIPTION
💡 What: Extracted the hardcoded "h" string used for relative time labels (e.g., "-2h", "+1h") in `WeatherClient.js` to use the localized `countdown.hourShort` translation key.
🎯 Why: The previous state used string concatenation with a hardcoded English abbreviation ("h"). Using the localization dictionary ensures the unit suffix respects the user's selected language.
🌐 Nuance: Reused an existing, semantically identical translation key (`countdown.hourShort`) to avoid creating unnecessary duplicates while fixing the hardcoded string in the logic.

---
*PR created automatically by Jules for task [16582613278256271802](https://jules.google.com/task/16582613278256271802) started by @2fst4u*