### PR TITLE
📚 Archivist: Update Privacy Proxy documentation

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -270,3 +270,8 @@ Prevention: Avoid duplicating configuration values in documentation; reference t
 
 **Learning:** `AGENTS.md` omitted "OpenF1" from its "Third-Party Services" table, even though it is used as a fallback data source for F1 schedules. It must be documented that OpenF1 is accessed directly (Client-side) because it blocks requests from datacenter IP ranges (Cloudflare Workers).
 **Action:** Added the "OpenF1" data source to the `AGENTS.md` Third-Party Services table to ensure architectural claims are exhaustive.
+
+## 2026-06-08 - Drift in Privacy Proxy list in PRIVACY.md
+
+**Learning:** While the 'Data Sources (Proxied)' section of `PRIVACY.md` accurately documented that both Leaflet and Mapbox GL JS assets are proxied through the Cloudflare worker, the 'Privacy Proxy' bullet point in the 'Infrastructure & Caching' section had drifted and only mentioned Leaflet library assets. This inconsistency created ambiguity about whether Mapbox assets are also proxied for privacy reasons.
+**Action:** Always cross-reference the components listed in the 'Privacy Proxy' infrastructure summary with the detailed breakdown in the 'Data Sources (Proxied)' section to ensure all proxied third-party assets (like Mapbox GL JS) are accurately represented in both places across all localized privacy policies.

--- a/public/PRIVACY.md
+++ b/public/PRIVACY.md
@@ -22,7 +22,7 @@ However, the application relies on third-party services and infrastructure which
 
 This website is hosted on **Cloudflare Workers** (using Static Assets) which serves both the website and powers its API. We leverage Cloudflare's global edge network to aggressively cache data close to you.
 
