### PR TITLE
🎨 Palette: Add focus visible styles for Mapbox weather widget

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -37,3 +37,8 @@
 
 **Learning:** When replacing `display: none` with `visibility: hidden` to enable CSS transitions on UI components (like dropdown menus), ensure the element is absolutely positioned (`position: absolute` or `position: fixed`) so it doesn't disrupt document layout. `visibility: hidden` preserves the element's box in layout, but correctly removes it from the accessibility tree mimicking `display: none` for screen readers.
 **Action:** When animating display states, prefer `opacity` and `visibility: hidden` with `position: absolute` over `display: none`.
+
+## 2024-11-20 - Multi-Renderer CSS Targeting
+
+**Learning:** When implementing custom UI controls that are compatible with both Leaflet and Mapbox GL JS (like `MapWeatherWidget`), the controls are wrapped in renderer-specific container classes. Writing CSS (like `:focus-visible` for accessibility) that targets only one of these classes (e.g., `.leaflet-control-weather`) will cause the style to fail when the other renderer (e.g., Mapbox) is active.
+**Action:** Always ensure CSS styles explicitly target both renderer-specific container classes (e.g., `.leaflet-control-weather:focus-visible` and `.mapboxgl-ctrl-group:focus-visible`) to maintain consistent styling and accessibility across both map engines.

--- a/public/styles.css
+++ b/public/styles.css
@@ -2027,7 +2027,8 @@ button:disabled,
 /* Accessibility: Ensure keyboard scrollable regions show focus */
 .weather-timeline:focus-visible,
 .privacy-modal-content:focus-visible,
-.leaflet-control-weather:focus-visible {
+.leaflet-control-weather:focus-visible,
+.mapboxgl-ctrl-group:focus-visible {
     outline: 2px solid var(--color-primary);
     outline-offset: -2px;
     border-radius: var(--radius-sm);


### PR DESCRIPTION
💡 **What:** Added `:focus-visible` styles to the `.mapboxgl-ctrl-group` CSS class used by the `MapWeatherWidget`.
🎯 **Why:** To ensure the current weather widget displays a visible focus indicator when a user navigates to it via keyboard while the application is using the Mapbox GL JS renderer (the primary map engine). It previously only targeted the Leaflet fallback class.
📸 **Before/After:** The focus ring now appears when tabbing to the widget, previously it was invisible on Mapbox.
♿ **Accessibility:** Fixes a WCAG violation (2.4.7 Focus Visible) where keyboard focus was lost when navigating into the scrollable widget container.

---
*PR created automatically by Jules for task [17397322892671241984](https://jules.google.com/task/17397322892671241984) started by @2fst4u*