### PR TITLE
🧹 Sweep: Remove redundant getWindDirection wrapper from WeatherClient

### DIFF
--- a/public/src/CircuitWeatherApp.js
+++ b/public/src/CircuitWeatherApp.js
@@ -15,6 +15,7 @@ import { ThemeManager } from './ui/ThemeManager.js';
 import { SidebarManager } from './ui/SidebarManager.js';
 import { getSessionStatus, getRoundStatus, formatStatusLabel } from './utils/status.js';
 import { i18n } from './i18n/index.js';
+import { getWindDirection } from './utils/wind.js';
 
 /**
  * Main application orchestrator for Circuit Weather.
@@ -1063,7 +1064,7 @@ export class CircuitWeatherApp {
             const maxPrecip = Math.max(...weather.hourly.map(h => h.precipProb));
 
             // Wind Direction Logic
-            const windInfo = this.weatherClient.getWindDirection(dir);
+            const windInfo = getWindDirection(dir);
             // Rotation: Input 0 (N) -> Blows South -> Arrow (Up) needs 180 deg rotation
             const rotation = windInfo.rotation;
 

--- a/public/src/api/WeatherClient.js
+++ b/public/src/api/WeatherClient.js
@@ -1,6 +1,6 @@
 import { CONFIG } from '../config.js';
 import { i18n } from '../i18n/index.js';
-import { getWindDirection as resolveWindDirection, windToVector } from '../utils/wind.js';
+import { windToVector } from '../utils/wind.js';
 
 export class WeatherClient {
     constructor() {
@@ -251,9 +251,5 @@ export class WeatherClient {
         }
         const unit = hours === 1 ? i18n.t('countdown.hour') : i18n.t('countdown.hourPlural');
         return i18n.t('radar.afterSession', { duration: `${hours} ${unit}` });
-    }
-
-    getWindDirection(degrees) {
-        return resolveWindDirection(degrees);
     }
 }

--- a/tests/circuit-weather-app.test.js
+++ b/tests/circuit-weather-app.test.js
@@ -117,10 +117,12 @@ vi.mock('../public/src/api/WeatherClient.js', () => ({
             getForecast: vi.fn().mockResolvedValue({ available: false }),
             getRelativeTime: vi.fn(),
             getWeatherDescription: vi.fn(),
-            getAccessibleRelativeTime: vi.fn(),
-            getWindDirection: vi.fn(() => ({ text: 'N', rotation: 0 }))
+            getAccessibleRelativeTime: vi.fn()
         }
     })
+}));
+vi.mock('../public/src/utils/wind.js', () => ({
+    getWindDirection: vi.fn(() => ({ text: 'N', rotation: 0 }))
 }));
 vi.mock('../public/src/map/TrackLayer.js', () => ({
     TrackLayer: vi.fn().mockImplementation(function () {
@@ -702,8 +704,9 @@ describe('CircuitWeatherApp Pure Methods', () => {
             expect(app.ui.forecastContent.innerHTML).toContain('weather-dashboard');
         });
 
-        it('escapes windInfo.text and rotation in the forecast dashboard', () => {
-            app.weatherClient.getWindDirection = vi.fn().mockReturnValue({
+        it('escapes windInfo.text and rotation in the forecast dashboard', async () => {
+            const windModule = await import('../public/src/utils/wind.js');
+            windModule.getWindDirection.mockReturnValue({
                 text: '<script>alert("xss")</script>',
                 rotation: '"><img src=x onerror=alert(1)>'
             });

--- a/tests/seo.test.js
+++ b/tests/seo.test.js
@@ -71,8 +71,7 @@ vi.mock('../public/src/api/WeatherClient.js', () => ({
             getForecast: vi.fn().mockResolvedValue({ available: false }),
             getRelativeTime: vi.fn(),
             getWeatherDescription: vi.fn(),
-            getAccessibleRelativeTime: vi.fn(),
-            getWindDirection: vi.fn(() => ({ text: 'N', rotation: 0 }))
+            getAccessibleRelativeTime: vi.fn()
         }
     })
 }));

--- a/tests/weather-client.test.js
+++ b/tests/weather-client.test.js
@@ -197,28 +197,6 @@ describe('WeatherClient', () => {
         });
     });
 
-    describe('getWindDirection', () => {
-        const cases = [
-            [0, 'N', 180],
-            [45, 'NE', 225],
-            [90, 'E', 270],
-            [135, 'SE', 315],
-            [180, 'S', 360],
-            [225, 'SW', 405],
-            [270, 'W', 450],
-            [315, 'NW', 495],
-            [360, 'N', 540],
-        ];
-
-        cases.forEach(([degrees, text, rotation]) => {
-            it(`returns ${text} (rotation ${rotation}°) for ${degrees}°`, () => {
-                const result = client.getWindDirection(degrees);
-                expect(result.text).toBe(text);
-                expect(result.rotation).toBe(rotation);
-            });
-        });
-    });
-
     describe('getForecast', () => {
         let mockFetch;
 


### PR DESCRIPTION
💡 What: Removed the `getWindDirection` method from `WeatherClient.js`, updated its caller in `CircuitWeatherApp.js` to use the utility function directly, and removed obsolete mocks and test blocks from test files.
🎯 Why: The method was a simple pass-through wrapper for `resolveWindDirection` imported from `utils/wind.js`. It didn't utilize any of the class's internal state. Removing it reduces codebase bloat and makes dependencies clearer without changing any functional behavior.
🔬 Verification: Ran a global workspace search `grep -rn "getWindDirection" public/src/` to confirm the wrapper is completely removed and all usages correctly point to the utility method. Ran `pnpm test` (all 888 tests passed).

---
*PR created automatically by Jules for task [16873210855011190200](https://jules.google.com/task/16873210855011190200) started by @2fst4u*