### PR TITLE
🧪 Test RadarErrorToast network failure path

### DIFF
--- a/tests/radar-error-toast.test.js
+++ b/tests/radar-error-toast.test.js
@@ -115,4 +115,26 @@ describe('RadarErrorToast edge cases', () => {
 
         i18nSpy.mockRestore();
     });
+
+    it('handleTileError calls updateErrorUI on fetch network rejection', async () => {
+        toast.failedTiles.add('tile');
+        toast.isCheckingStatus = false;
+
+        const error = new Error('Network error');
+        vi.stubGlobal('fetch', vi.fn(() => Promise.reject(error)));
+
+        toast.updateErrorUI = vi.fn();
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        toast.handleTileError({ tile: 'tile' });
+
+        // Let the promise reject
+        await new Promise(r => setImmediate(r));
+
+        expect(toast.isCheckingStatus).toBe(false);
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Network error during API status check:', error);
+        expect(toast.updateErrorUI).toHaveBeenCalled();
+
+        consoleErrorSpy.mockRestore();
+    });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap in `RadarErrorToast.js` where the network failure (Promise rejection) in `handleTileError` was not tested has been addressed.
📊 **Coverage:** Now the `catch` block of the `fetch` call in `handleTileError` is tested, ensuring that `updateErrorUI` is correctly called, `isCheckingStatus` is reset to false, and the error is properly logged.
✨ **Result:** Increased test coverage and confidence that network errors are properly caught and the UI is updated.

---
*PR created automatically by Jules for task [465011174947803440](https://jules.google.com/task/465011174947803440) started by @2fst4u*