### PR TITLE
🧹 Sweep: Remove unused map parameter from MapWeatherWidget

### DIFF
--- a/public/src/map/MapWeatherWidget.js
+++ b/public/src/map/MapWeatherWidget.js
@@ -72,13 +72,13 @@ class MapWeatherWidgetClass {
   }
 
   // Leaflet interface
-  onAdd(map) {
+  onAdd() {
     // Ensure Leaflet-specific classes are present
     this._div.classList.add("leaflet-control");
     return this._div;
   }
 
-  onRemove(map) {
+  onRemove() {
     if (this._div.parentNode) {
       this._div.parentNode.removeChild(this._div);
     }


### PR DESCRIPTION
💡 What: Removed the unused `map` parameter from the `onAdd` and `onRemove` lifecycle methods in `public/src/map/MapWeatherWidget.js`.
🎯 Why: The parameters were unread and flagged as unused variables by the linter, causing minor clutter.
🔬 Verification: Ran `npx eslint` to verify the variable was unread, then verified application integrity with `pnpm test` (all 894 tests passing).

---
*PR created automatically by Jules for task [13686652783357743333](https://jules.google.com/task/13686652783357743333) started by @2fst4u*