### PR TITLE
🧹 Sweep: Remove unused weather icon CSS classes

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1734,25 +1734,6 @@ body {
 
 
 /* Weather Icon Colors */
-.icon-temp {
-    color: #ef4444;
-    /* Red-500 */
-}
-
-.icon-humidity {
-    color: #3b82f6;
-    /* Blue-500 */
-}
-
-.icon-wind {
-    color: #64748b;
-    /* Slate-500 */
-}
-
-.icon-rain {
-    color: #3b82f6;
-    /* Blue-500 for rain/precip */
-}
 
 .icon-wind-arrow {
     width: 0.8em;


### PR DESCRIPTION
💡 **What**: Removed four CSS class definitions (`.icon-temp`, `.icon-humidity`, `.icon-wind`, and `.icon-rain`) from `public/styles.css`.
🎯 **Why**: These classes were orphaned unused assets. They were no longer used anywhere in the codebase.
🔬 **Verification**: 
- Ran a global workspace text search (`find_unused_css.js` and `grep`) across the `src/`, `public/`, and `tests/` directories to confirm these classes were unused.
- Ran `pnpm test` (all 887 tests passed) to ensure application functionality wasn't impacted.

---
*PR created automatically by Jules for task [10888296049201620139](https://jules.google.com/task/10888296049201620139) started by @2fst4u*