### PR TITLE
🌍 Globe: Fix translation for status.next

### DIFF
--- a/public/src/i18n/locales/de.js
+++ b/public/src/i18n/locales/de.js
@@ -132,7 +132,7 @@ export const de = {
     sessionLoadFailed:
       "Session-Prognose oder Radar konnte nicht geladen werden.",
   },
-  status: { live: "LIVE", current: "Aktuell", next: "Nachste" },
+  status: { live: "LIVE", current: "Aktuell", next: "Nächste" },
   meta: {
     defaultTitle: "Circuit Weather — Live-F1-Wetterradar und Prognosen",
     defaultDesc:


### PR DESCRIPTION
💡 What: Corrected the spelling of the translation key `status.next` in the `de.js` locale file from `Nachste` to `Nächste`.
🎯 Why: The previous state contained a typo/incorrect spelling of a German word ("Nachste" instead of the grammatically correct "Nächste" with an umlaut), making it culturally awkward for German speakers.
🌐 Nuance: Fixed a missing umlaut to ensure grammatically correct German.

---
*PR created automatically by Jules for task [14377128751077670155](https://jules.google.com/task/14377128751077670155) started by @2fst4u*