### PR TITLE
🎨 Palette: Add keyboard support for theme toggle buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-07-10 - Focus Indicators for Scrollable Regions
 **Learning:** Adding `tabindex="0"` to scrollable regions (like `.weather-timeline`, `.privacy-modal-content`, and `.leaflet-control-weather`) correctly makes them accessible to keyboard users for scrolling, but without explicit `:focus-visible` styles, the focus ring disappears entirely when navigating to these areas, causing users to lose track of their position.
 **Action:** When implementing custom scrollable regions with `tabindex="0"`, always explicitly define `:focus-visible` styles (e.g. an inset outline) to ensure keyboard users have visual confirmation of their focus state.
+## 2024-05-24 - Theme Toggle Keyboard Accessibility
+**Learning:** In vanilla JavaScript, custom theme toggle buttons (like those inside sidebars and mobile headers) that rely purely on `click` event listeners become inaccessible to keyboard users navigating via Tab, as they cannot trigger the action using Space or Enter.
+**Action:** When auditing or implementing interactive toggle components, explicitly bind `keydown` listeners for 'Space' and 'Enter' (with `e.preventDefault()`) to ensure complete keyboard accessibility, mirroring the functionality of the `click` handlers.

--- a/public/src/ui/ThemeManager.js
+++ b/public/src/ui/ThemeManager.js
@@ -57,12 +57,26 @@ export class ThemeManager {
         const toggleBtn = document.getElementById('themeToggle');
         if (toggleBtn) {
             toggleBtn.addEventListener('click', () => this.toggle());
+            // Palette A11y: Ensure keyboard users can activate the theme toggle switch
+            toggleBtn.addEventListener('keydown', (e) => {
+                if (e.key === ' ' || e.key === 'Enter') {
+                    e.preventDefault();
+                    this.toggle();
+                }
+            });
         }
 
         // Mobile header theme toggle
         const mobileToggleBtn = document.getElementById('mobileThemeToggle');
         if (mobileToggleBtn) {
             mobileToggleBtn.addEventListener('click', () => this.toggle());
+            // Palette A11y: Ensure keyboard users can activate the theme toggle switch
+            mobileToggleBtn.addEventListener('keydown', (e) => {
+                if (e.key === ' ' || e.key === 'Enter') {
+                    e.preventDefault();
+                    this.toggle();
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
💡 What: Added `keydown` event listeners for the `themeToggle` and `mobileThemeToggle` buttons.
🎯 Why: In this vanilla JavaScript codebase, the custom theme toggle buttons relied solely on `click` listeners. This left keyboard-only users unable to interact with the toggles using the Space or Enter keys.
📸 Before/After: Visuals remain unchanged, but the toggle now correctly changes the theme when receiving keyboard input.
♿ Accessibility: Ensures full keyboard accessibility for the primary theme controls on both desktop and mobile layouts.

---
*PR created automatically by Jules for task [17633909386534832354](https://jules.google.com/task/17633909386534832354) started by @2fst4u*