### PR TITLE
🧪 testing improvement: Add error test for radar polling updates

### DIFF
--- a/tests/weather-radar-polling.test.js
+++ b/tests/weather-radar-polling.test.js
@@ -203,6 +203,25 @@ describe('WeatherRadar Polling Logic', () => {
             expect(applySpy).not.toHaveBeenCalled();
             expect(radar.pendingFrames).toHaveLength(2);
         });
+
+        it('should catch and log errors during fetch without crashing', async () => {
+            const error = new Error('Fetch failed');
+
+            // Because radar.polling.fetchFrames uses RadarFrames.getFramesFromApi which catches its own errors
+            // and returns { frames: [], pastCount: 0 } instead of throwing, we need to mock radar.polling.fetchFrames
+            // directly to test RadarPolling's catch block in checkForUpdates.
+            radar.polling.fetchFrames = vi.fn().mockRejectedValueOnce(error);
+
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const applySpy = vi.spyOn(radar, 'applyFrameUpdate');
+
+            await expect(radar.checkForUpdates()).resolves.toBeUndefined();
+
+            expect(consoleSpy).toHaveBeenCalledWith('Failed to check for radar updates:', error);
+            expect(applySpy).not.toHaveBeenCalled();
+
+            consoleSpy.mockRestore();
+        });
     });
 
     describe('Polling Control', () => {


### PR DESCRIPTION
🎯 **What:** Added an error test case in `tests/weather-radar-polling.test.js` to cover the scenario where `radar.polling.fetchFrames` fails.
📊 **Coverage:** The catch block in `RadarPolling.checkForUpdates` is now tested.
✨ **Result:** Ensures the system correctly logs the error and does not crash when the fetch operation rejects, increasing reliability.

---
*PR created automatically by Jules for task [1338609209571013785](https://jules.google.com/task/1338609209571013785) started by @2fst4u*