### PR TITLE
🔭 Scout: Upgrade data source notice to semantic aside tag

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -65,3 +65,8 @@
 ## 2025-02-14 - Semantic List Upgrades
 **Learning:** Upgrading loosely grouped generic `<div>` wrappers into semantic HTML lists (`<dl>`, `<dt>`, `<dd>`) can break visual layout depending on global browser defaults and parent CSS rules for list elements, as they often introduce default margins/paddings.
 **Action:** When converting elements to `<dl>` or `<dd>` for SEO/a11y improvements without changing stylesheets, immediately apply inline CSS resets (e.g., `margin: 0`, `padding: 0`, `display: flex`) to strictly preserve the visual design constraints mandated by the SEO prompt guidelines.
+
+## 2025-05-24 - Semantic aside tags for secondary notices
+
+**Learning:** Upgrading generic fallback warning messages (like a `data-source-notice` `<div>`) to semantic `<aside>` tags correctly signals to search engines that the warning is supplementary content and not part of the primary page outline, improving indexation of the core content.
+**Action:** Always scan for persistent or fallback warning containers and replace generic `div`s with `<aside>`, taking care to ensure CSS continues to target class names (`.data-source-notice`) rather than the raw element tags so styling isn't broken.

--- a/public/index.html
+++ b/public/index.html
@@ -263,7 +263,8 @@
 
             <!-- Scout: Upgraded generic div to semantic footer for better structure -->
             <!-- Shown only when the schedule is served from the OpenF1 fallback source -->
-            <div class="data-source-notice" id="dataSourceNotice" role="status" hidden>
+            <!-- Scout: Upgraded generic div to semantic aside for the data source notice to explicitly signal to search engines that this warning message is secondary, supplementary content to the main document outline. -->
+            <aside class="data-source-notice" id="dataSourceNotice" role="status" hidden>
                 <svg class="icon-warning" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor"
                     stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
@@ -271,7 +272,7 @@
                     <line x1="12" y1="17" x2="12.01" y2="17"></line>
                 </svg>
                 <span data-i18n="errors.usingFallbackSource">Primary schedule source unavailable — showing data from a backup source.</span>
-            </div>
+            </aside>
 
             <footer class="sidebar-footer">
                 <div class="language-selector">


### PR DESCRIPTION
💡 **What:** Upgraded the generic `<div>` wrapper for the fallback data source notice (`#dataSourceNotice`) in `public/index.html` to a semantic `<aside>` element.

🎯 **Why:** To explicitly signal to search engine crawlers that this warning message is secondary, supplementary content to the main document outline, rather than generic textual content.

📊 **Value:** Prevents search engines from mistakenly elevating the temporary/fallback data source warning as primary page content in their indexing and snippets, keeping focus on the core circuit weather application content.

🔬 **Measurement:** Open the browser DevTools (Elements panel) and inspect the `#dataSourceNotice` element to verify it is an `<aside>` tag and retains its styling correctly. Validated via `pnpm test` that Vitest DOM structure tests were unaffected.

---
*PR created automatically by Jules for task [1184686702176699580](https://jules.google.com/task/1184686702176699580) started by @2fst4u*