### PR TITLE
🧹 Sweep: Remove unused export for PRODUCTION_DOMAIN

### DIFF
--- a/src/worker-utils.js
+++ b/src/worker-utils.js
@@ -2,7 +2,7 @@
 
 export const VALID_API_PATH_REGEX = /^[a-zA-Z0-9/._-]*$/;
 export const VALID_TRACK_ID_REGEX = /^[a-z0-9-]+$/;
-export const PRODUCTION_DOMAIN = 'https://circuit-weather.racing';
+const PRODUCTION_DOMAIN = 'https://circuit-weather.racing';
 const ALLOWED_ORIGIN_LOCALHOST_REGEX = /^http:\/\/localhost(:\d+)?(\/|$)/;
 const ALLOWED_ORIGIN_127_REGEX = /^http:\/\/127\.0\.0\.1(:\d+)?(\/|$)/;
 const ALLOWED_PREVIEW_REGEX = /^https:\/\/(?:[a-zA-Z0-9-]+\.)*circuit-weather\.pages\.dev(?:\/|$)/;

--- a/tests/worker-security.test.js
+++ b/tests/worker-security.test.js
@@ -3,9 +3,10 @@ import {
   checkRequestSource,
   checkFetchDest,
   getAllowedOrigin,
-  VALID_API_PATH_REGEX,
-  PRODUCTION_DOMAIN
+  VALID_API_PATH_REGEX
 } from '../src/worker-utils.js';
+
+const PRODUCTION_DOMAIN = 'https://circuit-weather.racing';
 
 // Mock Request object helper
 const createRequest = (headers = {}) => ({

--- a/tests/worker-utils-helpers.test.js
+++ b/tests/worker-utils-helpers.test.js
@@ -3,9 +3,10 @@ import {
     getErrorHeaders,
     getEmptyRadarResponse,
     calculateHash,
-    API_SECURITY_HEADERS,
-    PRODUCTION_DOMAIN
+    API_SECURITY_HEADERS
 } from '../src/worker-utils.js';
+
+const PRODUCTION_DOMAIN = 'https://circuit-weather.racing';
 
 // Mock Request helper
 const createRequest = (headers = {}) => ({


### PR DESCRIPTION
🎯 **What:** Removed the `export` keyword from `PRODUCTION_DOMAIN` in `src/worker-utils.js` and updated tests that relied on it.
💡 **Why:** `PRODUCTION_DOMAIN` is only used internally within `src/worker-utils.js` and does not need to be exported, reducing the public API surface of the module and improving encapsulation.
✅ **Verification:** Verified that all tests pass (`pnpm test` successfully completed with all 896 tests passing) after removing the export and fixing test imports.
✨ **Result:** Improved maintainability and encapsulation by keeping `PRODUCTION_DOMAIN` private to its module without breaking existing tests.

---
*PR created automatically by Jules for task [918828836912324031](https://jules.google.com/task/918828836912324031) started by @2fst4u*