### PR TITLE
🎨 Palette: Add focus visible styles for scrollable regions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-24 - Custom Toggle Keyboard Accessibility
 **Learning:** In this vanilla JavaScript codebase, custom interactive components (like switches or custom radio groups) often rely solely on `click` listeners. This leaves keyboard users (navigating via Tab) unable to interact with the controls using Space or Enter.
 **Action:** When auditing or implementing custom UI components, explicitly bind `keydown` listeners for 'Space' and 'Enter' (with `e.preventDefault()`) to ensure complete keyboard accessibility, mirroring the logic of the `click` handlers.
+## 2024-07-10 - Focus Indicators for Scrollable Regions
+**Learning:** Adding `tabindex="0"` to scrollable regions (like `.weather-timeline`, `.privacy-modal-content`, and `.leaflet-control-weather`) correctly makes them accessible to keyboard users for scrolling, but without explicit `:focus-visible` styles, the focus ring disappears entirely when navigating to these areas, causing users to lose track of their position.
+**Action:** When implementing custom scrollable regions with `tabindex="0"`, always explicitly define `:focus-visible` styles (e.g. an inset outline) to ensure keyboard users have visual confirmation of their focus state.

--- a/public/styles.css
+++ b/public/styles.css
@@ -2036,6 +2036,15 @@ button:disabled,
     box-shadow: 0 0 0 2px var(--color-bg), 0 0 0 4px var(--color-primary);
 }
 
+/* Accessibility: Ensure keyboard scrollable regions show focus */
+.weather-timeline:focus-visible,
+.privacy-modal-content:focus-visible,
+.leaflet-control-weather:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -2px;
+    border-radius: var(--radius-sm);
+}
+
 /* Ensure focus ring is visible on toggle buttons */
 .theme-toggle:focus-visible,
 .sidebar-toggle:focus-visible,


### PR DESCRIPTION
💡 **What:** Added a 2px explicit inset focus ring (`:focus-visible`) to custom scrollable elements that have `tabindex="0"` (`.weather-timeline`, `.privacy-modal-content`, and `.leaflet-control-weather`).

🎯 **Why:** Keyboard users navigating via the `Tab` key rely on visual focus indicators to know where they are on the page. While `tabindex="0"` correctly allows them to scroll these overflow regions, the lack of an explicit focus style caused the focus ring to disappear entirely when entering these areas, leading to a confusing and disorienting UX.

📸 **Before/After:**
*(Before)* Keyboard tabbing into the Privacy Policy modal content or Weather Timeline resulted in no visual change, making focus invisible.
*(After)* A clear, primary-colored inset ring appears when focusing these areas via keyboard.

♿ **Accessibility:** Fixes a critical WCAG 2.4.7 Focus Visible issue by explicitly defining styles for scrollable regions, ensuring the focus indicator is never lost.

---
*PR created automatically by Jules for task [13060319847476861763](https://jules.google.com/task/13060319847476861763) started by @2fst4u*