### PR TITLE
🎨 Palette: Add keyboard support to sidebar toggle switches

### DIFF
--- a/public/src/ui/SidebarManager.js
+++ b/public/src/ui/SidebarManager.js
@@ -19,6 +19,13 @@ export class SidebarManager {
                 e.stopPropagation();
                 this.toggle();
             });
+            // Palette A11y: Ensure keyboard users can activate the sidebar toggle switch
+            this.toggleBtn.addEventListener('keydown', (e) => {
+                if (e.key === ' ' || e.key === 'Enter') {
+                    e.preventDefault();
+                    this.toggle();
+                }
+            });
         }
 
         // Mobile header menu button
@@ -26,6 +33,13 @@ export class SidebarManager {
             this.mobileMenuBtn.addEventListener('click', (e) => {
                 e.stopPropagation();
                 this.toggle();
+            });
+            // Palette A11y: Ensure keyboard users can activate the mobile menu toggle switch
+            this.mobileMenuBtn.addEventListener('keydown', (e) => {
+                if (e.key === ' ' || e.key === 'Enter') {
+                    e.preventDefault();
+                    this.toggle();
+                }
             });
         }
 


### PR DESCRIPTION
💡 **What**: Added `keydown` event listeners to the sidebar toggle and mobile menu toggle buttons in `SidebarManager.js`.
🎯 **Why**: These custom UI components relied solely on `click` listeners. Keyboard users (navigating via Tab) were unable to activate them using 'Space' or 'Enter', preventing access to the sidebar on both desktop (when closed) and mobile.
📸 **Before/After**: Visually identical, interaction enhancement only.
♿ **Accessibility**: Restores keyboard accessibility to the application's primary navigation toggle by ensuring it behaves like a standard interactive element.

---
*PR created automatically by Jules for task [13464311582793589512](https://jules.google.com/task/13464311582793589512) started by @2fst4u*