### PR TITLE
🎨 Palette: Add keyboard support for radar playback controls

### DIFF
--- a/public/src/map/RadarPlayback.js
+++ b/public/src/map/RadarPlayback.js
@@ -32,9 +32,23 @@ export class RadarPlayback {
 
         if (this.ui.playBtn) {
             this.ui.playBtn.addEventListener('click', () => this.togglePlay());
+            // Palette A11y: Ensure keyboard users can activate the play button
+            this.ui.playBtn.addEventListener('keydown', (e) => {
+                if (e.key === ' ' || e.key === 'Enter') {
+                    e.preventDefault();
+                    this.togglePlay();
+                }
+            });
         }
         if (this.ui.speedBtn) {
             this.ui.speedBtn.addEventListener('click', () => this.cycleSpeed());
+            // Palette A11y: Ensure keyboard users can activate the speed button
+            this.ui.speedBtn.addEventListener('keydown', (e) => {
+                if (e.key === ' ' || e.key === 'Enter') {
+                    e.preventDefault();
+                    this.cycleSpeed();
+                }
+            });
         }
 
         this.updateSpeedLabel();


### PR DESCRIPTION
💡 What: Added `keydown` event listeners to the radar playback controls (`playBtn` and `speedBtn`) to trigger their respective actions when the 'Space' or 'Enter' keys are pressed.

🎯 Why: In this vanilla JavaScript codebase, these custom interactive components relied solely on `click` listeners. This leaves keyboard users (navigating via Tab) unable to interact with the controls using Space or Enter, creating an accessibility barrier.

📸 Before/After: No visual changes; strictly an interaction and accessibility enhancement.

♿ Accessibility: Ensure complete keyboard accessibility for the radar playback controls, mimicking the behavior of native buttons or properly configured custom elements when accessed via keyboard (Tab navigation).

---
*PR created automatically by Jules for task [16562253875488876435](https://jules.google.com/task/16562253875488876435) started by @2fst4u*