### PR TITLE
Remove all TODO comments from source code

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -19,9 +19,6 @@ import { i18n } from './i18n/index.js';
 /**
  * Main application orchestrator for Circuit Weather.
  */
-// TODO: Refactor — this orchestrator is large (~1100 lines). Consider extracting
-// cohesive responsibilities (session/forecast handling, selection + routing glue,
-// live-weather refresh loops) into smaller collaborators to ease testing.
 export class CircuitWeatherApp {
     constructor() {
         this.mapManager = new MapManager();

--- a/public/src/i18n/index.js
+++ b/public/src/i18n/index.js
@@ -15,10 +15,6 @@ import { nl } from './locales/nl.js';
 import { ptBR } from './locales/pt-BR.js';
 import { zhCN } from './locales/zh-CN.js';
 
-// TODO: Localisation roadmap (see AGENTS.md) — keep translations complete and
-// consistent against en.js as the source of truth, and add widely used languages
-// over time. The i18n-locales-completeness test guards key parity; prioritise
-// quality and consistency when extending coverage.
 export const TRANSLATIONS = {
     en,
     'en-GB': enGB,

--- a/public/src/map/WeatherRadar.js
+++ b/public/src/map/WeatherRadar.js
@@ -6,9 +6,6 @@ import { RadarFrames } from './RadarFrames.js';
 import { RadarPolling } from './RadarPolling.js';
 import { RadarReconcile } from './RadarReconcile.js';
 
-// TODO: Feature — rain alerts. We already retain ~2h of radar frames; derive an
-// "approaching precipitation" signal relative to the selected circuit centre and
-// surface a "rain incoming" indicator for race strategy.
 export class WeatherRadar {
     constructor(map) {
         this.map = map;


### PR DESCRIPTION
## Summary

- Removed TODO comment block from `public/src/i18n/index.js` (localisation roadmap note)
- Removed TODO comment block from `public/src/CircuitWeatherApp.js` (refactor suggestion)
- Removed TODO comment block from `public/src/map/WeatherRadar.js` (rain alerts feature idea)

## Test plan

- [ ] Verify no TODO comments remain in source files: `grep -r "TODO" public/src/`
- [ ] Confirm app still builds and runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQvW2ZwUFbB78dKmGQXujo

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQvW2ZwUFbB78dKmGQXujo)_