### PR TITLE
📚 Archivist: Clarify proxy cache durations in localized privacy policies

### DIFF
--- a/public/privacy/PRIVACY.de.md
+++ b/public/privacy/PRIVACY.de.md
@@ -82,11 +82,11 @@ Der Browser kann fur Karten, Tiles und Widgets direkt mit Drittanbietern kommuni
 
 ## Datenquellen (proxy)
 
-- **Jolpica F1**
-- **GitHub (bacinger/f1-circuits)**
-- **RainViewer**
-- **Leaflet (via Unpkg)**
-- **Mapbox (über Mapbox CDN):** Interaktionsbibliothek für Karten (aus Sicherheitsgründen geproxyt).
+- **Jolpica F1:** (24-Stunden-Edge-Cache).
+- **GitHub (bacinger/f1-circuits):** (24-Stunden-Edge-Cache).
+- **RainViewer:** Radarmetadaten (1-Minuten-Cache) und Kacheln (2-Stunden-Edge-Cache).
+- **Leaflet (via Unpkg):** (1-Jahr-Immutable-Cache).
+- **Mapbox (über Mapbox CDN):** Interaktionsbibliothek für Karten (aus Sicherheitsgründen geproxyt, 1-Jahr-Immutable-Cache).
 
 ## Lokaler Speicher
 

--- a/public/privacy/PRIVACY.en-GB.md
+++ b/public/privacy/PRIVACY.en-GB.md
@@ -82,11 +82,11 @@ Your browser may connect directly to third-party services for maps, tiles, and w
 
 ### Data Sources (Proxied)
 
-- **Jolpica F1:** F1 schedule data.
-- **GitHub (bacinger/f1-circuits):** GeoJSON track files.
-- **RainViewer:** Radar metadata and tiles.
-- **Leaflet (via Unpkg):** Map library assets.
-- **Mapbox (via Mapbox CDN):** Map interaction library assets (proxied for security).
+- **Jolpica F1:** F1 schedule data (24-hour edge cache).
+- **GitHub (bacinger/f1-circuits):** GeoJSON track files (24-hour edge cache).
+- **RainViewer:** Radar metadata (1-minute cache) and tiles (2-hour edge cache).
+- **Leaflet (via Unpkg):** Map library assets (1-year immutable cache).
+- **Mapbox (via Mapbox CDN):** Map interaction library assets (proxied for security, 1-year immutable cache).
 
 ## Local Storage
 

--- a/public/privacy/PRIVACY.en-NZ.md
+++ b/public/privacy/PRIVACY.en-NZ.md
@@ -82,11 +82,11 @@ Your browser may connect directly to third-party services for maps, tiles, and w
 
 ### Data Sources (Proxied)
 
-- **Jolpica F1:** F1 schedule data.
-- **GitHub (bacinger/f1-circuits):** GeoJSON track files.
-- **RainViewer:** Radar metadata and tiles.
-- **Leaflet (via Unpkg):** Map library assets.
-- **Mapbox (via Mapbox CDN):** Map interaction library assets (proxied for security).
+- **Jolpica F1:** F1 schedule data (24-hour edge cache).
+- **GitHub (bacinger/f1-circuits):** GeoJSON track files (24-hour edge cache).
+- **RainViewer:** Radar metadata (1-minute cache) and tiles (2-hour edge cache).
+- **Leaflet (via Unpkg):** Map library assets (1-year immutable cache).
+- **Mapbox (via Mapbox CDN):** Map interaction library assets (proxied for security, 1-year immutable cache).
 
 ## Local Storage
 

--- a/public/privacy/PRIVACY.en-US.md
+++ b/public/privacy/PRIVACY.en-US.md
@@ -82,11 +82,11 @@ Your browser may connect directly to third-party services for maps, tiles, and w
 
 ### Data Sources (Proxied)
 
-- **Jolpica F1:** F1 schedule data.
-- **GitHub (bacinger/f1-circuits):** GeoJSON track files.
-- **RainViewer:** Radar metadata and tiles.
-- **Leaflet (via Unpkg):** Map library assets.
-- **Mapbox (via Mapbox CDN):** Map interaction library assets (proxied for security).
+- **Jolpica F1:** F1 schedule data (24-hour edge cache).
+- **GitHub (bacinger/f1-circuits):** GeoJSON track files (24-hour edge cache).
+- **RainViewer:** Radar metadata (1-minute cache) and tiles (2-hour edge cache).
+- **Leaflet (via Unpkg):** Map library assets (1-year immutable cache).
+- **Mapbox (via Mapbox CDN):** Map interaction library assets (proxied for security, 1-year immutable cache).
 
 ## Local Storage
 