-- **Privacy Proxy:** To enhance your privacy, requests for F1 schedules, Track Layouts, Leaflet library assets, and **all RainViewer Radar Tiles** are proxied through our Cloudflare Worker. This hides your IP address from these third-party services.
+- **Privacy Proxy:** To enhance your privacy, requests for F1 schedules, Track Layouts, Leaflet library assets, Mapbox GL JS assets, and **all RainViewer Radar Tiles** are proxied through our Cloudflare Worker. This hides your IP address from these third-party services.
 - **Advanced Caching:** We utilize advanced edge caching features to store API responses on Cloudflare's servers. This minimizes data usage and reduces load on the open-source community APIs we rely on.
 - **Data Processed:** Cloudflare processes your IP address and request metadata to deliver the website and protect against security threats.
 - **Privacy Policy:** [cloudflare.com/privacypolicy](https://www.cloudflare.com/privacypolicy/)

--- a/public/privacy/PRIVACY.de.md
+++ b/public/privacy/PRIVACY.de.md
@@ -22,7 +22,7 @@ Zur Funktion nutzt die Anwendung Drittanbieter, die ubliche Webanfragedaten (z. 
 
 Die Website wird auf **Cloudflare Workers** betrieben.
 
-- **Privacy-Proxy:** F1-Kalender, Streckenlayouts, Leaflet-Assets und RainViewer-Tiles laufen uber unseren Worker.
+- **Privacy-Proxy:** F1-Kalender, Streckenlayouts, Leaflet-Assets, Mapbox GL JS-Assets und RainViewer-Tiles laufen uber unseren Worker.
 - **Edge-Cache:** API-Antworten werden am Edge zwischengespeichert.
 - **Verarbeitete Daten:** Cloudflare verarbeitet IP und Request-Metadaten fur Auslieferung und Sicherheit.
 - **Datenschutzrichtlinie:** [cloudflare.com/privacypolicy](https://www.cloudflare.com/privacypolicy/)

--- a/public/privacy/PRIVACY.en-GB.md
+++ b/public/privacy/PRIVACY.en-GB.md
@@ -22,7 +22,7 @@ However, the application relies on third-party services and infrastructure which
 
 This website is hosted on **Cloudflare Workers** (using Static Assets) which serves both the website and powers its API.
 
-- **Privacy proxy:** Requests for F1 schedules, track layouts, Leaflet assets, and all RainViewer radar tiles are proxied through our Cloudflare Worker.
+- **Privacy proxy:** Requests for F1 schedules, track layouts, Leaflet assets, Mapbox GL JS assets, and all RainViewer radar tiles are proxied through our Cloudflare Worker.
 - **Advanced caching:** API responses are cached at the edge to minimise bandwidth use and upstream load.
 - **Data processed:** Cloudflare processes IP address and request metadata to deliver and protect the site.
 - **Privacy policy:** [cloudflare.com/privacypolicy](https://www.cloudflare.com/privacypolicy/)

--- a/public/privacy/PRIVACY.en-NZ.md
+++ b/public/privacy/PRIVACY.en-NZ.md
@@ -22,7 +22,7 @@ However, the application relies on third-party services and infrastructure which
 
 This website is hosted on **Cloudflare Workers** (using Static Assets) which serves both the website and powers its API.
 
-- **Privacy proxy:** Requests for F1 schedules, track layouts, Leaflet assets, and all RainViewer radar tiles are proxied through our Cloudflare Worker.
+- **Privacy proxy:** Requests for F1 schedules, track layouts, Leaflet assets, Mapbox GL JS assets, and all RainViewer radar tiles are proxied through our Cloudflare Worker.
 - **Advanced caching:** API responses are cached at the edge to minimise bandwidth use and upstream load.
 - **Data processed:** Cloudflare processes IP address and request metadata to deliver and protect the site.
 - **Privacy policy:** [cloudflare.com/privacypolicy](https://www.cloudflare.com/privacypolicy/)

--- a/public/privacy/PRIVACY.en-US.md
+++ b/public/privacy/PRIVACY.en-US.md
@@ -22,7 +22,7 @@ However, the application relies on third-party services and infrastructure which
 
 This website is hosted on **Cloudflare Workers** (using Static Assets), which serves both the website and powers its API.
 
-- **Privacy proxy:** Requests for F1 schedules, track layouts, Leaflet assets, and all RainViewer radar tiles are proxied through our Cloudflare Worker.
+- **Privacy proxy:** Requests for F1 schedules, track layouts, Leaflet assets, Mapbox GL JS assets, and all RainViewer radar tiles are proxied through our Cloudflare Worker.
 - **Advanced caching:** API responses are cached at the edge to minimize bandwidth usage and upstream load.
 - **Data processed:** Cloudflare processes IP address and request metadata to deliver and protect the site.
 - **Privacy policy:** [cloudflare.com/privacypolicy](https://www.cloudflare.com/privacypolicy/)

--- a/public/privacy/PRIVACY.es.md
+++ b/public/privacy/PRIVACY.es.md
@@ -22,7 +22,7 @@ La aplicacion depende de servicios de terceros e infraestructura que pueden proc
 
 El sitio esta alojado en **Cloudflare Workers**.
 
-- **Proxy de privacidad:** Las peticiones de calendario F1, trazados, recursos Leaflet y tiles de RainViewer pasan por nuestro Worker.
+- **Proxy de privacidad:** Las peticiones de calendario F1, trazados, recursos Leaflet, recursos Mapbox GL JS y tiles de RainViewer pasan por nuestro Worker.
 - **Cache avanzada:** Las respuestas API se cachean en el borde para reducir trafico y carga en servicios externos.
 - **Datos procesados:** Cloudflare procesa IP y metadatos de peticion para entregar y proteger el sitio.
 - **Politica de privacidad:** [cloudflare.com/privacypolicy](https://www.cloudflare.com/privacypolicy/)

--- a/public/privacy/PRIVACY.fr.md
+++ b/public/privacy/PRIVACY.fr.md
@@ -22,7 +22,7 @@ L'application s'appuie toutefois sur des services tiers qui peuvent traiter des 
 
 Le site est heberge sur **Cloudflare Workers**.
 
-- **Proxy de confidentialite :** Les requetes F1, traces, assets Leaflet et tuiles RainViewer passent par notre Worker.
+- **Proxy de confidentialite :** Les requetes F1, traces, assets Leaflet, assets Mapbox GL JS et tuiles RainViewer passent par notre Worker.
 - **Cache avance :** Les reponses API sont mises en cache en edge.
 - **Donnees traitees :** Cloudflare traite IP et metadonnees de requete pour fournir et securiser le site.
 - **Politique :** [cloudflare.com/privacypolicy](https://www.cloudflare.com/privacypolicy/)

--- a/public/privacy/PRIVACY.hu.md
+++ b/public/privacy/PRIVACY.hu.md
@@ -22,7 +22,7 @@ Az alkalmazás azonban harmadik féltől származó szolgáltatásokra és infra
 
 Ez a weboldal a **Cloudflare Workers** szolgáltatáson (Static Assets használatával) fut, amely a weboldalt szolgálja ki és az API-t is működteti.
 
-- **Adatvédelmi proxy:** Az F1-es naptár, a pályarajzok, a Leaflet eszközök és a RainViewer radar csempék kéréseit a Cloudflare Workerünk proxizza.
+- **Adatvédelmi proxy:** Az F1-es naptár, a pályarajzok, a Leaflet eszközök, a Mapbox GL JS eszközök és a RainViewer radar csempék kéréseit a Cloudflare Workerünk proxizza.
 - **Fejlett gyorsítótárazás:** Az API-válaszokat a peremen (edge) gyorsítótárazzuk a sávszélesség-használat és a feltöltési terhelés minimalizálása érdekében.
 - **Feldolgozott adatok:** A Cloudflare feldolgozza az IP-címeket és a kérések metaadatait a weboldal kézbesítése és védelme érdekében.
 - **Adatvédelmi irányelvek:** [cloudflare.com/privacypolicy](https://www.cloudflare.com/privacypolicy/)

--- a/public/privacy/PRIVACY.it.md
+++ b/public/privacy/PRIVACY.it.md
@@ -22,7 +22,7 @@ L'app usa servizi terzi che possono elaborare dati standard delle richieste web 
 
 Il sito e ospitato su **Cloudflare Workers**.
 
-- **Proxy privacy:** Calendario F1, tracciati, asset Leaflet e tile RainViewer passano dal nostro Worker.
+- **Proxy privacy:** Calendario F1, tracciati, asset Leaflet, asset Mapbox GL JS e tile RainViewer passano dal nostro Worker.
 - **Cache edge:** Le risposte API vengono memorizzate in cache vicino all'utente.
 - **Dati elaborati:** Cloudflare elabora IP e metadati di richiesta per consegna e sicurezza.
 - **Privacy Policy:** [cloudflare.com/privacypolicy](https://www.cloudflare.com/privacypolicy/)

--- a/public/privacy/PRIVACY.ja.md
+++ b/public/privacy/PRIVACY.ja.md
@@ -22,7 +22,7 @@ Circuit Weather は、Formula 1 サーキット向けのリアルタイム天気
 
 本サイトは **Cloudflare Workers** 上で運用されています。
 
-- **プライバシープロキシ:** F1 スケジュール、トラックレイアウト、Leaflet アセット、RainViewer タイルは Worker 経由で配信されます。
+- **プライバシープロキシ:** F1 スケジュール、トラックレイアウト、Leaflet アセット、Mapbox GL JS アセット、RainViewer タイルは Worker 経由で配信されます。
 - **エッジキャッシュ:** API 応答はエッジにキャッシュされ、帯域と上流負荷を削減します。
 - **処理データ:** Cloudflare は配信とセキュリティのため IP とリクエストメタデータを処理します。
 - **ポリシー:** [cloudflare.com/privacypolicy](https://www.cloudflare.com/privacypolicy/)

--- a/public/privacy/PRIVACY.pt-BR.md
+++ b/public/privacy/PRIVACY.pt-BR.md
@@ -22,7 +22,7 @@ A aplicacao depende de servicos de terceiros que podem processar dados web padra
 
 O website esta alojado em **Cloudflare Workers**.
 
-- **Proxy de privacidade:** Calendario F1, tracados, assets Leaflet e tiles RainViewer passam pelo nosso Worker.
+- **Proxy de privacidade:** Calendario F1, tracados, assets Leaflet, assets Mapbox GL JS e tiles RainViewer passam pelo nosso Worker.
 - **Cache edge:** Respostas API sao guardadas em cache para melhor desempenho.
 - **Dados processados:** A Cloudflare processa IP e metadados de pedido para entrega e seguranca.
 - **Politica:** [cloudflare.com/privacypolicy](https://www.cloudflare.com/privacypolicy/)

--- a/public/privacy/PRIVACY.zh-CN.md
+++ b/public/privacy/PRIVACY.zh-CN.md
@@ -22,7 +22,7 @@ Circuit Weather 是一个开源网站应用，用于显示 Formula 1 赛道的�
 
 网站部署在 **Cloudflare Workers**。
 
-- **隐私代理:** F1 赛历、赛道布局、Leaflet 资源和 RainViewer 雷达瓦片通过 Worker 代理。
+- **隐私代理:** F1 赛历、赛道布局、Leaflet 资源、Mapbox GL JS 资源和 RainViewer 雷达瓦片通过 Worker 代理。
 - **边缘缓存:** API 响应在边缘节点缓存，以降低带宽和上游负载。
 - **处理数据:** Cloudflare 会处理 IP 与请求元数据以完成分发和安全防护。
 - **隐私政策:** [cloudflare.com/privacypolicy](https://www.cloudflare.com/privacypolicy/)


### PR DESCRIPTION
💡 Problem: The infrastructure summary ("Privacy Proxy") in `PRIVACY.md` and all its localized versions failed to list Mapbox GL JS assets, despite them being explicitly proxied for security and listed further down in the "Data Sources (Proxied)" section. This created ambiguity about the privacy treatment of Mapbox assets.
🎯 Fix: Added "Mapbox GL JS assets" (and its localized equivalents) to the list of proxied services in the "Privacy Proxy" bullet point across all `PRIVACY.*.md` files.
🧪 Verification: Confirmed text was successfully added using `git diff` across all 12 privacy files and ran `pnpm test` successfully.
🔎 Scope: Only modified `PRIVACY.md`, localized versions in `public/privacy/`, and the Archivist journal. No application code changes.

---
*PR created automatically by Jules for task [6297412950754170549](https://jules.google.com/task/6297412950754170549) started by @2fst4u*