### PR TITLE
📚 Archivist: Fix Jolpica F1 API cache duration claim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Circuit Weather is a real-time F1 race circuit weather radar application. It dis
 
 | Service         | Purpose                                                          | Connection           |
 | --------------- | ---------------------------------------------------------------- | -------------------- |
-| Jolpica F1 API  | Race schedule data (1-hour cache)                                | Proxied (Cached)     |
+| Jolpica F1 API  | Race schedule data (24-hour cache)                               | Proxied (Cached)     |
 | OpenF1          | Fallback race schedule data                                      | Direct (Client-side) |
 | RainViewer      | Weather radar tiles (2-hour cache) and metadata (1-minute cache) | Proxied (Cached)     |
 | Open-Meteo      | Weather forecasts                                                | Direct (Client-side) |


### PR DESCRIPTION
💡 Problem: `AGENTS.md` incorrectly claimed that the Jolpica F1 API has a 1-hour cache duration in the `Third-Party Services` table, which contradicted the actual implementation in `src/worker.js` (which uses a `max-age=86400` caching header, equating to 24 hours).
🎯 Fix: Updated the caching duration of `Jolpica F1 API` from `1-hour cache` to `24-hour cache` under the `Third-Party Services` section in `AGENTS.md`.
🔬 Verification: Verified the changes via `git diff` and validated that the update aligns precisely with the logic in `src/worker.js` (line 297: `Cache-Control: 'public, max-age=86400'`). Also verified by successfully passing all tests locally.
🔎 Scope: Only modified `AGENTS.md`. No application code or workflows were altered.

---
*PR created automatically by Jules for task [8636696942071401736](https://jules.google.com/task/8636696942071401736) started by @2fst4u*