--- a/public/privacy/PRIVACY.es.md
+++ b/public/privacy/PRIVACY.es.md
@@ -82,11 +82,11 @@ Tu navegador puede conectarse directamente a servicios de terceros para mapas, t
 
 ## Fuentes de datos (con proxy)
 
-- **Jolpica F1:** Calendario F1.
-- **GitHub (bacinger/f1-circuits):** Archivos GeoJSON de circuitos.
-- **RainViewer:** Metadatos y tiles de radar.
-- **Leaflet (via Unpkg):** Recursos de libreria de mapas.
-- **Mapbox (vía Mapbox CDN):** Recursos de librería de mapas (con proxy por seguridad).
+- **Jolpica F1:** Calendario F1 (caché de borde de 24 horas).
+- **GitHub (bacinger/f1-circuits):** Archivos GeoJSON de circuitos (caché de borde de 24 horas).
+- **RainViewer:** Metadatos de radar (caché de 1 minuto) y tiles (caché de borde de 2 horas).
+- **Leaflet (via Unpkg):** Recursos de libreria de mapas (caché inmutable de 1 año).
+- **Mapbox (vía Mapbox CDN):** Recursos de librería de mapas (con proxy por seguridad, caché inmutable de 1 año).
 
 ## Almacenamiento local
 

--- a/public/privacy/PRIVACY.fr.md
+++ b/public/privacy/PRIVACY.fr.md
@@ -82,11 +82,11 @@ Votre navigateur peut se connecter directement a certains services tiers.
 
 ## Sources de donnees (proxyfiees)
 
