### PR TITLE
🌍 Globe: Extract translation for radar controls aria-label

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -346,7 +346,7 @@
 
             <!-- Radar Timeline -->
             <!-- Scout: Upgraded generic div to semantic section for better structure and screen reader landmarks -->
-            <section class="radar-controls" id="radarControls" aria-label="Radar Playback Controls" style="display: none;">
+            <section class="radar-controls" id="radarControls" aria-label="Radar Playback Controls" data-i18n-attr="aria-label:radar.controlsLabel" style="display: none;">
                 <button class="radar-play-btn" id="radarPlayBtn" aria-label="Play radar animation" title="Play (Space)" data-i18n-attr="aria-label:radar.play,title:radar.playTitle"
                     aria-keyshortcuts="Space" aria-pressed="false">
                     <svg class="icon-play" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">

--- a/public/src/i18n/locales/de.js
+++ b/public/src/i18n/locales/de.js
@@ -64,6 +64,7 @@ export const de = {
     windSpeed: "Windgeschwindigkeit",
   },
   radar: {
+    controlsLabel: "Radar-Wiedergabesteuerung",
     play: "Radar abspielen",
     pause: "Radar pausieren",
     playTitle: "Abspielen (Leertaste)",

--- a/public/src/i18n/locales/en.js
+++ b/public/src/i18n/locales/en.js
@@ -63,6 +63,7 @@ export const en = {
     windSpeed: "Wind Speed",
   },
   radar: {
+    controlsLabel: "Radar Playback Controls",
     play: "Play radar animation",
     pause: "Pause radar animation",
     playTitle: "Play (Space)",

--- a/public/src/i18n/locales/es.js
+++ b/public/src/i18n/locales/es.js
@@ -63,6 +63,7 @@ export const es = {
     windSpeed: "Velocidad del viento",
   },
   radar: {
+    controlsLabel: "Controles de reproducción de radar",
     play: "Reproducir radar",
     pause: "Pausar radar",
     playTitle: "Reproducir (Espacio)",

--- a/public/src/i18n/locales/fr.js
+++ b/public/src/i18n/locales/fr.js
@@ -63,6 +63,7 @@ export const fr = {
     windSpeed: "Vitesse du vent",
   },
   radar: {
+    controlsLabel: "Contrôles de lecture du radar",
     play: "Lire le radar",
     pause: "Mettre le radar en pause",
     playTitle: "Lire (Espace)",

--- a/public/src/i18n/locales/hu.js
+++ b/public/src/i18n/locales/hu.js
@@ -65,6 +65,7 @@ export const hu = {
     windSpeed: "Szélsebesség",
   },
   radar: {
+    controlsLabel: "Radar lejátszás vezérlők",
     play: "Radar animáció lejátszása",
     pause: "Radar animáció szüneteltetése",
     playTitle: "Lejátszás (Szóköz)",

--- a/public/src/i18n/locales/it.js
+++ b/public/src/i18n/locales/it.js
@@ -63,6 +63,7 @@ export const it = {
     windSpeed: "Velocita vento",
   },
   radar: {
+    controlsLabel: "Controlli di riproduzione radar",
     play: "Avvia radar",
     pause: "Pausa radar",
     playTitle: "Avvia (Spazio)",

--- a/public/src/i18n/locales/ja.js
+++ b/public/src/i18n/locales/ja.js
@@ -63,6 +63,7 @@ export const ja = {
     windSpeed: "風速",
   },
   radar: {
+    controlsLabel: "レーダー再生コントロール",
     play: "レーダー再生",
     pause: "レーダー一時停止",
     playTitle: "再生 (Space)",

--- a/public/src/i18n/locales/ko.js
+++ b/public/src/i18n/locales/ko.js
@@ -63,6 +63,7 @@ export const ko = {
     windSpeed: "풍속",
   },
   radar: {
+    controlsLabel: "레이더 재생 제어",
     play: "레이더 애니메이션 재생",
     pause: "레이더 애니메이션 일시 중지",
     playTitle: "재생 (스페이스바)",

--- a/public/src/i18n/locales/nl.js
+++ b/public/src/i18n/locales/nl.js
@@ -64,6 +64,7 @@ export const nl = {
     windSpeed: "Windsnelheid",
   },
   radar: {
+    controlsLabel: "Radar afspeelbediening",
     play: "Speel radar animatie af",
     pause: "Pauzeer radar animatie",
     playTitle: "Afspelen (Spatie)",

--- a/public/src/i18n/locales/pt-BR.js
+++ b/public/src/i18n/locales/pt-BR.js
@@ -63,6 +63,7 @@ export const ptBR = {
     windSpeed: "Velocidade do vento",
   },
   radar: {
+    controlsLabel: "Controles de reprodução de radar",
     play: "Reproduzir radar",
     pause: "Pausar radar",
     playTitle: "Reproduzir (Espaco)",

--- a/public/src/i18n/locales/zh-CN.js
+++ b/public/src/i18n/locales/zh-CN.js
@@ -59,6 +59,7 @@ export const zhCN = {
     windSpeed: "风速",
   },
   radar: {
+    controlsLabel: "雷达播放控制",
     play: "播放雷达动画",
     pause: "暂停雷达动画",
     playTitle: "播放 (Space)",


### PR DESCRIPTION
💡 What: Extracted the hardcoded `aria-label="Radar Playback Controls"` string from the `<section class="radar-controls">` element in `public/index.html` and added it to the i18n dictionaries (`radar.controlsLabel`). Translated to all 11 supported locales.
🎯 Why: To ensure screen reader users browsing in non-English locales receive translated context for the radar playback controls section, aligning with the app's standard accessibility localization patterns.

---
*PR created automatically by Jules for task [14472952024199283295](https://jules.google.com/task/14472952024199283295) started by @2fst4u*