### PR TITLE
🧪 Testing Improvement: RadarFrames API fetch failure handling

### DIFF
--- a/tests/radar-frames.test.js
+++ b/tests/radar-frames.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RadarFrames } from '../public/src/map/RadarFrames.js';
+import { CONFIG } from '../public/src/config.js';
+
+// Mock global fetch
+const originalFetch = global.fetch;
+
+describe('RadarFrames.getFramesFromApi', () => {
+    beforeEach(() => {
+        global.fetch = vi.fn();
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        vi.restoreAllMocks();
+    });
+
+    it('returns formatted frames and pastCount on successful fetch', async () => {
+        const mockData = {
+            radar: {
+                past: [
+                    { time: 100, path: '/past1' },
+                    { time: 200, path: '/past2' }
+                ],
+                nowcast: [
+                    { time: 300, path: '/now1' }
+                ]
+            }
+        };
+
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockData
+        });
+
+        const result = await RadarFrames.getFramesFromApi();
+
+        expect(global.fetch).toHaveBeenCalledWith(CONFIG.rainViewerApi, expect.objectContaining({
+            signal: expect.any(AbortSignal)
+        }));
+
+        expect(result.pastCount).toBe(2);
+        expect(result.frames).toHaveLength(3);
+
+        expect(result.frames[0]).toEqual({
+            time: 100,
+            path: '/past1',
+            url: '/api/tiles/past1/512/{z}/{x}/{y}/2/1_1.png'
+        });
+
+        expect(result.frames[2]).toEqual({
+            time: 300,
+            path: '/now1',
+            url: '/api/tiles/now1/512/{z}/{x}/{y}/2/1_1.png'
+        });
+    });
+
+    it('returns empty frames when API responds with an error status (e.g. 500)', async () => {
+        global.fetch.mockResolvedValueOnce({
+            ok: false,
+            status: 500
+        });
+
+        const result = await RadarFrames.getFramesFromApi();
+
+        expect(result).toEqual({ frames: [], pastCount: 0 });
+        expect(console.error).toHaveBeenCalledWith('RainViewer API error: 500');
+    });
+
+    it('returns empty frames when fetch throws an error (network error)', async () => {
+        const networkError = new Error('Network failure');
+        global.fetch.mockRejectedValueOnce(networkError);
+
+        const result = await RadarFrames.getFramesFromApi();
+
+        expect(result).toEqual({ frames: [], pastCount: 0 });
+        expect(console.error).toHaveBeenCalledWith('Failed to fetch radar frames:', networkError);
+    });
+
+    it('handles successful response with missing data structures gracefully', async () => {
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({})
+        });
+
+        const result = await RadarFrames.getFramesFromApi();
+
+        expect(result).toEqual({ frames: [], pastCount: 0 });
+    });
+});


### PR DESCRIPTION
🎯 **What:** The `RadarFrames.getFramesFromApi()` method lacked test coverage for fetch failures, meaning network errors or HTTP status code failures (like 500) were untested. This patch introduces `tests/radar-frames.test.js` to cover these scenarios using Vitest.

📊 **Coverage:** The new tests cover:
- Successful fetch response containing both `past` and `nowcast` arrays
- Handing of non-ok HTTP status codes (e.g., 500 Internal Server Error)
- Handling of raw network errors (rejected Fetch promises)
- Graceful handling when the response data structure is missing

✨ **Result:** Test coverage for `RadarFrames.js` is significantly improved. Error boundaries for API fetching are properly verified, ensuring that failures gracefully resolve to empty data structures and don't crash the application, supporting confident refactoring in the future.

---
*PR created automatically by Jules for task [4541840837957867911](https://jules.google.com/task/4541840837957867911) started by @2fst4u*