### PR TITLE
Fix timer sync in RadarErrorToast

### DIFF
--- a/public/src/map/RadarErrorToast.js
+++ b/public/src/map/RadarErrorToast.js
@@ -107,7 +107,7 @@ export class RadarErrorToast {
             // Fix Timer Sync: Use actual remaining time if a retry cooldown is active
             let duration = 0;
             if (this.rateLimitResetTime > Date.now()) {
-                duration = Math.ceil((this.rateLimitResetTime - Date.now()) / 1000);
+                duration = (this.rateLimitResetTime - Date.now()) / 1000;
                 duration = Math.max(1, duration); // Ensure at least 1s
             }
 


### PR DESCRIPTION
Fix timer sync in RadarErrorToast

Removed `Math.ceil` when computing the timer duration during a retry cooldown. Using exact floating point seconds ensures `endTime` aligns perfectly with `rateLimitResetTime` without artificial rounding inaccuracies, as originally intended.

---
*PR created automatically by Jules for task [24648003967482610](https://jules.google.com/task/24648003967482610) started by @2fst4u*