-- **Jolpica F1**
-- **GitHub (bacinger/f1-circuits)**
-- **RainViewer**
-- **Leaflet (via Unpkg)**
-- **Mapbox (via Mapbox CDN) :** Assets de bibliothèque de carte (proxyfiés par sécurité).
+- **Jolpica F1 :** (cache edge de 24 heures).
+- **GitHub (bacinger/f1-circuits) :** (cache edge de 24 heures).
+- **RainViewer :** Métadonnées radar (cache d'une minute) et tuiles (cache edge de 2 heures).
+- **Leaflet (via Unpkg) :** (cache immuable d'un an).
+- **Mapbox (via Mapbox CDN) :** Assets de bibliothèque de carte (proxyfiés par sécurité, cache immuable d'un an).
 
 ## Stockage local
 

--- a/public/privacy/PRIVACY.hu.md
+++ b/public/privacy/PRIVACY.hu.md
@@ -82,11 +82,11 @@ A böngészője közvetlenül is csatlakozhat harmadik féltől származó szolg
 
 ### Adatforrások (Proxizva)
 
-- **Jolpica F1:** F1-es naptár adatok.
-- **GitHub (bacinger/f1-circuits):** GeoJSON pályafájlok.
-- **RainViewer:** Radar metaadatok és csempék.
-- **Leaflet (az Unpkg-n keresztül):** Térképkönyvtár eszközei.
-- **Mapbox (a Mapbox CDN-en keresztül):** Térkép interakciós könyvtár eszközei (biztonsági okokból proxizva).
+- **Jolpica F1:** F1-es naptár adatok (24 órás edge cache).
+- **GitHub (bacinger/f1-circuits):** GeoJSON pályafájlok (24 órás edge cache).
+- **RainViewer:** Radar metaadatok (1 perces cache) és csempék (2 órás edge cache).
+- **Leaflet (az Unpkg-n keresztül):** Térképkönyvtár eszközei (1 éves módosíthatatlan cache).
+- **Mapbox (a Mapbox CDN-en keresztül):** Térkép interakciós könyvtár eszközei (biztonsági okokból proxizva, 1 éves módosíthatatlan cache).
 
 ## Helyi Tárolás
 

--- a/public/privacy/PRIVACY.it.md
+++ b/public/privacy/PRIVACY.it.md
@@ -82,11 +82,11 @@ Il browser puo connettersi direttamente ad alcuni servizi per mappe, tile e widg
 
 ## Fonti dati (proxy)
 
-- **Jolpica F1**
-- **GitHub (bacinger/f1-circuits)**
-- **RainViewer**
-- **Leaflet (via Unpkg)**
-- **Mapbox (via Mapbox CDN):** Asset della libreria mappa (proxati per sicurezza).
+- **Jolpica F1:** (cache edge di 24 ore).
+- **GitHub (bacinger/f1-circuits):** (cache edge di 24 ore).
+- **RainViewer:** Metadati radar (cache di 1 minuto) e tile (cache edge di 2 ore).
+- **Leaflet (via Unpkg):** (cache immutabile di 1 anno).
+- **Mapbox (via Mapbox CDN):** Asset della libreria mappa (proxati per sicurezza, cache immutabile di 1 anno).
 
 ## Archiviazione locale
 

--- a/public/privacy/PRIVACY.ja.md
+++ b/public/privacy/PRIVACY.ja.md
@@ -82,11 +82,11 @@ Circuit Weather は、Formula 1 サーキット向けのリアルタイム天気
 
 ## データ提供元（プロキシ経由）
 
-- **Jolpica F1**
-- **GitHub (bacinger/f1-circuits)**
-- **RainViewer**
-- **Leaflet (via Unpkg)**
-- **Mapbox (Mapbox CDN 経由):** マップライブラリアセット (セキュリティのためプロキシされます)。
+- **Jolpica F1:** (24時間エッジキャッシュ).
+- **GitHub (bacinger/f1-circuits):** (24時間エッジキャッシュ).
+- **RainViewer:** レーダーメタデータ (1分間キャッシュ) とタイル (2時間エッジキャッシュ).
+- **Leaflet (via Unpkg):** (1年間不変キャッシュ).
+- **Mapbox (Mapbox CDN 経由):** マップライブラリアセット (セキュリティのためプロキシされます、1年間不変キャッシュ)。
 
 ## ローカルストレージ
 

--- a/public/privacy/PRIVACY.pt-BR.md
+++ b/public/privacy/PRIVACY.pt-BR.md
@@ -82,11 +82,11 @@ O navegador pode ligar-se diretamente a servicos terceiros para mapas, tiles e w
 
 ## Fontes de dados (proxy)
 
-- **Jolpica F1**
-- **GitHub (bacinger/f1-circuits)**
-- **RainViewer**
-- **Leaflet (via Unpkg)**
-- **Mapbox (via Mapbox CDN):** Recursos de biblioteca de mapas (com proxy por segurança).
+- **Jolpica F1:** (cache de borda de 24 horas).
+- **GitHub (bacinger/f1-circuits):** (cache de borda de 24 horas).
+- **RainViewer:** Metadados de radar (cache de 1 minuto) e tiles (cache de borda de 2 horas).
+- **Leaflet (via Unpkg):** (cache imutável de 1 ano).
+- **Mapbox (via Mapbox CDN):** Recursos de biblioteca de mapas (com proxy por segurança, cache imutável de 1 ano).
 
 ## Armazenamento local
 

--- a/public/privacy/PRIVACY.zh-CN.md
+++ b/public/privacy/PRIVACY.zh-CN.md
@@ -82,11 +82,11 @@ Circuit Weather 是一个开源网站应用，用于显示 Formula 1 赛道的�
 
 ## 数据来源（代理）
 
-- **Jolpica F1**
-- **GitHub (bacinger/f1-circuits)**
-- **RainViewer**
-- **Leaflet (via Unpkg)**
-- **Mapbox (通过 Mapbox CDN):** 地图交互库资产 (为了安全而进行代理)。
+- **Jolpica F1:** (24 小时边缘缓存).
+- **GitHub (bacinger/f1-circuits):** (24 小时边缘缓存).
+- **RainViewer:** 雷达元数据 (1 分钟缓存) 和瓦片 (2 小时边缘缓存).
+- **Leaflet (via Unpkg):** (1 年不可变缓存).
+- **Mapbox (通过 Mapbox CDN):** 地图交互库资产 (为了安全而进行代理, 1 年不可变缓存)。
 
 ## 本地存储
 


### PR DESCRIPTION
💡 Problem: The English `PRIVACY.md` accurately documented the proxy edge caching durations for various third-party services (e.g. 24-hour cache for F1 API, 1-year cache for mapping assets), but all localized translations (`PRIVACY.*.md`) were completely missing these vital data retention timelines in their "Data Sources (Proxied)" sections.

🎯 Fix: Read the current translation in every localized privacy file (`en-GB`, `en-NZ`, `en-US`, `es`, `hu`, `de`, `fr`, `it`, `ja`, `pt-BR`, `zh-CN`) and safely appended the missing cache duration strings in each corresponding language.

🧪 Verification: Ran a temporary Node script to ensure precision without breaking regex across languages, then ran Prettier on all files, validated formatting with `git diff`, and ensured the test suite still passed cleanly via `pnpm test`. The temporary script was deleted before commit.

🔎 Scope: This PR contains ONLY documentation changes.

---
*PR created automatically by Jules for task [13092855897443304699](https://jules.google.com/task/13092855897443304699) started by @2fst4u*