### PR TITLE
🧪 Add dedicated tests for SafeStorage helper

### DIFF
--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SafeStorage } from '../public/src/utils/storage.js';
+
+describe('SafeStorage', () => {
+  const mockLocalStorage = {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', mockLocalStorage);
+    mockLocalStorage.getItem.mockReset();
+    mockLocalStorage.setItem.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('gets item safely when localStorage works', () => {
+    mockLocalStorage.getItem.mockReturnValue('test-value');
+    const result = SafeStorage.getItem('test-key');
+    expect(result).toBe('test-value');
+    expect(mockLocalStorage.getItem).toHaveBeenCalledWith('test-key');
+  });
+
+  it('sets item safely when localStorage works', () => {
+    SafeStorage.setItem('key', 'value');
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith('key', 'value');
+  });
+
+  it('returns null when localStorage.getItem throws (e.g. disabled)', () => {
+    mockLocalStorage.getItem.mockImplementation(() => {
+      throw new Error('Access Denied');
+    });
+    const result = SafeStorage.getItem('key');
+    expect(result).toBeNull();
+  });
+
+  it('fails silently when localStorage.setItem throws', () => {
+    mockLocalStorage.setItem.mockImplementation(() => {
+      throw new Error('Quota Exceeded');
+    });
+    expect(() => SafeStorage.setItem('key', 'value')).not.toThrow();
+  });
+});

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { escapeHtml } from '../public/src/utils/escapeHtml.js';
-import { SafeStorage } from '../public/src/utils/storage.js';
 
 describe('Utility Functions', () => {
 
@@ -32,50 +31,6 @@ describe('Utility Functions', () => {
     it('leaves safe strings untouched', () => {
       const input = 'Hello World! 123';
       expect(escapeHtml(input)).toBe(input);
-    });
-  });
-
-  describe('SafeStorage', () => {
-    const mockLocalStorage = {
-      getItem: vi.fn(),
-      setItem: vi.fn(),
-    };
-
-    beforeEach(() => {
-      vi.stubGlobal('localStorage', mockLocalStorage);
-      mockLocalStorage.getItem.mockReset();
-      mockLocalStorage.setItem.mockReset();
-    });
-
-    afterEach(() => {
-      vi.unstubAllGlobals();
-    });
-
-    it('gets item safely when localStorage works', () => {
-      mockLocalStorage.getItem.mockReturnValue('test-value');
-      const result = SafeStorage.getItem('test-key');
-      expect(result).toBe('test-value');
-      expect(mockLocalStorage.getItem).toHaveBeenCalledWith('test-key');
-    });
-
-    it('sets item safely when localStorage works', () => {
-      SafeStorage.setItem('key', 'value');
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith('key', 'value');
-    });
-
-    it('returns null when localStorage.getItem throws (e.g. disabled)', () => {
-      mockLocalStorage.getItem.mockImplementation(() => {
-        throw new Error('Access Denied');
-      });
-      const result = SafeStorage.getItem('key');
-      expect(result).toBeNull();
-    });
-
-    it('fails silently when localStorage.setItem throws', () => {
-      mockLocalStorage.setItem.mockImplementation(() => {
-        throw new Error('Quota Exceeded');
-      });
-      expect(() => SafeStorage.setItem('key', 'value')).not.toThrow();
     });
   });
 


### PR DESCRIPTION
🎯 **What:** The issue flagged that there were missing tests for the `SafeStorage` wrapper. I discovered the tests actually existed, but were nested inappropriately inside `tests/utils.test.js` making them hard to find and muddying the utility tests. This PR extracts them into a dedicated `tests/storage.test.js` file.

📊 **Coverage:**
- Tests the happy path for `getItem` returning stored values
- Tests the happy path for `setItem` storing values
- Tests the error path where `localStorage.getItem` throws (e.g. storage disabled by privacy settings) verifying it securely returns `null`
- Tests the error path where `localStorage.setItem` throws (e.g. quota exceeded) verifying it fails silently and safely without breaking the app.

✨ **Result:** Test coverage for `public/src/utils/storage.js` remains at 100%, and the test suite is better organized with dedicated files for dedicated utilities, resolving the reported testing gap.

---
*PR created automatically by Jules for task [10623415576261355940](https://jules.google.com/task/10623415576261355940) started by @2fst4u*