### PR TITLE
Fix radar error toast timer sync

### DIFF
--- a/public/src/map/RadarErrorToast.js
+++ b/public/src/map/RadarErrorToast.js
@@ -105,7 +105,7 @@ export class RadarErrorToast {
             const message = this.retryingTilesMessage(count);
 
             // Fix Timer Sync: Use actual remaining time if a retry cooldown is active
-            let duration = 60;
+            let duration = 0;
             if (this.rateLimitResetTime > Date.now()) {
                 duration = Math.ceil((this.rateLimitResetTime - Date.now()) / 1000);
                 duration = Math.max(1, duration); // Ensure at least 1s
@@ -191,7 +191,7 @@ export class RadarErrorToast {
             } else {
                 this.ui.errorTimer.textContent = '';
                 this.toastAnimationFrame = null;
-                if (durationSec < 10 && this.rateLimitResetTime < Date.now()) {
+                if (durationSec > 0 && durationSec < 10 && this.rateLimitResetTime < Date.now()) {
                     this.hideErrorToast();
                 }
             }


### PR DESCRIPTION
Fixes a bug where the radar error toast would display an incorrect 60-second countdown timer instead of just remaining visible persistently without a timer when there is no active rate limit cooldown.

Changes:
1. Updated `RadarErrorToast.js` to set `let duration = 0;` instead of `60`.
2. Updated the auto-hide condition in `showErrorToast` from `durationSec < 10` to `durationSec > 0 && durationSec < 10` so that persistent toasts (duration 0) do not get accidentally hidden.

---
*PR created automatically by Jules for task [3167675645839433989](https://jules.google.com/task/3167675645839433989) started by @2fst4u*