### PR TITLE
🌍 Globe: Fix translation for Brazilian Portuguese networking and tabs

### DIFF
--- a/.jules/globe.md
+++ b/.jules/globe.md
@@ -13,3 +13,6 @@
 ## 2024-06-06 - Extracting Hardcoded Concatenations
 **Learning:** Hardcoded strings in UI components often disguise themselves as simple concatenations (e.g. `` `R${race.round}: ${race.name} (${dateStr})` ``). When extracting these, it's crucial to map the raw JavaScript variable names to proper i18n placeholders (like `{{round}}`) to ensure correct interpolation across locales.
 **Action:** Always replace string template literals containing UI text with `i18n.t()` calls passing a context object that maps the local variables to the placeholder keys defined in the dictionary.
+## 2026-07-04 - Brazilian vs European Portuguese Terminology
+**Learning:** When localizing for Brazilian Portuguese (pt-BR), 'separador' (European for tab) must be 'aba', and 'ligação' (European for network connection, but meaning phone call in Brazil) must be 'conexão'.
+**Action:** Always verify proper contextual translation for tabs and connections in pt-BR, avoiding direct translations from European Portuguese.

--- a/public/src/i18n/locales/pt-BR.js
+++ b/public/src/i18n/locales/pt-BR.js
@@ -79,7 +79,7 @@ export const ptBR = {
     liveAria: "Radar ao vivo",
     minutesAgo: "{{count}} min atras",
     minutesAgoPlural: "{{count}} mins atras",
-    connectionInstability: "Instabilidade de ligacao",
+    connectionInstability: "Instabilidade de conexão",
     serviceError: "Erro de servico",
     highTraffic: "Trafego elevado",
     rateLimitExceeded: "Limite de pedidos excedido. Pausa momentanea.",
@@ -112,14 +112,14 @@ export const ptBR = {
     title: "Politica de privacidade",
     closePolicy: "Fechar politica de privacidade",
     contentAria: "Conteudo da politica de privacidade",
-    opensInNewTab: "(abre em novo separador)",
+    opensInNewTab: "(abre em nova aba)",
     loadFailed:
       "Falha ao carregar a politica de privacidade. Tente novamente mais tarde.",
   },
   errors: {
-    connectionFailed: "Falha de ligacao",
-    retryConnection: "Tentar novamente ligacao",
-    retryingConnection: "Tentando novamente ligacao",
+    connectionFailed: "Falha de conexão",
+    retryConnection: "Tentar novamente conexão",
+    retryingConnection: "Tentando novamente conexão",
     initFailed: "Falha ao iniciar a aplicacao.",
     scheduleUnavailable:
       "Não foi possível carregar o calendário de F1. A fonte de dados (api.jolpi.ca) está indisponível no momento. Por favor, tente novamente mais tarde.",


### PR DESCRIPTION
💡 What: Updated network connection strings to use "conexão" instead of "ligação", and updated the tab translation to use "aba" instead of "separador" in `pt-BR.js`. Added a new journal entry to `.jules/globe.md`.
🎯 Why: The previous translations were direct literal copies or used European Portuguese dialect ("ligação", "separador") instead of the local conventions used in Brazil. 
🌐 Nuance: In Brazilian Portuguese, "ligação" is almost exclusively used to mean a phone call. For networking or the internet, the correct term is "conexão". Similarly, a browser tab in Brazil is called an "aba", whereas in Portugal it is a "separador".

---
*PR created automatically by Jules for task [2369036542850942651](https://jules.google.com/task/2369036542850942651) started by @2fst4u*