### PR TITLE
🧹 Sweep: finish the unused-export pass without losing coverage

### DIFF
--- a/public/src/api/openf1.js
+++ b/public/src/api/openf1.js
@@ -53,7 +53,7 @@ const OPENF1_TIMEOUT_MS = 8000;
  * timezone (e.g. "2026-03-22T15:00:00"), we apply gmtOffset ("03:00:00" /
  * "-05:00:00") to derive UTC.
  */
-export function openF1ToErgastDateTime(dateStr, gmtOffset) {
+function openF1ToErgastDateTime(dateStr, gmtOffset) {
     if (!dateStr) return null;
 
     // If date_start already carries a timezone (trailing Z, or ±HH:MM after the time),

--- a/public/src/i18n/index.js
+++ b/public/src/i18n/index.js
@@ -15,6 +15,11 @@ import { nl } from './locales/nl.js';
 import { ptBR } from './locales/pt-BR.js';
 import { zhCN } from './locales/zh-CN.js';
 
+// Exported for tests/i18n-locales-completeness.test.js, which checks every
+// locale against `en`. It needs this aggregate rather than the individual
+// locale modules — importing those separately would silently skip a newly
+// added locale, which is exactly what that test exists to catch. Intentionally
+// exported despite having no other importer: do not sweep it.
 export const TRANSLATIONS = {
     en,
     'en-GB': enGB,

--- a/tests/helpers/constants.js
+++ b/tests/helpers/constants.js
@@ -1,0 +1,7 @@
+// Shared constants for the worker test suites.
+//
+// PRODUCTION_DOMAIN is deliberately not exported from src/worker-utils.js (it is
+// module-private there), so the tests keep their own copy. Keeping that copy in
+// one place means a domain change is a two-line edit rather than a hunt through
+// every worker test file.
+export const PRODUCTION_DOMAIN = 'https://circuit-weather.racing';

--- a/tests/openf1.test.js
+++ b/tests/openf1.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { openF1ToErgastDateTime, fetchOpenF1Schedule } from '../public/src/api/openf1.js';
+import { fetchOpenF1Schedule } from '../public/src/api/openf1.js';
 
 describe('openf1', () => {
     let mockFetch;
@@ -12,57 +12,75 @@ describe('openf1', () => {
     afterEach(() => {
         vi.restoreAllMocks();
     });
-    describe('openF1ToErgastDateTime', () => {
-        it('converts a positive GMT offset to UTC', () => {
+
+    // fetchOpenF1Schedule requests meetings then sessions; queue both responses
+    // and return the transformed races.
+    const scheduleFrom = (meetings, sessions) => {
+        mockFetch
+            .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(meetings) })
+            .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(sessions) });
+        return fetchOpenF1Schedule();
+    };
+
+    // The datetime conversion is an internal helper, exercised here through the
+    // Race session of a minimal one-meeting schedule.
+    describe('session datetime conversion', () => {
+        const raceAt = (dateStart, gmtOffset) => scheduleFrom(
+            [{ meeting_key: 1, meeting_name: 'Test GP', date_start: '2026-01-01T00:00:00Z' }],
+            [{ meeting_key: 1, session_type: 'Race', date_start: dateStart, gmt_offset: gmtOffset }],
+        );
+
+        it('converts a positive GMT offset to UTC', async () => {
             // 15:00 local at UTC+3 → 12:00 UTC
-            expect(openF1ToErgastDateTime('2026-03-22T15:00:00', '03:00:00')).toEqual({
-                date: '2026-03-22',
-                time: '12:00:00Z',
-            });
+            const [race] = await raceAt('2026-03-22T15:00:00', '03:00:00');
+            expect(race.date).toBe('2026-03-22');
+            expect(race.time).toBe('12:00:00Z');
         });
 
-        it('converts a negative GMT offset to UTC', () => {
+        it('converts a negative GMT offset to UTC', async () => {
             // 14:00 local at UTC-5 → 19:00 UTC
-            expect(openF1ToErgastDateTime('2026-10-19T14:00:00', '-05:00:00')).toEqual({
-                date: '2026-10-19',
-                time: '19:00:00Z',
-            });
+            const [race] = await raceAt('2026-10-19T14:00:00', '-05:00:00');
+            expect(race.date).toBe('2026-10-19');
+            expect(race.time).toBe('19:00:00Z');
         });
 
-        it('rolls over to the next day when offset crosses midnight', () => {
+        it('rolls over to the next day when offset crosses midnight', async () => {
             // 23:00 local at UTC-5 → 04:00 UTC next day
-            expect(openF1ToErgastDateTime('2026-10-19T23:00:00', '-05:00:00')).toEqual({
-                date: '2026-10-20',
-                time: '04:00:00Z',
-            });
+            const [race] = await raceAt('2026-10-19T23:00:00', '-05:00:00');
+            expect(race.date).toBe('2026-10-20');
+            expect(race.time).toBe('04:00:00Z');
         });
 
-        it('parses an ISO string that already carries its timezone offset', () => {
+        it('parses an ISO string that already carries its timezone offset', async () => {
             // OpenF1 normally returns date_start with an embedded offset; gmt_offset is ignored.
             // 15:00 at +03:00 → 12:00 UTC
-            expect(openF1ToErgastDateTime('2026-03-22T15:00:00+03:00', '03:00:00')).toEqual({
-                date: '2026-03-22',
-                time: '12:00:00Z',
-            });
+            const [race] = await raceAt('2026-03-22T15:00:00+03:00', '03:00:00');
+            expect(race.date).toBe('2026-03-22');
+            expect(race.time).toBe('12:00:00Z');
         });
 
-        it('parses an ISO string with a trailing Z', () => {
-            expect(openF1ToErgastDateTime('2026-03-22T12:00:00Z', null)).toEqual({
-                date: '2026-03-22',
-                time: '12:00:00Z',
-            });
+        it('parses an ISO string with a trailing Z', async () => {
+            const [race] = await raceAt('2026-03-22T12:00:00Z', null);
+            expect(race.date).toBe('2026-03-22');
+            expect(race.time).toBe('12:00:00Z');
         });
 
-        it('returns null when no timezone is embedded and no gmt_offset is given', () => {
-            expect(openF1ToErgastDateTime('2026-03-22T15:00:00', null)).toBeNull();
+        it('skips the session when no timezone is embedded and no gmt_offset is given', async () => {
+            const [race] = await raceAt('2026-03-22T15:00:00', null);
+            expect(race.date).toBeUndefined();
+            expect(race.time).toBeUndefined();
         });
 
-        it('returns null for an absent datetime', () => {
-            expect(openF1ToErgastDateTime(null, '03:00:00')).toBeNull();
+        it('skips the session for an absent datetime', async () => {
+            const [race] = await raceAt(null, '03:00:00');
+            expect(race.date).toBeUndefined();
+            expect(race.time).toBeUndefined();
         });
 
-        it('returns null when the resulting datetime is invalid', () => {
-            expect(openF1ToErgastDateTime('invalid-date', '03:00:00')).toBeNull();
+        it('skips the session when the resulting datetime is invalid', async () => {
+            const [race] = await raceAt('invalid-date', '03:00:00');
+            expect(race.date).toBeUndefined();
+            expect(race.time).toBeUndefined();
         });
     });
 
@@ -106,10 +124,7 @@ describe('openf1', () => {
         ];
 
         it('filters out non-race meetings and sorts by date', async () => {
-            mockFetch
-                .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(meetings) })
-                .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(sessions) });
-            const races = await fetchOpenF1Schedule();
+            const races = await scheduleFrom(meetings, sessions);
 
             expect(races).toHaveLength(2);
             // Sorted chronologically: Bahrain (round 1) before Saudi (round 2)
@@ -120,19 +135,13 @@ describe('openf1', () => {
         });
 
         it('maps circuit_key to the Ergast circuitId', async () => {
-            mockFetch
-                .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(meetings) })
-                .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(sessions) });
-            const races = await fetchOpenF1Schedule();
+            const races = await scheduleFrom(meetings, sessions);
             expect(races[0].Circuit.circuitId).toBe('bahrain');
             expect(races[1].Circuit.circuitId).toBe('jeddah');
         });
 
         it('produces Ergast-shaped session fields with UTC times', async () => {
-            mockFetch
-                .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(meetings) })
-                .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(sessions) });
-            const races = await fetchOpenF1Schedule();
+            const races = await scheduleFrom(meetings, sessions);
             const bahrain = races[0];
             expect(bahrain.FirstPractice).toEqual({ date: '2026-03-20', time: '08:30:00Z' });
             expect(bahrain.Qualifying).toEqual({ date: '2026-03-21', time: '12:00:00Z' });
@@ -152,10 +161,7 @@ describe('openf1', () => {
                 { meeting_key: 10, session_type: 'Qualifying', date_start: '2026-07-03T14:00:00Z', gmt_offset: null },
                 { meeting_key: 10, session_type: 'Race', date_start: '2026-07-04T15:00:00Z', gmt_offset: null },
             ];
-            mockFetch
-                .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(allSessionsMtg) })
-                .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(allSessions) });
-            const races = await fetchOpenF1Schedule();
+            const races = await scheduleFrom(allSessionsMtg, allSessions);
             const race = races[0];
 
             expect(race.FirstPractice).toEqual({ date: '2026-07-01', time: '10:00:00Z' });
@@ -176,10 +182,7 @@ describe('openf1', () => {
                 { meeting_key: 3, session_type: 'Qualifying', date_start: '2026-05-02T15:00:00', gmt_offset: null },
                 { meeting_key: 3, session_type: 'Race', date_start: '2026-05-03T15:00:00', gmt_offset: '03:00:00' },
             ];
-            mockFetch
-                .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mtgs) })
-                .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(sess) });
-            const races = await fetchOpenF1Schedule();
+            const races = await scheduleFrom(mtgs, sess);
             expect(races).toHaveLength(1);
             expect(races[0].FirstPractice).toBeUndefined();
             expect(races[0].Qualifying).toBeUndefined();
@@ -187,10 +190,7 @@ describe('openf1', () => {
         });
 
         it('leaves coordinates empty (the map centre is derived from the track GeoJSON)', async () => {
-            mockFetch
-                .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(meetings) })
-                .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(sessions) });
-            const races = await fetchOpenF1Schedule();
+            const races = await scheduleFrom(meetings, sessions);
             expect(races[0].Circuit.Location.lat).toBe('');
             expect(races[0].Circuit.Location.long).toBe('');
         });
@@ -198,20 +198,14 @@ describe('openf1', () => {
         it('leaves circuitId null for an unknown circuit', async () => {
             const unknown = [{ meeting_key: 5, meeting_name: 'Mystery GP', circuit_short_name: 'Atlantis', date_start: '2026-05-01T12:00:00' }];
             const unknownSessions = [{ meeting_key: 5, session_type: 'Race', date_start: '2026-05-01T12:00:00', gmt_offset: '00:00:00' }];
-            mockFetch
-                .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(unknown) })
-                .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(unknownSessions) });
-            const races = await fetchOpenF1Schedule();
+            const races = await scheduleFrom(unknown, unknownSessions);
             expect(races[0].Circuit.circuitId).toBeNull();
         });
 
         it('handles a meeting with no sessions safely', async () => {
             const emptySessionMtg = [{ meeting_key: 6, meeting_name: 'No Sessions GP', date_start: '2026-06-01T12:00:00' }];
             const emptySessions = [];
-            mockFetch
-                .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(emptySessionMtg) })
-                .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(emptySessions) });
-            const races = await fetchOpenF1Schedule();
+            const races = await scheduleFrom(emptySessionMtg, emptySessions);
             expect(races).toHaveLength(0); // Because we filter out meetings with no "Race" session
         });
     });

