### PR TITLE
🎨 Palette: Add aria-hidden to sidebar backdrop

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Focus Management in Custom Selects
 **Learning:** In custom select dropdowns (like the language menu), always focusing the first element upon opening forces keyboard users to navigate back through the list to reach their current selection. The active element should be the initial focus target.
 **Action:** When implementing custom menus, always add focus management that targets the `.active` or `[aria-checked="true"]` item first, falling back to the first item if no active state is found.
+## 2024-05-24 - Screen Reader Ghost Elements
+**Learning:** Purely visual overlay elements (like full-screen backdrops used to close sidebars on mobile) can be announced by screen readers as empty, interactive regions if not explicitly hidden. Even if they are just empty `div`s, their presence in the DOM, especially when toggled alongside other interactive elements, adds unnecessary noise.
+**Action:** Always add `aria-hidden="true"` to visual backdrop or overlay elements that serve no semantic purpose and are not meant to be navigated to via keyboard.

--- a/public/index.html
+++ b/public/index.html
@@ -300,7 +300,7 @@
         </aside>
 
         <!-- Sidebar Backdrop (for mobile overlay) -->
-        <div class="sidebar-backdrop" id="sidebarBackdrop"></div>
+        <div class="sidebar-backdrop" id="sidebarBackdrop" aria-hidden="true"></div>
 
         <!-- Main Content -->
         <main id="main" class="main-content" tabindex="-1">


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to the `#sidebarBackdrop` div in `public/index.html`.
🎯 Why: The sidebar backdrop is a purely visual element used to close the sidebar on mobile when clicking outside it. It has no semantic meaning and cannot be interacted with via keyboard navigation (closing is handled by the Esc key or the close button). Hiding it from assistive technologies removes unnecessary noise.
📸 Before/After: Visuals are unchanged. The screen reader tree is cleaner.
♿ Accessibility: Improves the screen reader experience by preventing an empty, un-interactive element from being announced.

---
*PR created automatically by Jules for task [9795619593610756176](https://jules.google.com/task/9795619593610756176) started by @2fst4u*