### PR TITLE
🎨 Palette: Improve current weather card wind direction spacing

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,15 +1,29 @@
 ## 2024-05-24 - Focus Management in Custom Selects
+
 **Learning:** In custom select dropdowns (like the language menu), always focusing the first element upon opening forces keyboard users to navigate back through the list to reach their current selection. The active element should be the initial focus target.
 **Action:** When implementing custom menus, always add focus management that targets the `.active` or `[aria-checked="true"]` item first, falling back to the first item if no active state is found.
+
 ## 2024-05-24 - Screen Reader Ghost Elements
+
 **Learning:** Purely visual overlay elements (like full-screen backdrops used to close sidebars on mobile) can be announced by screen readers as empty, interactive regions if not explicitly hidden. Even if they are just empty `div`s, their presence in the DOM, especially when toggled alongside other interactive elements, adds unnecessary noise.
 **Action:** Always add `aria-hidden="true"` to visual backdrop or overlay elements that serve no semantic purpose and are not meant to be navigated to via keyboard.
+
 ## 2024-05-24 - Custom Toggle Keyboard Accessibility
+
 **Learning:** In this vanilla JavaScript codebase, custom interactive components (like switches or custom radio groups) often rely solely on `click` listeners. This leaves keyboard users (navigating via Tab) unable to interact with the controls using Space or Enter.
 **Action:** When auditing or implementing custom UI components, explicitly bind `keydown` listeners for 'Space' and 'Enter' (with `e.preventDefault()`) to ensure complete keyboard accessibility, mirroring the logic of the `click` handlers.
+
 ## 2024-07-10 - Focus Indicators for Scrollable Regions
+
 **Learning:** Adding `tabindex="0"` to scrollable regions (like `.weather-timeline`, `.privacy-modal-content`, and `.leaflet-control-weather`) correctly makes them accessible to keyboard users for scrolling, but without explicit `:focus-visible` styles, the focus ring disappears entirely when navigating to these areas, causing users to lose track of their position.
 **Action:** When implementing custom scrollable regions with `tabindex="0"`, always explicitly define `:focus-visible` styles (e.g. an inset outline) to ensure keyboard users have visual confirmation of their focus state.
+
 ## 2024-05-24 - Theme Toggle Keyboard Accessibility
+
 **Learning:** In vanilla JavaScript, custom theme toggle buttons (like those inside sidebars and mobile headers) that rely purely on `click` event listeners become inaccessible to keyboard users navigating via Tab, as they cannot trigger the action using Space or Enter.
 **Action:** When auditing or implementing interactive toggle components, explicitly bind `keydown` listeners for 'Space' and 'Enter' (with `e.preventDefault()`) to ensure complete keyboard accessibility, mirroring the functionality of the `click` handlers.
+
+## 2024-07-15 - Inline Spacing in Shrink-to-Fit Flex Items
+
+**Learning:** Flex containers without explicit gaps or flexible base sizing can cause adjacent horizontal content blocks to collide in narrow widget views (such as map-based current weather widgets), reducing spacing between units (e.g. "km/h") and direction indicators (e.g. "NE") to 0px.
+**Action:** Ensure inline-related elements have guaranteed physical spacing (such as `margin-left: var(--spacing-sm)`) rather than relying on `margin-left: auto` in container dimensions that shrink to fit.

--- a/public/styles.css
+++ b/public/styles.css
@@ -553,6 +553,7 @@ body {
 .weather-sub {
     font-size: 0.6rem;
     color: var(--color-text-secondary);
+    margin-top: var(--spacing-xs);
 }
 
 .weather-timeline {
@@ -1804,7 +1805,7 @@ body {
     align-items: center;
     gap: 2px;
     min-width: 0;
-    margin-left: auto;
+    margin-left: var(--spacing-sm);
     opacity: 0.8;
 }
 


### PR DESCRIPTION
### 💡 What
This change improves the layout and visual presentation of the current conditions widget. Specifically, it ensures a minimum of 8px horizontal separation (using standard `--spacing-sm` variables) between wind speed units (e.g., "7 km/h") and the corresponding direction cardinal (e.g., "NE ↙"). It also ensures vertical separation on the side panel's weather card between the stacked wind components using `--spacing-xs`.

### 🎯 Why
In narrower viewports or inline layout contexts (such as on-map current conditions boxes), the wind direction label collided tightly with the speed/unit label due to `margin-left: auto` collapsing down to zero in shrink-to-fit flex elements. Using guaranteed spacing values prevents layout collisions and significantly enhances readability.

### 📸 Before/After
- **Before:** Wind display rendered tightly adjacent to the metric units, e.g., `7 km/hNE ↙` with zero spacing.
- **After:** Wind display renders with appropriate, clear visual margins: `7 km/h   NE ↙`.

### ♿ Accessibility
Keyboard navigation, focus indicators, and visual spacing indicators are aligned with standard visual hierarchy rules. Ensures easier reading of text on small screens.

Fixes #755

---
*PR created automatically by Jules for task [10454730929370870061](https://jules.google.com/task/10454730929370870061) started by @2fst4u*