--- a/tests/worker-security.test.js
+++ b/tests/worker-security.test.js
@@ -5,8 +5,7 @@ import {
   getAllowedOrigin,
   VALID_API_PATH_REGEX
 } from '../src/worker-utils.js';
-
-const PRODUCTION_DOMAIN = 'https://circuit-weather.racing';
+import { PRODUCTION_DOMAIN } from './helpers/constants.js';
 
 // Mock Request object helper
 const createRequest = (headers = {}) => ({

--- a/tests/worker-utils-helpers.test.js
+++ b/tests/worker-utils-helpers.test.js
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
+    createErrorResponse,
     getEmptyRadarResponse,
     calculateHash,
     API_SECURITY_HEADERS
 } from '../src/worker-utils.js';
-
-const PRODUCTION_DOMAIN = 'https://circuit-weather.racing';
+import { PRODUCTION_DOMAIN } from './helpers/constants.js';
 
 // Mock Request helper
 const createRequest = (headers = {}) => ({
@@ -15,6 +15,52 @@ const createRequest = (headers = {}) => ({
 });
 
 describe('Worker Utils Helpers', () => {
+
+    // getErrorHeaders is module-private; its behaviour is verified here through
+    // createErrorResponse, which is the public path every API error takes.
+    describe('error response headers', () => {
+        it('returns JSON content-type and no-store cache-control', () => {
+            const res = createErrorResponse(createRequest({}), 500, 'boom');
+
+            expect(res.headers.get('Content-Type')).toBe('application/json');
+            expect(res.headers.get('Cache-Control')).toBe('no-store');
+        });
+
+        it('includes all API security headers', () => {
+            const res = createErrorResponse(createRequest({}), 500, 'boom');
+
+            for (const [key, value] of Object.entries(API_SECURITY_HEADERS)) {
+                expect(res.headers.get(key)).toBe(value);
+            }
+        });
+
+        it('adds CORS headers for allowed origin', () => {
+            const res = createErrorResponse(createRequest({ 'Origin': PRODUCTION_DOMAIN }), 500, 'boom');
+
+            expect(res.headers.get('Access-Control-Allow-Origin')).toBe(PRODUCTION_DOMAIN);
+            expect(res.headers.get('Vary')).toBe('Origin');
+        });
+
+        it('omits CORS headers for disallowed origin', () => {
+            const res = createErrorResponse(createRequest({ 'Origin': 'https://evil.com' }), 500, 'boom');
+
+            expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
+            expect(res.headers.get('Vary')).toBeNull();
+        });
+
+        it('omits CORS headers when no Origin header is present', () => {
+            const res = createErrorResponse(createRequest({}), 500, 'boom');
+
+            expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
+        });
+
+        it('adds CORS headers for localhost origin', () => {
+            const res = createErrorResponse(createRequest({ 'Origin': 'http://localhost:8787' }), 500, 'boom');
+
+            expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:8787');
+            expect(res.headers.get('Vary')).toBe('Origin');
+        });
+    });
 
     describe('getEmptyRadarResponse', () => {
         it('returns a 200 Response', async () => {


### PR DESCRIPTION
🎯 **What:** Completes the unused-export sweep started in #774–#778 and repairs the test coverage lost along the way. Follow-up to the four PRs merged today (#775, #776, #777, #778); supersedes #774.

💡 **Why:** The sweep arrived as five separate PRs, each removing one export. Two pairs collided on the same files, and two of them hit their target by deleting tests. An audit of the repo found exactly **five** exports unused outside their own module — so the campaign was one PR short of finishing, and would have needed at least one more. This closes it out.

### Changes

- **Un-export `openF1ToErgastDateTime`** — #774's goal, but keeping all eight timezone tests (positive/negative offsets, midnight rollover, embedded offset vs trailing `Z`, three null/invalid paths), exercised through `fetchOpenF1Schedule`. This is the pattern #775 established for `transformOpenF1` in the same file; #774 deleted its tests instead, costing 2 branches. With this, #774 can close with nothing lost.
- **Restore the six error-header assertions #778 deleted** — verified through `createErrorResponse`, the public path every API error takes, so `getErrorHeaders` stays module-private with its behaviour still covered. Suite goes 890 → 896.
- **`TRANSLATIONS` — documented, deliberately not swept.** It is the fifth unused export and no PR covered it, but it should stay exported: `tests/i18n-locales-completeness.test.js` checks every locale against `en` and needs the aggregate map. Rebuilding that map from the individual locale modules would silently skip a newly added locale, which is the exact failure the test exists to catch. Commented in place so the next sweep doesn't have to rediscover this.
- **Dedupe `PRODUCTION_DOMAIN`** — #776 copied the literal into two test files; moved to a single `tests/helpers/constants.js`.
- **Collapse fetch-mock boilerplate** — the same two-line mock setup appeared eight times in the openf1 suite; now a `scheduleFrom` helper.

### Result

| | before sweep | after #774–#778 | this PR |
|---|---|---|---|
| Tests passing | 896 | 890 | **896** |
| Branches | 1501/1556 | 1500/1555 | 1500/1555 |
| Unused exports | 5 | 1 undocumented | **0 undocumented** |

✅ **Verification:** `pnpm run test:coverage` — 55 files, 896 tests passing. Statements 99.13% (≥99), branches 96.46% (≥95), functions 96.01% (≥95), lines 99.13% (≥99). Confirmed the four un-exported symbols have no remaining importers, and re-ran the audit: `TRANSLATIONS` is the only unused export left and is now annotated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNVQebfs38GbVcDCnuAmmG)_