### PR TITLE
🔭 Scout: [SEO improvement] Upgrade forecast unavailable notice to semantic aside

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -70,3 +70,6 @@
 
 **Learning:** Upgrading generic fallback warning messages (like a `data-source-notice` `<div>`) to semantic `<aside>` tags correctly signals to search engines that the warning is supplementary content and not part of the primary page outline, improving indexation of the core content.
 **Action:** Always scan for persistent or fallback warning containers and replace generic `div`s with `<aside>`, taking care to ensure CSS continues to target class names (`.data-source-notice`) rather than the raw element tags so styling isn't broken.
+## 2026-06-14 - Semantic aside tags for forecast warning
+**Learning:** Upgrading generic fallback warning containers (like `<div id="forecastUnavailable">`) to semantic `<aside>` tags correctly signals to search engines that the warning is supplementary content and not part of the primary page outline, improving indexation of the core content. However, CSS must be verified to ensure it targets IDs or classes rather than the generic `div` tag.
+**Action:** Always scan for persistent or fallback warning containers and replace generic `div`s with `<aside>`, taking care to ensure CSS continues to target class names or IDs so styling isn't broken.

--- a/public/index.html
+++ b/public/index.html
@@ -230,9 +230,10 @@
                             </section>
                         </article>
                     </div>
-                    <div id="forecastUnavailable" style="display: none;" aria-live="polite">
+                    <!-- Scout: Upgraded generic div to semantic aside for the forecast unavailable notice to correctly signal to search engines that it is a supplementary warning message, and not part of the primary page outline. -->
+                    <aside id="forecastUnavailable" style="display: none;" aria-live="polite">
                         <p class="forecast-unavailable" data-i18n="forecast.availableCloser">Forecast available closer to session</p>
-                    </div>
+                    </aside>
                 </section>
 
                 <!-- Session Empty State -->


### PR DESCRIPTION
💡 **What**: Upgraded the generic `<div id="forecastUnavailable">` wrapper to a semantic `<aside>` element.
🎯 **Why**: The "Forecast available closer to session" notice is supplementary, conditional warning text. Wrapping it in an `<aside>` signals to search engine crawlers that this content is secondary and distinct from the primary page outline, helping them better prioritize and index the core weather content.
📊 **Value**: Improves document outline clarity for search engines by segregating fallback messaging from the primary content tree.
🔬 **Measurement**: Inspect the DOM using browser developer tools and verify the `<aside id="forecastUnavailable">` tag renders with the correct semantic role when no session is selected.


---
*PR created automatically by Jules for task [3272122833813195821](https://jules.google.com/task/3272122833813195821) started by @2fst4u*