### PR TITLE
📚 Archivist: Update OpenF1 architecture and credits in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The application is built with vanilla HTML, CSS, and native ES modules, keeping 
 
 The frontend is organised into small, maintainable modules located in `public/src/`. It uses native browser support for ES modules (`import`/`export`), which means there is **no build step** required. The files are served directly as-is, making the development workflow extremely simple.
 
-External API and asset requests (Jolpica F1, RainViewer, GitHub for track layouts, Unpkg for Leaflet assets, and Mapbox CDN for Mapbox GL JS assets) are proxied through a **Cloudflare Worker** to cache data at the edge, enforce strict Content Security Policy (CSP), and protect user privacy. Weather forecasts are fetched directly from Open-Meteo by the client to ensure reliability. Optimised **512px tile caching** is used to reduce request volume by 75% compared to standard implementations.
+External API and asset requests (Jolpica F1, RainViewer, GitHub for track layouts, Unpkg for Leaflet assets, and Mapbox CDN for Mapbox GL JS assets) are proxied through a **Cloudflare Worker** to cache data at the edge, enforce strict Content Security Policy (CSP), and protect user privacy. Weather forecasts are fetched directly from Open-Meteo by the client to ensure reliability, and fallback F1 schedule data is fetched directly from OpenF1 by the client to bypass datacenter IP blocks. Optimised **512px tile caching** is used to reduce request volume by 75% compared to standard implementations.
 
 The primary map tiles and rendering are provided by Mapbox. When falling back to Leaflet, map tiles are provided by Carto (based on OpenStreetMap data), ensuring a clean look that works well with the weather overlays.
 
@@ -42,6 +42,7 @@ The primary map tiles and rendering are provided by Mapbox. When falling back to
 Huge thanks to the free APIs and data sources that make this possible:
 
 - **[Jolpica F1](https://jolpi.ca/)** for the race data.
+- **[OpenF1](https://openf1.org/)** for the fallback race data.
 - **[RainViewer](https://www.rainviewer.com/)** for the weather radar.
 - **[Open-Meteo](https://open-meteo.com/)** for the weather forecasts.
 - **[Mapbox](https://www.mapbox.com/)** for the primary map rendering and tiles.


### PR DESCRIPTION
💡 Problem: The OpenF1 API fallback was not documented in the 'How it works' architecture summary, and it was missing from the 'Credits' section, leading to incomplete documentation of data sources.
🎯 Fix: Updated `README.md` to explicitly state that fallback F1 schedule data is fetched directly from OpenF1 by the client to bypass datacenter IP blocks, and added OpenF1 to the Credits list.
🧪 Verification: Checked `src/worker.js` and `public/src/api/openf1.js` against the updated text, verified with `cat` and `git diff`, and ensured formatting with Prettier. Tests pass.
🔎 Scope: ONLY documentation changes were made in `README.md`.

---
*PR created automatically by Jules for task [163872334499571767](https://jules.google.com/task/163872334499571767) started by @2fst4u*