### PR TITLE
🌍 Globe: Refine Brazilian Portuguese dialect translations

### DIFF
--- a/.jules/globe.md
+++ b/.jules/globe.md
@@ -13,3 +13,6 @@
 ## 2024-06-06 - Extracting Hardcoded Concatenations
 **Learning:** Hardcoded strings in UI components often disguise themselves as simple concatenations (e.g. `` `R${race.round}: ${race.name} (${dateStr})` ``). When extracting these, it's crucial to map the raw JavaScript variable names to proper i18n placeholders (like `{{round}}`) to ensure correct interpolation across locales.
 **Action:** Always replace string template literals containing UI text with `i18n.t()` calls passing a context object that maps the local variables to the placeholder keys defined in the dictionary.
+## 2024-10-25 - Brazilian Portuguese Dialect Preferences
+**Learning:** The `pt-BR` locale initially contained European Portuguese (pt-PT) terms. For browser tabs, Brazilian Portuguese strictly uses "aba" instead of the European "separador". The word for a network connection is "conexão", not "ligação" (which means a phone call in Brazil).
+**Action:** Always use "aba" for tabs and "conexão" for network connections to ensure Brazilian terminology is maintained over European equivalents.

--- a/public/src/i18n/locales/pt-BR.js
+++ b/public/src/i18n/locales/pt-BR.js
@@ -79,7 +79,7 @@ export const ptBR = {
     liveAria: "Radar ao vivo",
     minutesAgo: "{{count}} min atras",
     minutesAgoPlural: "{{count}} mins atras",
-    connectionInstability: "Instabilidade de ligacao",
+    connectionInstability: "Instabilidade de conexão",
     serviceError: "Erro de servico",
     highTraffic: "Trafego elevado",
     rateLimitExceeded: "Limite de pedidos excedido. Pausa momentanea.",
@@ -112,14 +112,14 @@ export const ptBR = {
     title: "Politica de privacidade",
     closePolicy: "Fechar politica de privacidade",
     contentAria: "Conteudo da politica de privacidade",
-    opensInNewTab: "(abre em novo separador)",
+    opensInNewTab: "(abre em nova aba)",
     loadFailed:
       "Falha ao carregar a politica de privacidade. Tente novamente mais tarde.",
   },
   errors: {
-    connectionFailed: "Falha de ligacao",
-    retryConnection: "Tentar novamente ligacao",
-    retryingConnection: "Tentando novamente ligacao",
+    connectionFailed: "Falha de conexão",
+    retryConnection: "Tentar novamente a conexão",
+    retryingConnection: "Tentando conectar novamente",
     initFailed: "Falha ao iniciar a aplicacao.",
     scheduleUnavailable:
       "Não foi possível carregar o calendário de F1. A fonte de dados (api.jolpi.ca) está indisponível no momento. Por favor, tente novamente mais tarde.",


### PR DESCRIPTION
💡 **What:** 
Replaced occurrences of European Portuguese (pt-PT) terms with correct Brazilian Portuguese (pt-BR) terminology in the `pt-BR.js` locale file.
Specifically:
- Replaced "separador" with "aba" in the privacy policy section.
- Replaced "ligacao" with "conexão" across multiple error messages (e.g. "Instabilidade de conexão", "Falha de conexão", "Tentar novamente a conexão").

🎯 **Why:**
The current `pt-BR` locale incorrectly uses European Portuguese terminology. This makes the application feel foreign to Brazilian users.

🌐 **Nuance:**
In Brazil, the word "ligação" is used strictly to refer to a telephone call. A network or internet connection is a "conexão". Similarly, a browser tab is called an "aba" in Brazil, while "separador" is the European Portuguese term. These changes ensure the application feels truly native to Brazilian users.

---
*PR created automatically by Jules for task [9397359164476104935](https://jules.google.com/task/9397359164476104935) started by @2fst4u*