### PR TITLE
fix: RadarErrorToast timer sync cooldown math

### DIFF
--- a/public/src/map/RadarErrorToast.js
+++ b/public/src/map/RadarErrorToast.js
@@ -107,7 +107,7 @@ export class RadarErrorToast {
             // Fix Timer Sync: Use actual remaining time if a retry cooldown is active
             let duration = 0;
             if (this.rateLimitResetTime > Date.now()) {
-                duration = (this.rateLimitResetTime - Date.now()) / 1000;
+                duration = Math.ceil((this.rateLimitResetTime - Date.now()) / 1000);
                 duration = Math.max(1, duration); // Ensure at least 1s
             }
 


### PR DESCRIPTION
This change updates the `duration` calculation in `RadarErrorToast.js` to correctly round up to integer seconds using `Math.ceil()` when determining the active cooldown duration, preventing floating-point bugs in the UI countdown.

---
*PR created automatically by Jules for task [11575860149373163214](https://jules.google.com/task/11575860149373163214) started by @2fst4u*