### PR TITLE
🎨 Palette: Improve keyboard accessibility for toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-24 - Screen Reader Ghost Elements
 **Learning:** Purely visual overlay elements (like full-screen backdrops used to close sidebars on mobile) can be announced by screen readers as empty, interactive regions if not explicitly hidden. Even if they are just empty `div`s, their presence in the DOM, especially when toggled alongside other interactive elements, adds unnecessary noise.
 **Action:** Always add `aria-hidden="true"` to visual backdrop or overlay elements that serve no semantic purpose and are not meant to be navigated to via keyboard.
+## 2024-05-24 - Custom Toggle Keyboard Accessibility
+**Learning:** In this vanilla JavaScript codebase, custom interactive components (like switches or custom radio groups) often rely solely on `click` listeners. This leaves keyboard users (navigating via Tab) unable to interact with the controls using Space or Enter.
+**Action:** When auditing or implementing custom UI components, explicitly bind `keydown` listeners for 'Space' and 'Enter' (with `e.preventDefault()`) to ensure complete keyboard accessibility, mirroring the logic of the `click` handlers.

--- a/public/src/map/RangeCircles.js
+++ b/public/src/map/RangeCircles.js
@@ -31,6 +31,17 @@ export class RangeCircles {
                 const option = e.target.closest('.unit-option');
                 if (option) this.setUnit(option.dataset.unit);
             });
+
+            // Palette A11y: Add keyboard navigation for unit toggles
+            toggle.addEventListener('keydown', (e) => {
+                if (e.key === ' ' || e.key === 'Enter') {
+                    const option = e.target.closest('.unit-option');
+                    if (option) {
+                        e.preventDefault();
+                        this.setUnit(option.dataset.unit);
+                    }
+                }
+            });
         }
 
         // Adjust visible circles based on zoom and map movement

--- a/public/src/map/WindOverlay.js
+++ b/public/src/map/WindOverlay.js
@@ -69,6 +69,13 @@ export class WindOverlay {
             : null;
         if (this._toggle && this._toggle.addEventListener) {
             this._toggle.addEventListener('click', () => this.setEnabled(!this.enabled));
+            // Palette A11y: Ensure keyboard users can activate the switch
+            this._toggle.addEventListener('keydown', (e) => {
+                if (e.key === ' ' || e.key === 'Enter') {
+                    e.preventDefault();
+                    this.setEnabled(!this.enabled);
+                }
+            });
         }
         this._updateToggleUI();
         this._resize();


### PR DESCRIPTION
- 💡 What: Added keyboard navigation support (Space/Enter) for the Wind overlay switch and the Distance unit toggles.
- 🎯 Why: Screen reader and keyboard-only users were unable to toggle these controls via keyboard.
- ♿ Accessibility: Improved keyboard navigation compliance for interactive custom toggle components.

---
*PR created automatically by Jules for task [7210208478981286798](https://jules.google.com/task/7210208478981286798) started by @2fst4u*