### PR TITLE
🧹 Sweep: Remove unused getErrorHeaders import

### DIFF
--- a/tests/worker-edge-cases.test.js
+++ b/tests/worker-edge-cases.test.js
@@ -16,7 +16,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Import worker-utils for helper mocking
 import {
-    getErrorHeaders,
     getAllowedOrigin,
 } from '../src/worker-utils.js';
 


### PR DESCRIPTION
💡 What: Removed the unused import `getErrorHeaders` from `tests/worker-edge-cases.test.js`.
🎯 Why: `getErrorHeaders` was imported from `src/worker-utils.js` but was never actually referenced or used within the `worker-edge-cases.test.js` file, making it dead code.
🔬 Verification: Ran a global workspace text search (`grep -rn 'getErrorHeaders' tests/worker-edge-cases.test.js`) to guarantee it was unreferenced in the file outside of the import statement. Tests run locally (`pnpm test`) to ensure nothing broke.

---
*PR created automatically by Jules for task [14788888947797242437](https://jules.google.com/task/14788888947797242437) started by @2fst4u*